### PR TITLE
Add support for doas

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,17 @@ Optionnal support for the AUR (through [yay](https://aur.archlinux.org/packages/
 ## Dependencies
 
 Arch-Update depends on:
-- [pacman-contrib](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package") to check and print the list packages available updates.  
+- [sudo](https://archlinux.org/packages/core/x86_64/sudo/ "sudo package") or [doas](https://archlinux.org/packages/community/x86_64/opendoas/ "doas package") for privilege elevation.
+- [pacman-contrib](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package") to check and print the list of packages available updates.  
   
-Arch-Update **optionnally** depends on:
-- [yay](https://aur.archlinux.org/packages/yay "yay package") or [paru](https://aur.archlinux.org/packages/paru "paru package") to check, list and apply AUR packages available updates.  
+Arch-Update **optionally** depends on:
+- [yay](https://aur.archlinux.org/packages/yay "yay package") or [paru](https://aur.archlinux.org/packages/paru "paru package") to check, list and apply available updates for AUR packages.  
 - [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package") (`notify-send`) to send desktop notifications when checking for available updates.  
 *In order to get `libnotify` (and thus `notify-send`) you have to install a notification server (if you don't already have one).*  
 *See https://wiki.archlinux.org/title/Desktop_notifications#Notification_servers*  
   
-The [make](https://www.gnu.org/software/make/) package is necessary to install/uninstall `arch-update`, install it via your package manager if needed.
-
-### Installing dependencies
-
-*You don't need to install dependencies if you install `arch-update` via the [AUR](#aur) as it already takes care of them*  
-
-```
-sudo pacman -S pacman-contrib
-```
+Arch-Update's installation/uninstallation depends on:
+- [make](https://www.gnu.org/software/make/ "make package") to execute the `Makefile` required to install/uninstall `arch-update`.
 
 ## Installation
 
@@ -45,49 +39,42 @@ Install the [arch-update](https://aur.archlinux.org/packages/arch-update "arch-u
 
 ### From Source
 
-After [installing dependencies](#installing-dependencies) on your system, download the archive of the [latest stable release](https://github.com/Antiz96/arch-update/releases/latest) and extract it.  
+After installing the [dependencies](#dependencies) on your system, download the archive of the [latest stable release](https://github.com/Antiz96/arch-update/releases/latest) and extract it.  
 *Alternatively, you can clone this repository via `git`.*  
   
-To install `arch-update`, go into the extracted/cloned directory and run the following command:
+To install `arch-update`, go into the extracted/cloned directory and run the following command *(replace `sudo` by `doas` if needed)*:
 ```
 sudo make install
 ```
    
-To uninstall `arch-update`, go into the extracted/cloned directory and run the following command:  
+To uninstall `arch-update`, go into the extracted/cloned directory and run the following command *(replace `sudo` by `doas` if needed)*:  
 ```
 sudo make uninstall
 ```
 
 ## Usage
 
-The usage consist of integrating [the .desktop file](#the-desktop-file) anywhere (could be your desktop, your dock, your launch bar and/or your app menu) and enabling the [systemd timer](#the-systemd-service-and-timer).
+The usage consist of integrating [the .desktop file](#the-desktop-file) anywhere (could be your desktop, your dock, your launch bar and/or your app menu) and enabling the [systemd timer](#the-systemd-timer).
 
 ### The .desktop file
 
 The .desktop file is located in `/usr/share/applications/arch-update.desktop` (or `/usr/local/share/applications/arch-update.desktop` if you installed `arch-update` [from source](#from-source).  
-Its icon will automatically change depending on the different states (cheking for updates, updates available, installing updates, up to date).  
+Its icon will automatically change depending on the different states (checking for updates, updates available, installing updates, up to date).  
 It will launch the main `update` function when clicked. It is easy to integrate with any DE/WM, docks, launch bars or app menus.  
 
-### The systemd service and timer
+### The systemd timer
 
-There is a systemd service in `/usr/lib/systemd/user/arch-update.service` (or in `/etc/systemd/user/arch-update.service` if you installed `arch-update` [from source](#from-source)) that launches the `--check` function.  
-  
-There's  also  a  systemd timer in `/usr/lib/systemd/user/arch-update.timer` (or in `/etc/systemd/user/arch-update.timer` if you installed `arch-update` [from source](#from-source)) that automatically launches the systemd service at boot and then every hour. 
-   
-In order to make the systemd timer work, you need to enable it with the following command:  
-  
+There is a systemd service in `/usr/lib/systemd/user/arch-update.service` (or in `/etc/systemd/user/arch-update.service` if you installed `arch-update` [from source](#from-source)) that executes the arch-update's `--check` function when launched, in order to check for available updates. To launch it automatically **at boot and then once every hour**, enable the associated systemd timer:  
 ```
 systemctl --user enable --now arch-update.timer
 ```
-  
-Check the screenshots below for more information.
 
 ### Screenshot
 
 Personally, I integrated the (.desktop) file on my dock.  
   
 It is the penultimate icon from left to right (next to the red "Power Sign" icon).  
-This is how it looks like when `arch-update` is checking for available updates (*the check is automatically triggered at boot and then every hour if you enabled the [systemd timer](#the-systemd-service-and-timer) and can be manually triggered with the `arch-update -c` command:*  
+This is how it looks like when `arch-update` is checking for available updates (*the check is automatically triggered at boot and then once every hour if you enabled the [systemd timer](#the-systemd-timer) and can be manually triggered with the `arch-update -c` command:*  
 ![Arch-Update_Check](https://user-images.githubusercontent.com/53110319/161241670-8cab8a54-199b-41f1-80e3-95b171bbb70f.png)  
   
 If there are available updates, the icon will change and a desktop notification indicating the number of available updates will be sent (*requires [libnotify/notify-send](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package")*):
@@ -119,20 +106,20 @@ arch-update [OPTION]
 ### DESCRIPTION
 
 A (.desktop) clickeable icon that automatically changes to act as a pacman update notifier/applier, easy to integrate with any DE/WM, docks, launch bars or app menus.  
-Optionnal support for the AUR (through [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru)) and desktop notifications.  
+Optionnal support for AUR package updates (through [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru)) and desktop notifications.  
 
 ### OPTIONS
 
-If no option is passed, perform the main update function: Check for available updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (``pacman -Syu``).  
-It also supports AUR packages if [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru) is installed.  
+If no option is passed, perform the main update function: Check for available updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (`pacman -Syu`).  
+It also supports AUR package updates if [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru) is installed.  
 The update function is launched when you click on the (.desktop) icon.  
 
 #### -c, --check
 
 Check for available updates and change the (.desktop) icon if there are.  
 It sends a desktop notification if [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/) is installed.  
-It supports AUR updates if [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru) is installed.  
-The `--check` option is automatically launched at boot and then every hour if you enabled the `systemd.timer` with the following command:  
+It supports AUR package updates if [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru) is installed.  
+The `--check` option is automatically launched at boot and then once every hour if you enabled the `systemd.timer` with the following command:  
 ```
 systemctl --user enable --now arch-update.timer
 ```
@@ -159,7 +146,7 @@ if problems (user didn't gave confirmation to proceed with the installation, a p
 
 ### AUR Support
 
-Arch-Update supports AUR packages when checking and installing updates if **yay** or **paru** is installed:  
+Arch-Update supports AUR package updates when checking and installing updates if **yay** or **paru** is installed:  
 See https://github.com/Jguer/yay and https://aur.archlinux.org/packages/yay  
 See https://github.com/morganamilo/paru and https://aur.archlinux.org/packages/paru  
 
@@ -170,7 +157,7 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 
 ### Modify the auto-check cycle
 
-If you enabled the systemd.timer, the `--check` option is launched automatically at boot and then every hour.  
+If you enabled the systemd.timer, the `--check` option is automatically launched at boot and then once every hour.  
   
 If you want to change that cycle, you can edit the `/usr/lib/systemd/user/arch-update.timer` file (or `/etc/systemd/user/arch-update.timer` if you installed `arch-update` [from source](#from-source)) and modify the `OnUnitActiveSec` value.  
 The timer needs to be re-enabled to apply changes, you can do so by typing the following command:  
@@ -182,13 +169,14 @@ See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 
 ### Show packages version changes
 
-If you want `arch-update` to show the packages version changes in the main `update` function, run the following command:  
+If you want `arch-update` to show the packages version changes in the main `update` function, run the following command *(replace `sudo` with `doas` if needed)*:  
 ```
 sudo sed -i "s/ | awk '{print \$1}'//g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null || true
 ```
+  
 **Be aware that you'll have to relaunch that command at each `arch-update`'s new release.**  
 
 ## Contributing
 
 You can raise your issues, feedbacks and suggestions in the [issues tab](https://github.com/Antiz96/arch-update/issues).  
-[Pull requests](https://github.com/Antiz96/arch-update/pulls) are welcomed as well !
+[Pull requests](https://github.com/Antiz96/arch-update/pulls) are welcomed as well!

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Arch-Update **optionally** depends on:
 *See https://wiki.archlinux.org/title/Desktop_notifications#Notification_servers*  
   
 Arch-Update's installation/uninstallation depends on:
-- [make](https://www.gnu.org/software/make/ "make package") to execute the `Makefile` required to install/uninstall `arch-update`.
+- [make](https://archlinux.org/packages/core/x86_64/make/ "make package") to execute the `Makefile` required to install/uninstall `arch-update`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ The usage consist of integrating [the .desktop file](#the-desktop-file) anywhere
 
 ### The .desktop file
 
-The .desktop file is located in `/usr/share/applications/arch-update.desktop` (or `/usr/local/share/applications/arch-update.desktop` if you installed `arch-update` [from source](#from-source).  
+The .desktop file is located in `/usr/share/applications/arch-update.desktop` (or `/usr/local/share/applications/arch-update.desktop` if you installed `arch-update` [from source](#from-source)).  
 Its icon will automatically change depending on the different states (checking for updates, updates available, installing updates, up to date).  
 It will launch the main `update` function when clicked. It is easy to integrate with any DE/WM, docks, launch bars or app menus.  
 
 ### The systemd timer
 
-There is a systemd service in `/usr/lib/systemd/user/arch-update.service` (or in `/etc/systemd/user/arch-update.service` if you installed `arch-update` [from source](#from-source)) that executes the arch-update's `--check` function when launched, in order to check for available updates. To launch it automatically **at boot and then once every hour**, enable the associated systemd timer:  
+There is a systemd service in `/usr/lib/systemd/user/arch-update.service` (or in `/etc/systemd/user/arch-update.service` if you installed `arch-update` [from source](#from-source)) that executes the arch-update's `--check` function when launched, in order to check for available updates.  
+To launch it automatically **at boot and then once every hour**, enable the associated systemd timer:  
 ```
 systemctl --user enable --now arch-update.timer
 ```

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "September 2022" "Arch-Update v1" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "November 2022" "Arch-Update v1" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- A (.desktop) clickeable icon that automatically changes to act as an update notifier/applier
@@ -10,13 +10,13 @@ arch-update \- A (.desktop) clickeable icon that automatically changes to act as
 .SH DESCRIPTION
 A (.desktop) clickeable icon that automatically changes to act as a pacman update notifier/applier, easy to integrate with any DE/WM, docks, launch bars or app menus. 
 .br
-.RB "Optionnal support for the AUR (through " "yay " "or " "paru" ") and desktop notifications."
+.RB "Optionnal support for AUR package updates (through " "yay " "or " "paru" ") and desktop notifications."
 
 .SH OPTIONS
 .PP
-.RB "If no option is passed, perform the main " "update " "function : Check for available updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (" "pacman -Syu" ")."
+.RB "If no option is passed, perform the main " "update " "function: Check for available updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (" "pacman -Syu" ")."
 .br
-.RB "It also supports AUR packages if " "yay " "or " "paru " "is installed."
+.RB "It also supports AUR package updates if " "yay " "or " "paru " "is installed."
 .br
 .RB "The " "update " "function is launched when you click on the (.desktop) icon."
 .PP
@@ -27,9 +27,9 @@ A (.desktop) clickeable icon that automatically changes to act as a pacman updat
 .br
 .RB "It sends a desktop notification if " "libnotify " "is installed."
 .br
-.RB "It supports AUR updates if " "yay " "or " "paru " "is installed."
+.RB "It supports AUR packages updates if " "yay " "or " "paru " "is installed."
 .br
-.RB "The " "\-\-check " "option is automatically launched at boot and then every hour if you enabled the " "systemd.timer " "with the following command :" 
+.RB "The " "\-\-check " "option is automatically launched at boot and then every hour if you enabled the " "systemd.timer " "with the following command:" 
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
 
@@ -58,19 +58,15 @@ if problems (user didn't gave confirmation to proceed with the installation, a p
 .RB "It will automatically change depending on different states (cheking for updates, updates available, installing updates, up to date). It will launch the main " "update " "function when clicked. It is easy to integrate with any DE/WM, docks, launch bars or app menus."
 
 .TP
-.B The systemd service and timer
-.RB "There is a systemd service in " "/usr/lib/systemd/user/arch-update.service " "(or in " "/etc/systemd/user/arch-update.service " "if you installed arch-update from source) that launches the " "\-\-check " "function."
-.br
-.RB "There's also a systemd timer in " "/usr/lib/systemd/user/arch-update.timer " "(or in " "/etc/systemd/user/arch-update.timer " "if you installed arch-update from source) that automatically launches the systemd service at boot and then every hour. 
-.br
-In order to make the systemd timer work, you need to enable it with the following command : 
+.B The systemd timer
+.RB "There is a systemd service in " "/usr/lib/systemd/user/arch-update.service " "(or in " "/etc/systemd/user/arch-update.service " "if you installed arch-update from source) that executes the " "\-\-check " "function when launched. To launch it automatically " "at boot and then once every hour " "enable the associated systemd timer:"
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
 
 .SH TIPS AND TRICKS 
 .TP
 .B AUR Support
-.RB "Arch-Update supports AUR packages when checking and installing updates if " "yay " "or " "paru " "is installed"
+.RB "Arch-Update supports AUR package updates when checking and installing updates if " "yay " "or " "paru " "is installed"
 .br
 See https://github.com/Jguer/yay and https://aur.archlinux.org/packages/yay
 .br
@@ -84,11 +80,11 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 
 .TP
 .B Modify the auto-check cycle
-.RB "If you enabled the " "systemd.timer" ", the " "--check " "option is launched automatically at boot and then every hour"
+.RB "If you enabled the " "systemd.timer" ", the " "--check " "option is automatically launched at boot and then once every hour"
 .br
 .RB "If you want to change that cycle, you can edit the " "/usr/lib/systemd/user/arch-update.timer " "(or "/etc/systemd/user/arch-update.timer " if you installed arch-update from source) file and modify the " "OnUnitActiveSec " "value"
 .br
-The timer needs to be re-enabled to apply changes, you can do so by launching the following command :
+The timer needs to be re-enabled to apply changes, you can do so by launching the following command:
 .br
 .B systemctl --user enable --now arch-update.timer
 .br
@@ -96,15 +92,18 @@ See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 
 .TP
 .B Show packages version changes
-.RB "If you want Arch-Update to show the packages version changes in the main " "update " "function, launch the following command :" 
+.RB "If you want Arch-Update to show the packages version changes in the main " "update " "function, launch the following command (replace sudo by doas if needed):" 
 .br
 .B sudo sed -i "s/ | awk '{print \$1}'//g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null || true
+.br
+.B Be aware that you'll have to relaunch that command at each arch-update's new release.
 
 .SH SEE ALSO
 .BR cp (1),
 .BR checkupdates (8),
 .BR echo (1),
 .BR sudo (8),
+.BR doas (1),
 .BR pacman (8),
 .BR pacman.conf (5),
 .BR systemd.service (5),
@@ -118,7 +117,7 @@ See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 The documentation is also available on the GitHub page https://github.com/Antiz96/arch-update
 
 .SH BUGS
-Please report bugs to the GitHub page https://github.com/Antiz96/arch-update
+Please report bugs to the GitHub page https://github.com/Antiz96/arch-update/issues
 
 .SH AUTHOR
 Robin Candau <robincandau@protonmail.com>

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -43,12 +43,12 @@ case "${option}" in
 
 		#If there are updates available for pacman, print them
 		if [ -n "${packages}" ]; then
-			echo -e "Packages:\n" && echo -e "${packages}\n"
+			echo -e "--Packages--" && echo -e "${packages}\n"
 		fi
 
 		#If there are updates available for the AUR, print them
 		if [ -n "${aur_packages}" ]; then
-			echo -e "AUR Packages:\n" && echo -e "${aur_packages}\n"
+			echo -e "--AUR Packages--" && echo -e "${aur_packages}\n"
 		fi
 
 		#If there is no update available for Pacman nor the AUR, change the desktop icon to "up-to-date" and quit

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -1,12 +1,27 @@
 #!/bin/bash
 
 #Current version
-version="1.3.2"
+version="1.4.0"
 
-#Check for optionnal dependencies ("yay" or "paru" for AUR support and "notify-send" (libnotify) for desktop notifications support)
-YAY=$(command -v yay)
-PARU=$(command -v paru)
-NOTIF=$(command -v notify-send)
+#Check which privilege elevation package is installed (sudo or doas)
+if command -v sudo; then
+	su_cmd="sudo"
+elif command -v doas; then
+	su_cmd="doas"
+else
+	echo -e >&2 "A privilege elevation method is required\nPlease, install sudo or doas\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
+	exit 1
+fi
+
+#Check if an AUR helper is installed (yay or paru) for the optional AUR package updates support
+if command -v yay; then
+	aur_helper="yay"
+elif command -v paru; then
+	aur_helper="paru"
+fi
+
+#Check if notify-send is installed for the optional desktop notification support
+notif=$(command -v notify-send)
 
 #Replace the $1 var by "option" just to make the script more readable/less complex
 option="${1}"
@@ -19,63 +34,50 @@ case "${option}" in
 		cp -f /usr/share/icons/arch-update/arch-update_checking.svg /usr/share/icons/arch-update/arch-update.svg
 		
 		#Get the available updates list for Pacman
-		PACKAGES=$(checkupdates | awk '{print $1}')
+		packages=$(checkupdates | awk '{print $1}')
 
-		#Get the available updates list for AUR (if "yay" or "paru" is installed)
-		if [ -n "${YAY}" ]; then
-			AURPACKAGES=$(yay -Qua | awk '{print $1}')
-		elif [ -n "${PARU}" ]; then
-			AURPACKAGES=$(paru -Qua | awk '{print $1}')
-		else
-			AURPACKAGES=""
+		#Get the available updates list for the AUR (if "yay" or "paru" is installed)
+		if [ -n "${aur_helper}" ]; then
+			aur_packages=$("${aur_helper}" -Qua | awk '{print $1}')
 		fi
 
 		#If there are updates available for pacman, print them
-		if [ -n "${PACKAGES}" ]; then
-			echo -e "Packages :\n" && echo -e "${PACKAGES}\n"
+		if [ -n "${packages}" ]; then
+			echo -e "Packages:\n" && echo -e "${packages}\n"
 		fi
 
-		#If there are updates available for AUR, print them
-		if [ -n "${AURPACKAGES}" ]; then
-			echo -e "AUR Packages :\n" && echo -e "${AURPACKAGES}\n"
+		#If there are updates available for the AUR, print them
+		if [ -n "${aur_packages}" ]; then
+			echo -e "AUR Packages:\n" && echo -e "${aur_packages}\n"
 		fi
 
-		#If there is no update available for Pacman nor AUR, change the desktop icon to "up-to-date" and quit
-		if [ -z "${PACKAGES}" ] && [ -z "${AURPACKAGES}" ]; then
+		#If there is no update available for Pacman nor the AUR, change the desktop icon to "up-to-date" and quit
+		if [ -z "${packages}" ] && [ -z "${aur_packages}" ]; then
 			cp -f /usr/share/icons/arch-update/arch-update_up-to-date.svg /usr/share/icons/arch-update/arch-update.svg
 			echo -e "No update available\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
 			exit 0
 		#If there are updates available, change the desktop icon to "updates-available" and ask the confirmation to apply them to the user
 		else
 			cp -f /usr/share/icons/arch-update/arch-update_updates-available.svg /usr/share/icons/arch-update/arch-update.svg
-			read -rp $'Proceed with installation ? [Y/n] ' answer
+			read -rp $'Proceed with installation? [Y/n] ' answer
 
 			case "${answer}" in
-				#If the user gives the confirmation, change the desktop icon to "installing" and apply updates...
+				#If the user gives the confirmation to proceed, change the desktop icon to "installing" and apply updates
 				[Yy]|"")
 					cp -f /usr/share/icons/arch-update/arch-update_installing.svg /usr/share/icons/arch-update/arch-update.svg
 
-					#...for both pacman and AUR (if there are)
-					if [ -n "${PACKAGES}" ] && [ -n "${AURPACKAGES}" ]; then
-						if [ -n "${YAY}" ]; then
-							sudo pacman -Syu && yay -Syu
-						else
-							sudo pacman -Syu && paru -Syu
-						fi
-					#... for pacman only (if there are)
-					elif [ -n "${PACKAGES}" ]; then
-						sudo pacman -Syu
-					#... for AUR only (if there are)
-					else
-						if [ -n "${YAY}" ]; then
-							yay -Syu
-						else
-							paru -Syu
-						fi
+					#Update for pacman (if there are)
+					if [ -n "${packages}" ]; then
+						"${su_cmd}" pacman -Syu
+					fi
+					
+					#Update for the AUR (if there are)
+					if [ -n "${aur_packages}" ]; then
+						"${aur_helper}" -Syu
 					fi
 				;;
 
-				#If the user didn't give the confirmation, quit
+				#If the user doesn't give the confirmation to proceed, exit
 				*)
 					exit 1
 				;;
@@ -101,23 +103,21 @@ case "${option}" in
 		cp -f /usr/share/icons/arch-update/arch-update_checking.svg /usr/share/icons/arch-update/arch-update.svg
 
 		#Get the number of available
-		if [ -n "${YAY}" ]; then
-			UPDATE_NUMBER=$( (checkupdates ; yay -Qua) | wc -l)
-		elif [ -n "${PARU}" ]; then
-			UPDATE_NUMBER=$( (checkupdates ; paru -Qua) | wc -l)
+		if [ -n "${aur_helper}" ]; then
+			update_number=$( (checkupdates ; "${aur_helper}" -Qua) | wc -l)
 		else
-			UPDATE_NUMBER=$(checkupdates | wc -l)
+			update_number=$(checkupdates | wc -l)
 		fi
 
 		#If there are updates available, change the desktop icon to "updates-available" and quit
-		if [ "${UPDATE_NUMBER}" -gt 0 ]; then
+		if [ "${update_number}" -gt 0 ]; then
 			cp -f /usr/share/icons/arch-update/arch-update_updates-available.svg /usr/share/icons/arch-update/arch-update.svg
 			#If notify-send (libnotify) is installed, also send a desktop notification before quitting
-			if [ -n "${NOTIF}" ]; then
-				if [ "${UPDATE_NUMBER}" -eq 1 ]; then
-					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch Update" "${UPDATE_NUMBER} update available"
+			if [ -n "${notif}" ]; then
+				if [ "${update_number}" -eq 1 ]; then
+					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch Update" "${update_number} update available"
 				else
-					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch Update" "${UPDATE_NUMBER} updates available"
+					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch Update" "${update_number} updates available"
 				fi
 			fi
 			exit 0
@@ -133,8 +133,8 @@ case "${option}" in
 		exit 0
 	;;
 	#If the -h (or --help) option is passed to the script, print the documentation (man page)
-	#This can be triggered directly by the user, by typing the following command in a terminal : arch-update --help
-	#The documentation is also readable here https://github.com/Antiz96/Arch-Update or by typing the following command in a terminal : man arch-update
+	#This can be triggered directly by the user, by typing the following command in a terminal: arch-update --help
+	#The documentation is also readable here https://github.com/Antiz96/Arch-Update or by typing the following command in a terminal: man arch-update
 	-h|--help)
 		#Print the documentation (man page) and quit
 		man arch-update | col
@@ -143,7 +143,7 @@ case "${option}" in
 
 	#If any other option(s) are passed to the script, print an error and quit
 	*)
-		echo -e >&2 "arch-update : invalid option -- '${option}'\nTry 'arch-update --help' for more information."
+		echo -e >&2 "arch-update: invalid option -- '${option}'\nTry 'arch-update --help' for more information."
 		exit 1
 	;;
 esac


### PR DESCRIPTION
This PR aims to add support for [doas](https://wiki.archlinux.org/title/Doas) which is a *lighter* alternative to sudo.

It also includes various improvements and optimizations to the main script and documentations (README/man page) and it bumps the `version` variable of the main script to `1.4.0` in anticipation of the new release that will be available soon.
 