### PR TITLE
Add support for pacdiff to be able to process pacnew/pacsave files after an update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # Arch-Update
 
-A (.desktop) clickeable icon that automatically changes to act as a pacman update notifier/applier.
-
 ## Table of contents
 * [Description](#description)
-* [Dependencies](#dependencies)
 * [Installation](#installation)
 * [Usage](#usage)
 * [Documentation](#documentation)
@@ -13,23 +10,15 @@ A (.desktop) clickeable icon that automatically changes to act as a pacman updat
 
 ## Description
 
-A (.desktop) clickeable icon that automatically changes to act as a pacman update notifier/applier, easy to integrate with any DE/WM, docks, launch bars or app menus.   
-Optionnal support for the AUR (through [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru")) and desktop notifications. 
-
-## Dependencies
-
-Arch-Update depends on:
-- [sudo](https://archlinux.org/packages/core/x86_64/sudo/ "sudo package") or [doas](https://archlinux.org/packages/community/x86_64/opendoas/ "doas package") for privilege elevation.
-- [pacman-contrib](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package") to check and print the list of packages available updates.  
+An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.  
   
-Arch-Update **optionally** depends on:
-- [yay](https://aur.archlinux.org/packages/yay "yay package") or [paru](https://aur.archlinux.org/packages/paru "paru package") to check, list and apply available updates for AUR packages.  
-- [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package") (`notify-send`) to send desktop notifications when checking for available updates.  
-*In order to get `libnotify` (and thus `notify-send`) you have to install a notification server (if you don't already have one).*  
-*See https://wiki.archlinux.org/title/Desktop_notifications#Notification_servers*  
-  
-Arch-Update's installation/uninstallation depends on:
-- [make](https://archlinux.org/packages/core/x86_64/make/ "make package") to execute the `Makefile` required to install/uninstall `arch-update`.
+Features:
+- A (.desktop) clickeable icon that automatically changes to act as an update notifier/applier. Easy to integrate with any DE/WM, dock, status/launch bar, app menu, etc...
+- Automatic check and listing of every packages available for update (through [checkupdates](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package")), optionally shows the version changes as well.
+- Helps you managing pacnew/pacsave files after an update (through [pacdiff](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package")).
+- Support for both [sudo](https://archlinux.org/packages/core/x86_64/sudo/ "sudo package") and [doas](https://archlinux.org/packages/community/x86_64/opendoas/ "opendoas package").
+- Optional support for AUR package updates (through [yay](https://aur.archlinux.org/packages/yay "yay AUR package") or [paru](https://aur.archlinux.org/packages/paru "paru AUR package")).
+- Optional support for desktop notifications (through [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/) "libnotify package"), see: https://wiki.archlinux.org/title/Desktop_notifications).
 
 ## Installation
 
@@ -39,8 +28,12 @@ Install the [arch-update](https://aur.archlinux.org/packages/arch-update "arch-u
 
 ### From Source
 
-After installing the [dependencies](#dependencies) on your system, download the archive of the [latest stable release](https://github.com/Antiz96/arch-update/releases/latest) and extract it.  
-*Alternatively, you can clone this repository via `git`.*  
+Install dependencies *(replace `sudo` by `doas` if needed)*:  
+```
+sudo pacman -S --needed pacman-contrib diffutils vim
+```
+  
+Download the archive of the [latest stable release](https://github.com/Antiz96/arch-update/releases/latest) and extract it *(alternatively, you can clone this repository via `git`)*.  
   
 To install `arch-update`, go into the extracted/cloned directory and run the following command *(replace `sudo` by `doas` if needed)*:
 ```
@@ -54,17 +47,17 @@ sudo make uninstall
 
 ## Usage
 
-The usage consist of integrating [the .desktop file](#the-desktop-file) anywhere (could be your desktop, your dock, your launch bar and/or your app menu) and enabling the [systemd timer](#the-systemd-timer).
+The usage consist of integrating [the .desktop file](#the-desktop-file) anywhere (could be your desktop, your dock, your status/launch bar and/or your app menu) and enabling the [systemd timer](#the-systemd-timer).
 
 ### The .desktop file
 
 The .desktop file is located in `/usr/share/applications/arch-update.desktop` (or `/usr/local/share/applications/arch-update.desktop` if you installed `arch-update` [from source](#from-source)).  
 Its icon will automatically change depending on the different states (checking for updates, updates available, installing updates, up to date).  
-It will launch the main `update` function when clicked. It is easy to integrate with any DE/WM, docks, launch bars or app menus.  
+It will launch the main `update` function when clicked (see the [Documentation](#documentation) chapter). It is easy to integrate with any DE/WM, dock, status/launch bar or app menu.  
 
 ### The systemd timer
 
-There is a systemd service in `/usr/lib/systemd/user/arch-update.service` (or in `/etc/systemd/user/arch-update.service` if you installed `arch-update` [from source](#from-source)) that executes the arch-update's `--check` function when launched, in order to check for available updates.  
+There is a systemd service in `/usr/lib/systemd/user/arch-update.service` (or in `/etc/systemd/user/arch-update.service` if you installed `arch-update` [from source](#from-source)) that executes the `check` function when launched (see the [Documentation](#documentation) chapter).  
 To launch it automatically **at boot and then once every hour**, enable the associated systemd timer:  
 ```
 systemctl --user enable --now arch-update.timer
@@ -106,19 +99,20 @@ arch-update [OPTION]
 
 ### DESCRIPTION
 
-A (.desktop) clickeable icon that automatically changes to act as a pacman update notifier/applier, easy to integrate with any DE/WM, docks, launch bars or app menus.  
-Optionnal support for AUR package updates (through [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru)) and desktop notifications.  
+An update notifier/applier for Arch Linux that assists you with important pre/post update tasks which includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu. 
+Optionnal support for AUR package updates (through [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru)) and desktop notifications (through [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/)).  
 
 ### OPTIONS
 
 If no option is passed, perform the main update function: Check for available updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (`pacman -Syu`).  
 It also supports AUR package updates if [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru) is installed.  
+Once the update has been successfully performed, check for pacnew/pacsave files and, if there are, launch `pacdiff` to manage them.  
 The update function is launched when you click on the (.desktop) icon.  
 
 #### -c, --check
 
-Check for available updates and change the (.desktop) icon if there are.  
-It sends a desktop notification if [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/) is installed.  
+Check for available updates and change the (.desktop) icon accordingly if there are.  
+It sends a desktop notification containing the number of available update if [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/) is installed.  
 It supports AUR package updates if [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru) is installed.  
 The `--check` option is automatically launched at boot and then once every hour if you enabled the `systemd.timer` with the following command:  
 ```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Optionnal support for AUR package updates (through [yay](https://aur.archlinux.o
 
 If no option is passed, perform the main update function: Check for available updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (`pacman -Syu`).  
 It also supports AUR package updates if [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru) is installed.  
-Once the update has been successfully performed, check for pacnew/pacsave files and, if there are, launch `pacdiff` to manage them.  
+Once the update has been successfully performed, check for pacnew/pacsave files and, if there are, offers to launch `pacdiff` to process them.  
 The update function is launched when you click on the (.desktop) icon.  
 
 #### -c, --check

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.  
   
 Features:
-- A (.desktop) clickeable icon that automatically changes to act as an update notifier/applier. Easy to integrate with any DE/WM, dock, status/launch bar, app menu, etc...
+- Includes a (.desktop) clickeable icon that automatically changes to act as an update notifier/applier. Easy to integrate with any DE/WM, dock, status/launch bar, app menu, etc...
 - Automatic check and listing of every packages available for update (through [checkupdates](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package")), optionally shows the version changes as well.
 - Helps you managing pacnew/pacsave files after an update (through [pacdiff](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package")).
 - Support for both [sudo](https://archlinux.org/packages/core/x86_64/sudo/ "sudo package") and [doas](https://archlinux.org/packages/community/x86_64/opendoas/ "opendoas package").
 - Optional support for AUR package updates (through [yay](https://aur.archlinux.org/packages/yay "yay AUR package") or [paru](https://aur.archlinux.org/packages/paru "paru AUR package")).
-- Optional support for desktop notifications (through [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/) "libnotify package"), see: https://wiki.archlinux.org/title/Desktop_notifications).
+- Optional support for desktop notifications (through [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package"), see: https://wiki.archlinux.org/title/Desktop_notifications).
 
 ## Installation
 
@@ -65,7 +65,7 @@ systemctl --user enable --now arch-update.timer
 
 ### Screenshot
 
-Personally, I integrated the (.desktop) file on my dock.  
+Personally, I integrated the .desktop file on my dock.  
   
 It is the penultimate icon from left to right (next to the red "Power Sign" icon).  
 This is how it looks like when `arch-update` is checking for available updates (*the check is automatically triggered at boot and then once every hour if you enabled the [systemd timer](#the-systemd-timer) and can be manually triggered with the `arch-update -c` command:*  
@@ -99,7 +99,7 @@ arch-update [OPTION]
 
 ### DESCRIPTION
 
-An update notifier/applier for Arch Linux that assists you with important pre/post update tasks which includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu. 
+An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu. 
 Optionnal support for AUR package updates (through [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru)) and desktop notifications (through [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/)).  
 
 ### OPTIONS

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -8,7 +8,7 @@ arch-update \- An update notifier/applier for Arch Linux that assists you with i
 [\fI\,OPTION\/\fR]
 
 .SH DESCRIPTION
-An update notifier/applier for Arch Linux that assists you with important pre/post update tasks which includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu.
+An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu.
 .br
 .RB "Optionnal support for AUR package updates (through " "yay " "or " "paru" ") and desktop notifications (through " "libnotify" ")."
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -55,7 +55,7 @@ if problems (user didn't gave confirmation to proceed with the installation, a p
 .SH USAGE
 .TP
 .B The (.desktop) icon
-.RB "The (.desktop) icon is located in " "/usr/share/applications/arch-update.desktop". 
+.RB "The (.desktop) icon is located in " "/usr/share/applications/arch-update.desktop " "(or in " "/etc/local/share/applications/arch-update.deskop " "if you installed arch-update from source)." 
 .br
 .RB "It will automatically change depending on different states (cheking for updates, updates available, installing updates, up to date). It will launch the main " "update " "function when clicked. It is easy to integrate with any DE/WM, docks, launch bars or app menus."
 
@@ -108,7 +108,7 @@ See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 .BR doas (1),
 .BR find (1),
 .BR pacman (8),
-.BR pacman.conf (5),
+.BR pacdiff (8),
 .BR systemd.service (5),
 .BR systemd.timer (5),
 .BR man (1),

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -18,7 +18,7 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .br
 .RB "It also supports AUR package updates if " "yay " "or " "paru " "is installed."
 .br
-.RB "Once the update has been successfully performed, check for pacnew/pacsave files and, if there are, launch " "pacdiff " "to manage them."
+.RB "Once the update has been successfully performed, check for pacnew/pacsave files and, if there are, offers to launch " "pacdiff " "to process them."
 .br
 .RB "The " "update " "function is launched when you click on the (.desktop) icon."
 .PP

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,16 +1,16 @@
 .TH "ARCH-UPDATE" "1" "November 2022" "Arch-Update v1" "Arch-Update Manual"
 
 .SH NAME
-arch-update \- A (.desktop) clickeable icon that automatically changes to act as an update notifier/applier
+arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
 
 .SH SYNOPSIS
 .B arch-update
 [\fI\,OPTION\/\fR]
 
 .SH DESCRIPTION
-A (.desktop) clickeable icon that automatically changes to act as a pacman update notifier/applier, easy to integrate with any DE/WM, docks, launch bars or app menus. 
+An update notifier/applier for Arch Linux that assists you with important pre/post update tasks which includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu.
 .br
-.RB "Optionnal support for AUR package updates (through " "yay " "or " "paru" ") and desktop notifications."
+.RB "Optionnal support for AUR package updates (through " "yay " "or " "paru" ") and desktop notifications (through " "libnotify" ")."
 
 .SH OPTIONS
 .PP
@@ -18,14 +18,16 @@ A (.desktop) clickeable icon that automatically changes to act as a pacman updat
 .br
 .RB "It also supports AUR package updates if " "yay " "or " "paru " "is installed."
 .br
+.RB "Once the update has been successfully performed, check for pacnew/pacsave files and, if there are, launch " "pacdiff " "to manage them."
+.br
 .RB "The " "update " "function is launched when you click on the (.desktop) icon."
 .PP
 
 .TP
 .B \-c, \-\-check
-.RB "Check for available updates and change the (.desktop) icon if there are."
+.RB "Check for available updates and change the (.desktop) icon accordingly if there are."
 .br
-.RB "It sends a desktop notification if " "libnotify " "is installed."
+.RB "It sends a desktop notification containing the number of available updates if " "libnotify " "is installed."
 .br
 .RB "It supports AUR packages updates if " "yay " "or " "paru " "is installed."
 .br
@@ -104,6 +106,7 @@ See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 .BR echo (1),
 .BR sudo (8),
 .BR doas (1),
+.BR find (1),
 .BR pacman (8),
 .BR pacman.conf (5),
 .BR systemd.service (5),

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -60,6 +60,7 @@ case "${option}" in
 		else
 			cp -f /usr/share/icons/arch-update/arch-update_updates-available.svg /usr/share/icons/arch-update/arch-update.svg
 			read -rp $'Proceed with installation? [Y/n] ' answer
+			echo ""
 
 			case "${answer}" in
 				#If the user gives the confirmation to proceed, change the desktop icon to "installing" and apply updates
@@ -102,8 +103,9 @@ case "${option}" in
 
 		#If there are pacnew/pacsave files, ask the user if he wants to manage them
 		if [ -n "${pacnew_files}" ]; then
-			echo -e "Pacnew/Pacsave files has been found on the system\n"
+			echo "Pacnew/Pacsave files has been found on the system"
 			read -rp $'Would you like to process these files now? [Y/n] ' answer
+			echo ""
 
 			case "${answer}" in
 				#If the user gives the confirmation to proceed, launch pacdiff to manage the pacnew/pacsave files and exit

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -93,10 +93,36 @@ case "${option}" in
 				;;
 			esac
 
-		#If everything went well, change the desktop icon to "up-to-date" and quit
+		#If everything went well, change the desktop icon to "up-to-date"
 		cp -f /usr/share/icons/arch-update/arch-update_up-to-date.svg /usr/share/icons/arch-update/arch-update.svg
-		echo -e "\nUpdates have been applied\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
-		exit 0
+		echo -e "\nUpdates have been applied\n"
+
+		#Checking for pacnew/pacsave files
+		pacnew_files=$(find /etc -regextype posix-extended -regex ".+\.pac(new|save)" 2> /dev/null)
+
+		#If there are pacnew/pacsave files, ask the user if he wants to manage them
+		if [ -n "${pacnew_files}" ]; then
+			echo -e "Pacnew/Pacsave files has been found on the system\n"
+			read -rp $'Would you like to process these files now? [Y/n] ' answer
+
+			case "${answer}" in
+				#If the user gives the confirmation to proceed, launch pacdiff to manage the pacnew/pacsave files and exit
+				[Yy]|"")
+					"${su_cmd}" pacdiff
+					echo -e "\nPacnew/Pacsave files has been processed\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
+					exit 0
+				;;
+
+				#If the user doesn't give the confirmation to proceed, exit
+				*)
+					exit 0
+				;;
+			esac
+		#If there's no pacnew/pacsave files, exit
+		else
+			read -n 1 -r -s -p $'Press \"enter\" to quit\n'
+			exit 0
+		fi
 	fi
 	;;
 	


### PR DESCRIPTION
This PR aims to add support for [pacdiff](https://archlinux.org/packages/community/x86_64/pacman-contrib/) in order to be able to process potential pacnew/pacsave files after an update.

With this PR, `arch-update` now searches for pacnew/pacsave files after each update and offers to process them with `pacdiff` if there are.
This PR also includes a few improvements to the documentation (README/man page).