### PR TITLE
Use separated exit codes for each type of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,17 @@ Options:
   -c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)
   -h, --help     Display this message and exit
   -V, --version  Display version information and exit
-```
 
-For more information, see the ${name}(1) man page
+Exit Codes:
+0  OK
+1  Invalid option
+2  No privilege method (sudo or doas) is installed
+3  Error when changing icon
+4  User didn't gave the confirmation to proceed
+5  Error when updating the packages
+```
+  
+For more information, see the arch-update(1) man page
 
 ## Tips and tricks
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -48,11 +48,27 @@ Print the help
 .SH EXIT STATUS
 .TP
 .B 0
-if OK
+OK
 
 .TP
 .B 1
-if problems (user didn't gave confirmation to proceed with the installation, a problem happened during the update process, the user passed an invalid option, ...)
+Invalid option
+
+.TP
+.B 2
+No privilege method (sudo or doas) is installed
+
+.TP
+.B 3
+Error when changing icon
+
+.TP
+.B 4
+User didn't gave the confirmation to proceed
+
+.TP
+.B 5
+Error when updating the packages
 
 .SH USAGE
 .TP

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -16,7 +16,7 @@ elif command -v doas > /dev/null; then
 	su_cmd="doas"
 else
 	echo -e >&2 "A privilege elevation method is required\nPlease, install sudo or doas\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
-	exit 1
+	exit 2
 fi
 
 # Definition of the AUR helper to use (depending on if/which one is installed on the system) for the optional AUR packages support
@@ -60,22 +60,22 @@ invalid_option() {
 
 # Definition of the icon_checking function: Change icon to "checking" (used in the "list_packages" and "check" functions)
 icon_checking() {
-	cp -f /usr/share/icons/arch-update/arch-update_checking.svg /usr/share/icons/arch-update/arch-update.svg || exit 1
+	cp -f /usr/share/icons/arch-update/arch-update_checking.svg /usr/share/icons/arch-update/arch-update.svg || exit 3
 }
 
 # Definition of the icon_updates_available function: Change icon to "updates-available" (used in the "list_packages", "update" and "check" functions)
 icon_updates_available() {
-	cp -f /usr/share/icons/arch-update/arch-update_updates-available.svg /usr/share/icons/arch-update/arch-update.svg || exit 1
+	cp -f /usr/share/icons/arch-update/arch-update_updates-available.svg /usr/share/icons/arch-update/arch-update.svg || exit 3
 }
 
 # Definition of the icon_installing function: Change icon to "installing" (used in the "list_packages" function)
 icon_installing() {
-	cp -f /usr/share/icons/arch-update/arch-update_installing.svg /usr/share/icons/arch-update/arch-update.svg || exit 1
+	cp -f /usr/share/icons/arch-update/arch-update_installing.svg /usr/share/icons/arch-update/arch-update.svg || exit 3
 }
 
 # Definition of the icon_up_to_date function: Change icon to "up to date" (used in the "list_packages", "update" and "check" functions)
 icon_up_to_date() {
-	cp -f /usr/share/icons/arch-update/arch-update_up-to-date.svg /usr/share/icons/arch-update/arch-update.svg || exit 1
+	cp -f /usr/share/icons/arch-update/arch-update_up-to-date.svg /usr/share/icons/arch-update/arch-update.svg || exit 3
 }
 
 # Definition of the list_packages function: Print packages that are available for update and offer to apply them if there are (used in the "update" functions)
@@ -112,7 +112,7 @@ list_packages() {
 		;;
 		*)
 			echo -e >&2 "The update has been aborted\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
-			exit 1
+			exit 4
 		;;
 	esac
 }
@@ -157,7 +157,7 @@ update() {
 		if ! "${su_cmd}" pacman -Syu; then
 			icon_updates_available
 			echo -e >&2 "\nAn error has occured\nThe update has been aborted\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
-			exit 1
+			exit 5
 		fi
 	fi
 					
@@ -165,7 +165,7 @@ update() {
 		if ! "${aur_helper}" -Syu; then
 			icon_updates_available
 			echo -e >&2 "\nAn error has occured\nThe update has been aborted\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
-			exit 1
+			exit 5
 		fi
 	fi
 


### PR DESCRIPTION
This PR aims to make use of separated exit codes for each type of errors in order to simplify potential debugging.