### PR TITLE
Filter all special characters/symbols when parsing the Arch news urls to avoid ending with a wrong url

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -136,7 +136,7 @@ list_news() {
 
 		case "${answer}" in
 			1|2|3|4|5)
-				news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ /-/g | sed s/[.]//g | awk '{print tolower($0)}')
+				news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ -//g | sed s/\ /-/g | sed s/[.]//g | sed s/=//g | sed s/\>//g | sed s/\<//g | sed s/\`//g | sed s/://g | sed s/+//g | sed s/[[]//g | sed s/]//g | sed s/,//g | sed s/\(//g | sed s/\)//g | sed s/[/]//g | sed s/@//g | sed s/\'//g | sed s/--/-/g | awk '{print tolower(a$0)}')
 				news_info=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | htmlq --text .article-info)
 				news_content=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | htmlq --text .article-content)
 				echo -e "\n${news_info}\n\n${news_content}\n" && read -n 1 -r -s -p $'Press \"enter\" to continue\n'

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -136,7 +136,7 @@ list_news() {
 
 		case "${answer}" in
 			1|2|3|4|5)
-				news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ -//g | sed s/\ /-/g | sed s/[.]//g | sed s/=//g | sed s/\>//g | sed s/\<//g | sed s/\`//g | sed s/://g | sed s/+//g | sed s/[[]//g | sed s/]//g | sed s/,//g | sed s/\(//g | sed s/\)//g | sed s/[/]//g | sed s/@//g | sed s/\'//g | sed s/--/-/g | awk '{print tolower(a$0)}')
+				news_selected=$(sed -n "${answer}"p <<< "${news_title}" | sed s/\ -//g | sed s/\ /-/g | sed s/[.]//g | sed s/=//g | sed s/\>//g | sed s/\<//g | sed s/\`//g | sed s/://g | sed s/+//g | sed s/[[]//g | sed s/]//g | sed s/,//g | sed s/\(//g | sed s/\)//g | sed s/[/]//g | sed s/@//g | sed s/\'//g | sed s/--/-/g | awk '{print tolower($0)}')
 				news_info=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | htmlq --text .article-info)
 				news_content=$(curl -Ls "https://www.archlinux.org/news/${news_selected}" | htmlq --text .article-content)
 				echo -e "\n${news_info}\n\n${news_content}\n" && read -n 1 -r -s -p $'Press \"enter\" to continue\n'

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -6,7 +6,7 @@
 
 # Variables definition
 name="arch-update"
-version="1.5.4"
+version="1.5.5"
 option="${1}"
 
 # Definition of the evelation method to use (depending on which one is installed on the system)


### PR DESCRIPTION
This PR aims to add more `sed` filters on special characters/symbols when parsing the Arch news urls to avoid processing a wrong url during the `list_news` function, resulting in an empty printed news.