### PR TITLE
Make searching and processing orphan packages and pacnew files independent from updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Features:
 - Includes a (.desktop) clickeable icon that automatically changes to act as an update notifier/applier. Easy to integrate with any DE/WM, dock, status/launch bar, app menu, etc...
 - Automatic check and listing of every packages available for update (through [checkupdates](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package")), optionally shows the version changes as well.
 - Offers to print the latest Arch Linux news before applying updates (through [curl](https://archlinux.org/packages/core/x86_64/curl/ "curl package") and [hq](https://archlinux.org/packages/community/x86_64/hq/ "hq package")).
-- Automatic check and listing of orphan packages after an update, offering you to remove them.
-- Helps you processing pacnew/pacsave files after an update (through [pacdiff](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package")).
+- Automatic check and listing of orphan packages, offering you to remove them.
+- Helps you processing pacnew/pacsave files (through [pacdiff](https://archlinux.org/packages/community/x86_64/pacman-contrib/ "pacman-contrib package")).
 - Support for both [sudo](https://archlinux.org/packages/core/x86_64/sudo/ "sudo package") and [doas](https://archlinux.org/packages/community/x86_64/opendoas/ "opendoas package").
 - Optional support for AUR package updates (through [yay](https://aur.archlinux.org/packages/yay "yay AUR package") or [paru](https://aur.archlinux.org/packages/paru "paru AUR package")).
 - Optional support for desktop notifications (through [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package"), see: https://wiki.archlinux.org/title/Desktop_notifications).
@@ -90,14 +90,14 @@ Once you gave the confirmation to proceed, `arch-update` offers to print latest 
 While `arch-update` is performing updates, the icon changes accordingly:  
 ![Installing_updates](https://user-images.githubusercontent.com/53110319/204068693-1f71b07a-e273-46aa-a8c1-7d729617e466.png)  
   
-After each successful update, `arch-update` will scan your system for orphan packages and offers to remove them:
-![Orphan](https://user-images.githubusercontent.com/53110319/204069868-34443ec8-6f30-4b9a-871c-113e9bf80fff.png)  
-  
-After each successful update, `arch-update` will scan your system for pacnew/pacsave files and offers to process them via `pacdiff` (if there are):  
-![Pacdiff](https://user-images.githubusercontent.com/53110319/204069868-34443ec8-6f30-4b9a-871c-113e9bf80fff.png)  
-  
-Finally, when the update is over, the icon changes accordingly:  
+When the update is over, the icon changes accordingly:  
 ![Up_to_date](https://user-images.githubusercontent.com/53110319/204068822-85f19af5-f817-49b9-9a25-96c5364e61fa.png)  
+  
+`arch-update` will also scan your system for orphan packages and offers to remove them (if there are):
+![Orphan](https://user-images.githubusercontent.com/53110319/217640788-c4d10023-185c-49a3-a3a9-b8beb893e09f.png)  
+  
+Additionally `arch-update` will scan your system for pacnew/pacsave files and offers to process them via `pacdiff` (if there are):  
+![Pacdiff](https://user-images.githubusercontent.com/53110319/204069868-34443ec8-6f30-4b9a-871c-113e9bf80fff.png)  
 
 ## Documentation
 
@@ -120,7 +120,7 @@ Optionnal support for AUR package updates (through [yay](https://aur.archlinux.o
 If no option is passed, perform the main update function: Check for updates and print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (`pacman -Syu`).  
 It also supports AUR package updates if [yay](https://aur.archlinux.org/packages/yay) or [paru](https://aur.archlinux.org/packages/paru) is installed. 
 Before performing the updates, it offers to print the latest Arch Linux news to the user.  
-Once the update has been successfully performed, it checks for orphan packages and pacnew/pacsave files and, if there are, offers to process them."  
+It also checks for orphan packages and pacnew/pacsave files and, if there are, offers to process them."  
   
 The update function is launched when you click on the (.desktop) icon.  
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -20,7 +20,7 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .br
 .RB "Before performing the updates, it offers to print the latest Arch Linux news to the user."
 .br
-.RB "Once the update has been successfully performed, it checks for orphan packages and pacnew/pacsave files and, if there are, offers to process them."
+.RB "It also checks for orphan packages and pacnew/pacsave files and, if there are, offers to process them."
 .br
 .RB "The " "update " "function is launched when you click on the (.desktop) icon."
 .PP

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -51,11 +51,10 @@ case "${option}" in
 			echo "--AUR Packages--" && echo -e "${aur_packages}\n"
 		fi
 
-		#If there is no update available for Pacman nor the AUR, change the desktop icon to "up-to-date" and quit
+		#If there is no update available for Pacman nor the AUR, change the desktop icon to "up-to-date"
 		if [ -z "${packages}" ] && [ -z "${aur_packages}" ]; then
 			cp -f /usr/share/icons/arch-update/arch-update_up-to-date.svg /usr/share/icons/arch-update/arch-update.svg
-			echo -e "No update available\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
-			exit 0
+			echo -e "No update available\n"
 		#If there are updates available, change the desktop icon to "updates-available" and ask the confirmation to apply them to the user
 		else
 			cp -f /usr/share/icons/arch-update/arch-update_updates-available.svg /usr/share/icons/arch-update/arch-update.svg
@@ -129,9 +128,10 @@ case "${option}" in
 				;;
 			esac
 
-		#If everything went well, change the desktop icon to "up-to-date"
-		cp -f /usr/share/icons/arch-update/arch-update_up-to-date.svg /usr/share/icons/arch-update/arch-update.svg
-		echo -e "\nUpdates have been applied\n"
+			#If everything went well, change the desktop icon to "up-to-date"
+			cp -f /usr/share/icons/arch-update/arch-update_up-to-date.svg /usr/share/icons/arch-update/arch-update.svg
+			echo -e "\nUpdates have been applied\n"
+		fi
 
 		#Checking for orphan packages
 		orphan_packages=$(pacman -Qtdq)
@@ -165,24 +165,25 @@ case "${option}" in
 			echo ""
 
 			case "${answer}" in
-				#If the user gives the confirmation to proceed, launch pacdiff to manage the pacnew/pacsave files and exit
+				#If the user gives the confirmation to proceed, launch pacdiff to manage the pacnew/pacsave files
 				[Yy]|"")
 					"${su_cmd}" pacdiff
-					echo -e "\nPacnew/Pacsave files have been processed\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
-					exit 0
+					echo -e "\nPacnew/Pacsave files have been processed\n"
 				;;
 
-				#If the user doesn't give the confirmation to proceed, exit
+				#If the user doesn't give the confirmation to proceed, print a relevant sentence
 				*)
-					exit 0
+					echo -e "Pacnew/Pacsave files haven't been processed\n"
 				;;
 			esac
-		#If there's no pacnew/pacsave files, exit
+		#If there's no pacnew/pacsave files, print a relevant sentence
 		else
-			read -n 1 -r -s -p $'Press \"enter\" to quit\n'
-			exit 0
+			echo -e "No Pacnew/Pacsave files found\n"
 		fi
-	fi
+
+		#If everything went well, exit
+		read -n 1 -r -s -p $'Press \"enter\" to quit\n'
+		exit 0
 	;;
 	
 	#If the -c (or --check) option is passed to the "arch-update" command, execute the check function


### PR DESCRIPTION
This PR aims to make searching and processing orphan packages and pacnew files independent from updates.

`arch-update` will search for orphan packages and pacnew/pacsave files (and offer to process them if there are) even if there's no update available.