### PR TITLE
Fix the 'checkupdate' issue when using yay

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #Current version
-version="1.5.1"
+version="1.5.2"
 
 #Check which privilege elevation package is installed (sudo or doas)
 if command -v sudo > /dev/null; then
@@ -38,7 +38,7 @@ case "${option}" in
 
 		#Get the list of available update(s) for the AUR (if "yay" or "paru" is installed)
 		if [ -n "${aur_helper}" ]; then
-			aur_packages=$("${aur_helper}" -Qua | awk '{print $1}')
+			aur_packages=$("${aur_helper}" -Qua | grep -v ^"::" | awk '{print $1}')
 		fi
 
 		#If there are updates available for pacman, print them
@@ -209,7 +209,7 @@ case "${option}" in
 
 		#Get the number of available update(s)
 		if [ -n "${aur_helper}" ]; then
-			update_number=$( (checkupdates ; "${aur_helper}" -Qua) | wc -l )
+			update_number=$( (checkupdates ; "${aur_helper}" -Qua | grep -v ^"::") | wc -l )
 		else
 			update_number=$(checkupdates | wc -l)
 		fi


### PR DESCRIPTION
`yay` recently introduced a new behavior in its "checkupdate" function (in this [PR](https://github.com/Jguer/yay/pull/1915)) which now prints the following sentence:
```
user@Arch-Linux ~ yay -Qua
:: Searching AUR for updates...
```
This produces "false positive" with `arch-update` which thinks there are updates available (even if there are not) because of this output.
This pull request aims to fix this issue.