### PR TITLE
Add a feature to read the latest Arch Linux news before updating the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 Features:
 - Includes a (.desktop) clickeable icon that automatically changes to act as an update notifier/applier. Easy to integrate with any DE/WM, dock, status/launch bar, app menu, etc...
 - Automatic check and listing of every packages available for update (through [checkupdates](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package")), optionally shows the version changes as well.
-- Helps you managing pacnew/pacsave files after an update (through [pacdiff](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package")).
+- Offers to print the latest Arch Linux news before applying updates (through [curl](https://archlinux.org/packages/core/x86_64/curl/ "curl package") and [hq](https://archlinux.org/packages/community/x86_64/hq/ "hq package")).
+- Helps you processing pacnew/pacsave files after an update (through [pacdiff](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package")).
 - Support for both [sudo](https://archlinux.org/packages/core/x86_64/sudo/ "sudo package") and [doas](https://archlinux.org/packages/community/x86_64/opendoas/ "opendoas package").
 - Optional support for AUR package updates (through [yay](https://aur.archlinux.org/packages/yay "yay AUR package") or [paru](https://aur.archlinux.org/packages/paru "paru AUR package")).
 - Optional support for desktop notifications (through [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package"), see: https://wiki.archlinux.org/title/Desktop_notifications).
@@ -30,7 +31,7 @@ Install the [arch-update](https://aur.archlinux.org/packages/arch-update "arch-u
 
 Install dependencies *(replace `sudo` by `doas` if needed)*:  
 ```
-sudo pacman -S --needed pacman-contrib diffutils vim
+sudo pacman -S --needed pacman-contrib curl hq diffutils vim
 ```
   
 Download the archive of the [latest stable release](https://github.com/Antiz96/arch-update/releases/latest) and extract it *(alternatively, you can clone this repository via `git`)*.  
@@ -104,9 +105,10 @@ Optionnal support for AUR package updates (through [yay](https://aur.archlinux.o
 
 ### OPTIONS
 
-If no option is passed, perform the main update function: Check for available updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (`pacman -Syu`).  
-It also supports AUR package updates if [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru) is installed.  
-Once the update has been successfully performed, check for pacnew/pacsave files and, if there are, offers to launch `pacdiff` to process them.  
+If no option is passed, perform the main update function: Check for updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (`pacman -Syu`).  
+It also supports AUR package updates if [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru) is installed. 
+Before performing the updates, it offers to print the latest Arch Linux news to the user.  
+Once the update has been successfully performed, it checks for pacnew/pacsave files and, if there are, it offers to launch `pacdiff` to process them.  
 The update function is launched when you click on the (.desktop) icon.  
 
 #### -c, --check

--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ Install the [arch-update](https://aur.archlinux.org/packages/arch-update "arch-u
 
 ### From Source
 
-Install dependencies *(replace `sudo` by `doas` if needed)*:  
+Install dependencies:  
 ```
 sudo pacman -S --needed pacman-contrib curl hq diffutils vim
 ```
   
 Download the archive of the [latest stable release](https://github.com/Antiz96/arch-update/releases/latest) and extract it *(alternatively, you can clone this repository via `git`)*.  
   
-To install `arch-update`, go into the extracted/cloned directory and run the following command *(replace `sudo` by `doas` if needed)*:
+To install `arch-update`, go into the extracted/cloned directory and run the following command:
 ```
 sudo make install
 ```
    
-To uninstall `arch-update`, go into the extracted/cloned directory and run the following command *(replace `sudo` by `doas` if needed)*:  
+To uninstall `arch-update`, go into the extracted/cloned directory and run the following command:  
 ```
 sudo make uninstall
 ```
@@ -166,7 +166,7 @@ See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 
 ### Show packages version changes
 
-If you want `arch-update` to show the packages version changes in the main `update` function, run the following command *(replace `sudo` with `doas` if needed)*:  
+If you want `arch-update` to show the packages version changes in the main `update` function, run the following command:  
 ```
 sudo sed -i "s/ | awk '{print \$1}'//g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null || true
 ```

--- a/README.md
+++ b/README.md
@@ -66,25 +66,24 @@ systemctl --user enable --now arch-update.timer
 
 ### Screenshot
 
-Personally, I integrated the .desktop file in my top bar.  
-  
+Personally, I integrated the .desktop icon in my top bar.  
 It is the first icon from the left.  
 ![Up_to_date](https://user-images.githubusercontent.com/53110319/204068077-40775c1c-06dd-4665-b837-08f0cefb3941.png)  
      
-When `arch-update` is checking for updates, the icon changes accordingly *(the check function is automatically triggered at boot and then once every hour if you enabled the [systemd timer](#the-systemd-timer) and can be manually triggered by running the `arch-update -c` command)*:  
+When `arch-update` is checking for updates, the icon changes accordingly *(the `check` function is automatically triggered at boot and then once every hour if you enabled the [systemd timer](#the-systemd-timer) and can be manually triggered by running the `arch-update -c` command)*:  
 ![Searching_for_updates](https://user-images.githubusercontent.com/53110319/204068136-25adb912-54f7-4d95-afd6-f08c5b73677d.png)  
    
 If there are available updates, the icon will show a bell sign and a desktop notification indicating the number of available updates will be sent *(requires [libnotify/notify-send](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package"))*:  
 ![Updates_availables](https://user-images.githubusercontent.com/53110319/204068175-5ef1cb05-b72b-44b1-9f4b-0a801d363663.png)  
 ![Updates_availables+notif](https://user-images.githubusercontent.com/53110319/204068184-e2fddf44-ffd6-4b2a-80fe-75e8d20ecf7e.png)  
    
-When the icon is clicked, it refreshes the list of packages available for updates and print it inside a terminal window. Then it asks for the user's confirmation to proceed with the installation *(requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR package updates support)*:  
+When the icon is clicked, it launches the main `update` function which refreshes the list of packages available for updates, print it inside a terminal window and asks for the user's confirmation to proceed with the installation *(It can also be launched by running the `arch-update` command. It requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR package updates support)*:  
 ![List_of_packages](https://user-images.githubusercontent.com/53110319/204068223-a31e7a21-8df7-4e51-ac4b-7df6c52c5d20.png)  
   
-You can optionally configure `arch-update` to show the version changes during the package listing *(see: [Tips and tricks - Show package version changes](#show-packages-version-changes))*:  
+You can optionally configure `arch-update` to show the version changes during the package listing *(see: [Tips and tricks - Show package version changes](#show-package-version-changes))*:  
 ![List_of_packages_with_version](https://user-images.githubusercontent.com/53110319/204068369-2da6480f-7faa-4fa1-937c-6b168ca11795.png)  
 
-Once you gave the confirmation to proceed, `arch-update` offers to print latest Arch Linux news so you can acknowledge them easily. Select which news to read by typing its associated number. After your read a news, `arch-update` will once again offers to print latest Arch Linux news, so you can multiple news at each update. Simply press "enter" without typing any number beforehand to proceed with update:  
+Once you gave the confirmation to proceed, `arch-update` offers to print latest Arch Linux news so you can acknowledge them easily. Select which news to read by typing its associated number. After your read a news, `arch-update` will once again offers to print latest Arch Linux news, so you can read multiple news at each update. Simply press "enter" without typing any number beforehand to proceed with update:  
 ![Arch_news](https://user-images.githubusercontent.com/53110319/204068653-de484935-344a-4956-b134-5b4b1771360e.png)  
    
 While `arch-update` is performing updates, the icon changes accordingly:  

--- a/README.md
+++ b/README.md
@@ -66,26 +66,35 @@ systemctl --user enable --now arch-update.timer
 
 ### Screenshot
 
-Personally, I integrated the .desktop file on my dock.  
+Personally, I integrated the .desktop file in my top bar.  
   
-It is the penultimate icon from left to right (next to the red "Power Sign" icon).  
-This is how it looks like when `arch-update` is checking for available updates (*the check is automatically triggered at boot and then once every hour if you enabled the [systemd timer](#the-systemd-timer) and can be manually triggered with the `arch-update -c` command:*  
-![Arch-Update_Check](https://user-images.githubusercontent.com/53110319/161241670-8cab8a54-199b-41f1-80e3-95b171bbb70f.png)  
+It is the first icon from the left.  
+![Up_to_date](https://user-images.githubusercontent.com/53110319/204068077-40775c1c-06dd-4665-b837-08f0cefb3941.png)  
+     
+When `arch-update` is checking for updates, the icon changes accordingly *(the check function is automatically triggered at boot and then once every hour if you enabled the [systemd timer](#the-systemd-timer) and can be manually triggered by running the `arch-update -c` command)*:  
+![Searching_for_updates](https://user-images.githubusercontent.com/53110319/204068136-25adb912-54f7-4d95-afd6-f08c5b73677d.png)  
+   
+If there are available updates, the icon will show a bell sign and a desktop notification indicating the number of available updates will be sent *(requires [libnotify/notify-send](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package"))*:  
+![Updates_availables](https://user-images.githubusercontent.com/53110319/204068175-5ef1cb05-b72b-44b1-9f4b-0a801d363663.png)  
+![Updates_availables+notif](https://user-images.githubusercontent.com/53110319/204068184-e2fddf44-ffd6-4b2a-80fe-75e8d20ecf7e.png)  
+   
+When the icon is clicked, it refreshes the list of packages available for updates and print it inside a terminal window. Then it asks for the user's confirmation to proceed with the installation *(requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR package updates support)*:  
+![List_of_packages](https://user-images.githubusercontent.com/53110319/204068223-a31e7a21-8df7-4e51-ac4b-7df6c52c5d20.png)  
   
-If there are available updates, the icon will change and a desktop notification indicating the number of available updates will be sent (*requires [libnotify/notify-send](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package")*):
-![Arch-Update_Updates_Available+Notif](https://user-images.githubusercontent.com/53110319/161244079-b2ce8f2f-d4d3-42ad-83c1-62161d6da62f.png)  
+You can optionally configure `arch-update` to show the version changes during the package listing *(see: [Tips and tricks - Show package version changes](#show-packages-version-changes))*:  
+![List_of_packages_with_version](https://user-images.githubusercontent.com/53110319/204068369-2da6480f-7faa-4fa1-937c-6b168ca11795.png)  
+
+Once you gave the confirmation to proceed, `arch-update` offers to print latest Arch Linux news so you can acknowledge them easily. Select which news to read by typing its associated number. After your read a news, `arch-update` will once again offers to print latest Arch Linux news, so you can multiple news at each update. Simply press "enter" without typing any number beforehand to proceed with update:  
+![Arch_news](https://user-images.githubusercontent.com/53110319/204068653-de484935-344a-4956-b134-5b4b1771360e.png)  
+   
+While `arch-update` is performing updates, the icon changes accordingly:  
+![Installing_updates](https://user-images.githubusercontent.com/53110319/204068693-1f71b07a-e273-46aa-a8c1-7d729617e466.png)  
+
+After each successful update, `arch-update` will scan your system for pacnew/pacsave files and offers to process them via `pacdiff` (if there are):  
+![Pacdiff](https://user-images.githubusercontent.com/53110319/204068789-a45e1576-9336-469b-8b6e-a482fbf6b160.png)  
   
-When the icon is clicked, it refreshes the list of packages available for updates and print it inside a terminal window. Then it asks for the user's confirmation to proceed (*requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR packages support*):
-![Arch-Update_List_Packages](https://user-images.githubusercontent.com/53110319/161244601-8ddeb5c4-b6cd-47a7-a035-debdbad75936.png)  
-  
-If you chose to show the packages version changes (refer to the [Tips and tricks](#tips-and-tricks) section below), this is how it looks like:
-![Arch-Update_List_Packages_With_Version_Changes](https://user-images.githubusercontent.com/53110319/161244783-bb0de764-04bb-4c39-b17a-54dcfb9de449.png)  
-  
-Once the user gave the confirmation to proceed, the update process will begin and the icon will change accordingly:
-![Arch-Update_Installing](https://user-images.githubusercontent.com/53110319/161245498-35bb8f9d-c050-40f5-ae67-d7a01b0bae19.png)  
-  
-Finally, when the update is over and your machine is up to date, the icon will look like this:
-![Arch-Update_up_to_date](https://user-images.githubusercontent.com/53110319/161245726-b3adff52-f91e-40b6-9acc-a7f0d35fa7a5.png)
+Finally, when the update is over, the icon changes accordingly:  
+![Up_to_date](https://user-images.githubusercontent.com/53110319/204068822-85f19af5-f817-49b9-9a25-96c5364e61fa.png)  
 
 ## Documentation
 
@@ -164,7 +173,7 @@ systemctl --user enable --now arch-update.timer
   
 See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 
-### Show packages version changes
+### Show package version changes
 
 If you want `arch-update` to show the packages version changes in the main `update` function, run the following command:  
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ While `arch-update` is performing updates, the icon changes accordingly:
 ![Installing_updates](https://user-images.githubusercontent.com/53110319/204068693-1f71b07a-e273-46aa-a8c1-7d729617e466.png)  
 
 After each successful update, `arch-update` will scan your system for pacnew/pacsave files and offers to process them via `pacdiff` (if there are):  
-![Pacdiff](https://user-images.githubusercontent.com/53110319/204068789-a45e1576-9336-469b-8b6e-a482fbf6b160.png)  
+![Pacdiff](https://user-images.githubusercontent.com/53110319/204069868-34443ec8-6f30-4b9a-871c-113e9bf80fff.png)  
   
 Finally, when the update is over, the icon changes accordingly:  
 ![Up_to_date](https://user-images.githubusercontent.com/53110319/204068822-85f19af5-f817-49b9-9a25-96c5364e61fa.png)  

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -14,10 +14,11 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 
 .SH OPTIONS
 .PP
-.RB "If no option is passed, perform the main " "update " "function: Check for available updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (" "pacman -Syu" ")."
+.RB "If no option is passed, perform the main " "update " "function: Check for updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (" "pacman -Syu" ")."
 .br
 .RB "It also supports AUR package updates if " "yay " "or " "paru " "is installed."
 .br
+.RB "Before performing the updates, it offers to print the latest Arch Linux news to the user."
 .RB "Once the update has been successfully performed, check for pacnew/pacsave files and, if there are, offers to launch " "pacdiff " "to process them."
 .br
 .RB "The " "update " "function is launched when you click on the (.desktop) icon."
@@ -107,6 +108,7 @@ See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 .BR sudo (8),
 .BR doas (1),
 .BR find (1),
+.BR curl (1),
 .BR pacman (8),
 .BR pacdiff (8),
 .BR systemd.service (5),

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -19,6 +19,7 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .RB "It also supports AUR package updates if " "yay " "or " "paru " "is installed."
 .br
 .RB "Before performing the updates, it offers to print the latest Arch Linux news to the user."
+.br
 .RB "Once the update has been successfully performed, check for pacnew/pacsave files and, if there are, offers to launch " "pacdiff " "to process them."
 .br
 .RB "The " "update " "function is launched when you click on the (.desktop) icon."

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -95,7 +95,7 @@ See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 
 .TP
 .B Show packages version changes
-.RB "If you want Arch-Update to show the packages version changes in the main " "update " "function, launch the following command (replace sudo by doas if needed):" 
+.RB "If you want Arch-Update to show the packages version changes in the main " "update " "function, launch the following command:" 
 .br
 .B sudo sed -i "s/ | awk '{print \$1}'//g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null || true
 .br

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -87,7 +87,7 @@ case "${option}" in
 						case "${answer}" in
 							#If the user selected a news to read, print its info and content and offer to read news once again (in case the user wants to read another one)
 							1|2|3|4|5)
-								news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ /-/g | awk '{print tolower($0)}')
+								news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ /-/g | sed s/[.]//g | awk '{print tolower($0)}')
 								news_info=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | hq '.article-info' text)
 								news_content=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | hq '.article-content' text)
 								echo -e "\n${news_info}\n\n${news_content}\n" && read -n 1 -r -s -p $'Press \"enter\" to continue\n'

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -87,7 +87,7 @@ case "${option}" in
 						case "${answer}" in
 							#If the user selected a news to read, print its info and content and offer to read news once again (in case the user wants to read another one)
 							1|2|3|4|5)
-								news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ /-/g | sed s/.//g | awk '{print tolower($0)}')
+								news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ /-/g | awk '{print tolower($0)}')
 								news_info=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | hq '.article-info' text)
 								news_content=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | hq '.article-content' text)
 								echo -e "\n${news_info}\n\n${news_content}\n" && read -n 1 -r -s -p $'Press \"enter\" to continue\n'

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -138,7 +138,7 @@ case "${option}" in
 
 		#If there are pacnew/pacsave files, ask the user if he wants to manage them
 		if [ -n "${pacnew_files}" ]; then
-			echo "Pacnew/Pacsave files has been found on the system"
+			echo "Pacnew/Pacsave files have been found on the system"
 			read -rp $'Would you like to process these files now? [Y/n] ' answer
 			echo ""
 
@@ -146,7 +146,7 @@ case "${option}" in
 				#If the user gives the confirmation to proceed, launch pacdiff to manage the pacnew/pacsave files and exit
 				[Yy]|"")
 					"${su_cmd}" pacdiff
-					echo -e "\nPacnew/Pacsave files has been processed\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
+					echo -e "\nPacnew/Pacsave files have been processed\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
 					exit 0
 				;;
 

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -43,12 +43,12 @@ case "${option}" in
 
 		#If there are updates available for pacman, print them
 		if [ -n "${packages}" ]; then
-			echo -e "--Packages--" && echo -e "${packages}\n"
+			echo "--Packages--" && echo -e "${packages}\n"
 		fi
 
 		#If there are updates available for the AUR, print them
 		if [ -n "${aur_packages}" ]; then
-			echo -e "--AUR Packages--" && echo -e "${aur_packages}\n"
+			echo "--AUR Packages--" && echo -e "${aur_packages}\n"
 		fi
 
 		#If there is no update available for Pacman nor the AUR, change the desktop icon to "up-to-date" and quit
@@ -63,9 +63,43 @@ case "${option}" in
 			echo ""
 
 			case "${answer}" in
-				#If the user gives the confirmation to proceed, change the desktop icon to "installing" and apply updates
+				#If the user gives the confirmation to proceed, change the desktop icon to "installing"
 				[Yy]|"")
 					cp -f /usr/share/icons/arch-update/arch-update_installing.svg /usr/share/icons/arch-update/arch-update.svg
+				
+					#Offers to read latest Arch Linux news while the redo variable equals "y"
+					redo="y"
+					
+					while [ "${redo}" = "y" ]; do
+						#Get the titles of the latest Arch Linux news
+						news_title=$(curl -Ls https://www.archlinux.org/news | hq a attr title | grep ^"View:" | sed s/View:\ //g | head -5)
+	
+						#Print them to the user with a unique number in front of them (so the user can easily select the one to read)
+						echo "--Arch News--"
+						i=1
+						while IFS= read -r line; do
+							echo "${i}" - "${line}"
+							((i=i+1))
+						done < <(printf '%s\n' "${news_title}")
+	
+						#Ask the user which news he wants to read
+						read -rp $'\nSelect the news to read (just press \"enter\" to proceed with the installation): ' answer
+	
+						case "${answer}" in
+							#If the user selected a news to read, print its info and content and offer to read news once again (in case the user wants to read another one)
+							1|2|3|4|5)
+								news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ /-/g | awk '{print tolower($0)}')
+								news_info=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | hq '.article-info' text)
+								news_content=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | hq '.article-content' text)
+								echo -e "\n${news_info}\n\n${news_content}\n"
+							;;
+		
+							#If the user didn't select a news to read, proceed with the installation
+							*)
+								redo="n"
+							;;
+						esac
+					done
 
 					#Update for pacman (if there are)
 					if [ -n "${packages}" ]; then

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -87,7 +87,7 @@ case "${option}" in
 						case "${answer}" in
 							#If the user selected a news to read, print its info and content and offer to read news once again (in case the user wants to read another one)
 							1|2|3|4|5)
-								news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ /-/g | awk '{print tolower($0)}')
+								news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ /-/g | sed s/.//g | awk '{print tolower($0)}')
 								news_info=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | hq '.article-info' text)
 								news_content=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | hq '.article-content' text)
 								echo -e "\n${news_info}\n\n${news_content}\n" && read -n 1 -r -s -p $'Press \"enter\" to continue\n'

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -60,7 +60,6 @@ case "${option}" in
 		else
 			cp -f /usr/share/icons/arch-update/arch-update_updates-available.svg /usr/share/icons/arch-update/arch-update.svg
 			read -rp $'Proceed with installation? [Y/n] ' answer
-			echo ""
 
 			case "${answer}" in
 				#If the user gives the confirmation to proceed, change the desktop icon to "installing"
@@ -75,7 +74,7 @@ case "${option}" in
 						news_title=$(curl -Ls https://www.archlinux.org/news | hq a attr title | grep ^"View:" | sed s/View:\ //g | head -5)
 	
 						#Print them to the user with a unique number in front of them (so the user can easily select the one to read)
-						echo "--Arch News--"
+						echo -e "\n--Arch News--"
 						i=1
 						while IFS= read -r line; do
 							echo "${i}" - "${line}"
@@ -97,6 +96,7 @@ case "${option}" in
 		
 							#If the user didn't select a news to read, proceed with the installation
 							*)
+								echo ""
 								redo="n"
 							;;
 						esac

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -91,7 +91,8 @@ case "${option}" in
 								news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ /-/g | awk '{print tolower($0)}')
 								news_info=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | hq '.article-info' text)
 								news_content=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | hq '.article-content' text)
-								echo -e "\n${news_info}\n\n${news_content}\n"
+								echo -e "\n${news_info}\n\n${news_content}\n" && read -n 1 -r -s -p $'Press \"enter\" to continue\n'
+
 							;;
 		
 							#If the user didn't select a news to read, proceed with the installation


### PR DESCRIPTION
This PR aims to add a new feature into `arch-update` that offers the possibility to read the latest Arch Linux news before updating the system. 
It prints the title of the latest Arch Linux news and offers to expand their content.
Users can choose which news to read or can proceed to update without reading any if they want to.

This PR also includes a complete rework of the "screenshot" section of the README.