### PR TITLE
Add a '[NEW]' tag to each Arch news that are newer than 15 days

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -125,7 +125,7 @@ list_news() {
 	while [ "${redo}" = "y" ]; do
 		news=$(curl -Ls https://www.archlinux.org/news)
 		news_titles=$(echo "${news}" | htmlq -a title a | grep ^"View:" | sed s/View:\ //g | head -5)
-		news_dates=($(echo "${news}" | htmlq td | grep -v "class" | grep "[0-9]" | sed "s/<[^>]*>//g" | head -5 | xargs -I{} date -d "{}" "+%s"))
+		mapfile -t news_dates < <(echo "${news}" | htmlq td | grep -v "class" | grep "[0-9]" | sed "s/<[^>]*>//g" | head -5 | xargs -I{} date -d "{}" "+%s")
 
 		echo -e "\n--Arch News--"
 		i=1


### PR DESCRIPTION
This PR aims to add a '[NEW]' tag to each Arch news that are newer than 15 days when printing the news title so the user can quickly identify a recently published news:

```
1 - Title 1 [NEW]
2 - Title 2 [NEW]
3 - Title 3
4 - Title 4
5 - Title 5
```