### PR TITLE
Make the pacnew processing feature lists pacnew files before offering to process them

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ When the update is over, the icon changes accordingly:
 ![Orphan](https://user-images.githubusercontent.com/53110319/217640788-c4d10023-185c-49a3-a3a9-b8beb893e09f.png)  
   
 Additionally `arch-update` will scan your system for pacnew/pacsave files and offers to process them via `pacdiff` (if there are):  
-![Pacdiff](https://user-images.githubusercontent.com/53110319/204069868-34443ec8-6f30-4b9a-871c-113e9bf80fff.png)  
+![Pacnew](https://user-images.githubusercontent.com/53110319/217660567-f00db345-55b9-424b-9436-77492d6c00b8.png)  
 
 ## Documentation
 

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -160,7 +160,7 @@ case "${option}" in
 
 		#If there are pacnew/pacsave files, ask the user if he wants to manage them
 		if [ -n "${pacnew_files}" ]; then
-			echo "Pacnew/Pacsave files have been found on the system"
+			echo -e "--Pacnew files--\n${pacnew_files}\n"
 			read -rp $'Would you like to process these files now? [Y/n] ' answer
 			echo ""
 


### PR DESCRIPTION
This PR aims to make the pacnew processing feature lists pacnew files before offering to process them.

`arch-update` gives the list of pacnew/pacsave files (in the same format as the list of packages available to update or orphan packages to remove) before offering to process them.