### PR TITLE
Add Flatpak support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Description
 
-An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu. Optional support for AUR package updates and desktop notifications.
+An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu. Optional support for AUR & Flatpak packages updates and desktop notifications.
 
 Features:
 
@@ -21,8 +21,9 @@ Features:
 - Automatic check and listing of orphan packages and offering you to remove them.
 - Helps you processing pacnew/pacsave files (through [pacdiff](https://archlinux.org/packages/extra/x86_64/pacman-contrib/ "pacman-contrib package")).
 - Support for both [sudo](https://archlinux.org/packages/core/x86_64/sudo/ "sudo package") and [doas](https://archlinux.org/packages/extra/x86_64/opendoas/ "opendoas package").
-- Optional support for AUR package updates (through [yay](https://aur.archlinux.org/packages/yay "yay AUR package") or [paru](https://aur.archlinux.org/packages/paru "paru AUR package")).
-- Optional support for desktop notifications (through [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package"), see <https://wiki.archlinux.org/title/Desktop_notifications>).
+- Optional support for AUR packages update (through [yay](https://aur.archlinux.org/packages/yay "yay AUR package") or [paru](https://aur.archlinux.org/packages/paru "paru AUR package")).
+- Optional support for Flatpak packages update (through [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak "Flatpak package").
+- Optional support for desktop notifications (through [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify "libnotify package"), see <https://wiki.archlinux.org/title/Desktop_notifications>).
 
 ## Installation
 
@@ -87,11 +88,11 @@ If there are available updates, the icon will show a bell sign and a desktop not
 ![top_bar_update_available](https://github.com/Antiz96/arch-update/assets/53110319/e76be2e4-07b1-41db-8a5d-8cff89e904f6)  
 ![notification](https://github.com/Antiz96/arch-update/assets/53110319/4d7fb15e-2d94-4740-9831-fe4dfd264c13)
 
-When the icon is clicked, it launches the main `update` function which refreshes the list of packages available for updates, print it inside a terminal window and asks for the user's confirmation to proceed with the installation *(it can also be launched by running the `arch-update` command, requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR package updates support)*:
+When the icon is clicked, it launches the main `update` function which refreshes the list of packages available for updates, print it inside a terminal window and asks for the user's confirmation to proceed with the installation *(it can also be launched by running the `arch-update` command, requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR packages update support and [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak/) for Flatpak packages update support)*:
 
 ![main_update_function](https://github.com/Antiz96/arch-update/assets/53110319/0536f8c3-3942-444e-b942-60c5c729c0bb)
 
-You can optionally configure `arch-update` to show the version changes during the package listing *(see [Tips and tricks - Show package version changes](#show-package-version-changes))*:
+You can optionally configure `arch-update` to show the version changes during the package listing *(see [Tips and tricks - Show package version changes](#show-package-version-changes), not supported for Flatpak packages update)*:
 
 ![main_update_function_with_version_changes](https://github.com/Antiz96/arch-update/assets/53110319/42ccff54-04df-481b-8fc8-8631f456c8aa)
 
@@ -111,7 +112,7 @@ When the update is over, the icon changes accordingly:
 
 ![top_bar_up_to_date](https://github.com/Antiz96/arch-update/assets/53110319/794696a0-3452-4afd-8d64-a41d64225082)
 
-`arch-update` will also search for orphan packages and offers to remove them (if there are):
+`arch-update` will also search for orphan packages/unused Flatpak packages and offers to remove them (if there are):
 
 ![remove_orphan](https://github.com/Antiz96/arch-update/assets/53110319/4abf2623-ba27-4c42-8289-884199bfb579)
 
@@ -147,9 +148,14 @@ For more information, see the arch-update(1) man page
 
 ### AUR Support
 
-Arch-Update supports AUR package updates when checking and installing updates if **yay** or **paru** is installed:  
+Arch-Update supports AUR packages update when checking and installing updates if **yay** or **paru** is installed:  
 See <https://github.com/Jguer/yay> and <https://aur.archlinux.org/packages/yay>  
 See <https://github.com/morganamilo/paru> and <https://aur.archlinux.org/packages/paru>
+
+### Flatpak Support
+
+Arch-Update supports Flatpak packages update when checking and installing updates (as well as removing unused Flatpak packages) if **flatpak** is installed:  
+See <https://www.flatpak.org/> and <https://archlinux.org/packages/extra/x86_64/flatpak/>
 
 ### Desktop notifications Support  
 
@@ -171,7 +177,7 @@ See <https://www.freedesktop.org/software/systemd/man/systemd.time.html>
 
 ### Show package version changes
 
-If you want `arch-update` to show the packages version changes in the main `update` function, run the following command:
+If you want `arch-update` to show the packages version changes in the main `update` function, run the following command *(only shows version changes for pacman/AUR packages. Showing version changes for Flatpak packages is not supported)*:
 
 ```bash
 sudo sed -i "s/ | awk '{print \$1}'//g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 
 ## Description
 
-An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu. Optional support for AUR & Flatpak packages updates and desktop notifications.
+An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu.  
+Optional support for AUR/Flatpak packages updates and desktop notifications.
 
 Features:
 
@@ -22,7 +23,7 @@ Features:
 - Helps you processing pacnew/pacsave files (through [pacdiff](https://archlinux.org/packages/extra/x86_64/pacman-contrib/ "pacman-contrib package")).
 - Support for both [sudo](https://archlinux.org/packages/core/x86_64/sudo/ "sudo package") and [doas](https://archlinux.org/packages/extra/x86_64/opendoas/ "opendoas package").
 - Optional support for AUR packages update (through [yay](https://aur.archlinux.org/packages/yay "yay AUR package") or [paru](https://aur.archlinux.org/packages/paru "paru AUR package")).
-- Optional support for Flatpak packages update (through [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak "Flatpak package").
+- Optional support for Flatpak packages update (through [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak "Flatpak package")).
 - Optional support for desktop notifications (through [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify "libnotify package"), see <https://wiki.archlinux.org/title/Desktop_notifications>).
 
 ## Installation
@@ -126,7 +127,7 @@ Additionally `arch-update` will search for pacnew/pacsave files and offers to pr
 Run arch-update to perform the main "update" function:
 Print the list of packages available for update, then ask for the user's confirmation to proceed with the installation.
 Before performing the update, offer to print the latest Arch Linux news.
-Post update, check for orphan packages and pacnew/pacsave files and, if there are, offers to process them.
+Post update, check for orphan/unused packages and pacnew/pacsave files and, if there are, offers to process them.
 
 Options:
 -c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)
@@ -177,7 +178,7 @@ See <https://www.freedesktop.org/software/systemd/man/systemd.time.html>
 
 ### Show package version changes
 
-If you want `arch-update` to show the packages version changes in the main `update` function, run the following command *(only shows version changes for pacman/AUR packages. Showing version changes for Flatpak packages is not supported)*:
+If you want `arch-update` to show the packages version changes in the main `update` function, run the following command *(only shows version changes for pacman/AUR packages, showing version changes for Flatpak packages is not supported)*:
 
 ```bash
 sudo sed -i "s/ | awk '{print \$1}'//g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ If there are available updates, the icon will show a bell sign and a desktop not
 
 When the icon is clicked, it launches the main `update` function which refreshes the list of packages available for updates, print it inside a terminal window and asks for the user's confirmation to proceed with the installation *(it can also be launched by running the `arch-update` command, requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR packages update support and [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak/) for Flatpak packages update support)*:
 
-![main_update_function](https://github.com/Antiz96/arch-update/assets/53110319/0536f8c3-3942-444e-b942-60c5c729c0bb)
+![main_update_function](https://github.com/Antiz96/arch-update/assets/53110319/76827a27-be4f-4937-b231-53be62d9115f)
 
 You can optionally configure `arch-update` to show the version changes during the package listing *(see [Tips and tricks - Show package version changes](#show-package-version-changes), not supported for Flatpak packages update)*:
 
-![main_update_function_with_version_changes](https://github.com/Antiz96/arch-update/assets/53110319/42ccff54-04df-481b-8fc8-8631f456c8aa)
+![main_update_function_with_version_changes](https://github.com/Antiz96/arch-update/assets/53110319/43ff2d3a-a6d6-455b-9642-b11c42ed1985)
 
 Once you gave the confirmation to proceed, `arch-update` offers to print latest Arch Linux news.  
 Arch news that have been published within the last 15 days are tagged as `[NEW]`.  

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "July 2023" "Arch-Update v1" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "November 2023" "Arch-Update v1" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
@@ -10,17 +10,17 @@ arch-update \- An update notifier/applier for Arch Linux that assists you with i
 .SH DESCRIPTION
 An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu.
 .br
-.RB "Optional support for AUR package updates (through " "yay " "or " "paru" ") and desktop notifications (through " "libnotify" ")."
+.RB "Optional support for AUR package updates (through " "yay " "or " "paru" "), Flatpak package update (through " "flatpak " ") and desktop notifications (through " "libnotify" ")."
 
 .SH OPTIONS
 .PP
 .RB "If no option is passed, perform the main " "update " "function: Print the list of packages available for update, then ask for the user's confirmation to proceed with the installation (" "pacman -Syu" ")."
 .br
-.RB "It also supports AUR packages updates if " "yay " "or " "paru " "is installed."
+.RB "It also supports AUR packages update (if " "yay " "or " "paru " "is installed) and Flatpak packages update (if " "flatpak " "is installed)."
 .br
 .RB "Before performing the update, it offers to print the latest Arch Linux news to the user. Arch news that have been published within the last 15 days are tagged as '[NEW]'."
 .br
-.RB "It also checks for orphan packages and pacnew/pacsave files and, if there are, offers to process them."
+.RB "It also checks for orphan packages, unused Flatpak packages and pacnew/pacsave files and, if there are, offers to process them."
 .br
 .RB "The " "update " "function is launched when you click on the (.desktop) icon."
 .PP
@@ -31,7 +31,7 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .br
 .RB "It sends a desktop notification containing the number of available updates if " "libnotify " "is installed."
 .br
-.RB "It supports AUR packages updates if " "yay " "or " "paru " "is installed."
+.RB "It supports AUR packages update (if " "yay " "or " "paru " "is installed) and Flatpak packages update (if " "flatpak " "is installed)."
 .br
 .RB "The " "\-\-check " "option is automatically launched at boot and then every hour if you enabled the " "systemd.timer " "with the following command:" 
 .br
@@ -86,11 +86,17 @@ Error when updating the packages
 .SH TIPS AND TRICKS 
 .TP
 .B AUR Support
-.RB "Arch-Update supports AUR package updates when checking and installing updates if " "yay " "or " "paru " "is installed"
+.RB "Arch-Update supports AUR packages update when checking and installing updates if " "yay " "or " "paru " "is installed"
 .br
 See https://github.com/Jguer/yay and https://aur.archlinux.org/packages/yay
 .br
 See https://github.com/morganamilo/paru and https://aur.archlinux.org/packages/paru
+
+.TP
+.B Flatpak Support
+.RB "Arch-Update supports Flatpak packages update when checking and installing updates (as well as removing unused Flatpak packages) if " "flatpak " "is installed"
+.br
+See https://www.flatpak.org/ and https://archlinux.org/packages/extra/x86_64/flatpak/
 
 .TP
 .B Desktop notifications Support
@@ -112,7 +118,7 @@ See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 
 .TP
 .B Show packages version changes
-.RB "If you want Arch-Update to show the packages version changes in the main " "update " "function, launch the following command:" 
+.RB "If you want Arch-Update to show the packages version changes in the main " "update " "function, launch the following command (only shows version changes for pacman/AUR packages. Showing version changes for Flatpak packages is not supported):" 
 .br
 sudo sed -i "s/ | awk '{print $1}'//g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null || true
 .br
@@ -132,6 +138,7 @@ sudo sed -i "s/ | awk '{print $1}'//g" /usr/bin/arch-update /usr/local/bin/arch-
 .BR systemd.timer (5),
 .BR yay (8),
 .BR paru (8),
+.BR flatpak (1),
 .BR notify-send (1)
 
 .SH BUGS

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -10,7 +10,7 @@ arch-update \- An update notifier/applier for Arch Linux that assists you with i
 .SH DESCRIPTION
 An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu.
 .br
-.RB "Optional support for AUR package updates (through " "yay " "or " "paru" "), Flatpak package update (through " "flatpak " ") and desktop notifications (through " "libnotify" ")."
+.RB "Optional support for AUR packages update (through " "yay " "or " "paru" "), Flatpak packages update (through " "flatpak" ") and desktop notifications (through " "libnotify" ")."
 
 .SH OPTIONS
 .PP
@@ -118,7 +118,7 @@ See https://www.freedesktop.org/software/systemd/man/systemd.time.html
 
 .TP
 .B Show packages version changes
-.RB "If you want Arch-Update to show the packages version changes in the main " "update " "function, launch the following command (only shows version changes for pacman/AUR packages. Showing version changes for Flatpak packages is not supported):" 
+.RB "If you want Arch-Update to show the packages version changes in the main " "update " "function, launch the following command (only shows version changes for pacman/AUR packages, showing version changes for Flatpak packages is not supported):" 
 .br
 sudo sed -i "s/ | awk '{print $1}'//g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null || true
 .br

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -39,7 +39,7 @@ ${name} v${version}
 
 An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.
 
-Run arch-update to perform the main "update" function: Print the list of packages available for update, then ask for the user's confirmation to proceed with the installation. Before performing the update, offer to print the latest Arch Linux news. Post update, check for orphan packages and pacnew/pacsave files and, if there are, offers to process them.
+Run arch-update to perform the main "update" function: Print the list of packages available for update, then ask for the user's confirmation to proceed with the installation. Before performing the update, offer to print the latest Arch Linux news. Post update, check for orphan/unused packages and pacnew/pacsave files and, if there are, offers to process them.
 
 Options:
   -c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -26,7 +26,7 @@ elif command -v paru > /dev/null; then
 	aur_helper="paru"
 fi
 
-# Check if flatpak is installed for the optional flatpak support
+# Check if flatpak is installed for the optional Flatpak support
 flatpak=$(command -v flatpak)
 
 # Check if notify-send is installed for the optional desktop notification support
@@ -240,9 +240,9 @@ orphan_packages() {
 		echo -e "--Flatpak Unused Packages--\n${flatpak_unused}\n"
 
 		if [ "$(echo "${flatpak_unused}" | wc -l)" -eq 1 ]; then
-			read -rp $'Would you like to remove this flatpak unused package now? [y/N] ' answer
+			read -rp $'Would you like to remove this Flatpak unused package now? [y/N] ' answer
 		else
-			read -rp $'Would you like to remove these flatpak unused packages now? [y/N] ' answer
+			read -rp $'Would you like to remove these Flatpak unused packages now? [y/N] ' answer
 		fi
 
 		case "${answer}" in
@@ -255,7 +255,7 @@ orphan_packages() {
 			;;
 		esac
 	else
-		echo -e "No flatpak unused package found\n"
+		echo -e "No Flatpak unused package found\n"
 	fi
 }
 

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -293,11 +293,11 @@ pacnew_files() {
 check() {
 	icon_checking
 
-	if [ -n "${aur_helper}" ] && [ -n ${flatpak} ]; then
+	if [ -n "${aur_helper}" ] && [ -n "${flatpak}" ]; then
 		update_number=$( (checkupdates ; "${aur_helper}" -Qua ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d') | wc -l )
-	elif [ -n "${aur_helper}" ] && [ -z ${flatpak} ]; then
+	elif [ -n "${aur_helper}" ] && [ -z "${flatpak}" ]; then
 		update_number=$( (checkupdates ; "${aur_helper}" -Qua) | wc -l )
-	elif [ -z "${aur_helper}" ] && [ -n ${flatpak} ]; then
+	elif [ -z "${aur_helper}" ] && [ -n "${flatpak}" ]; then
 		update_number=$( (checkupdates ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d') | wc -l )
 	else
 		update_number=$(checkupdates | wc -l)

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -26,6 +26,9 @@ elif command -v paru > /dev/null; then
 	aur_helper="paru"
 fi
 
+# Check if flatpak is installed for the optional flatpak support
+flatpak=$(command -v flatpak)
+
 # Check if notify-send is installed for the optional desktop notification support
 notif=$(command -v notify-send)
 
@@ -88,6 +91,10 @@ list_packages() {
 		aur_packages=$("${aur_helper}" -Qua | awk '{print $1}')
 	fi
 
+	if [ -n "${flatpak}" ]; then
+		flatpak_packages=$(flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d')
+	fi
+
 	if [ -n "${packages}" ]; then
 		echo -e "--Packages--\n${packages}\n"
 	fi
@@ -96,7 +103,11 @@ list_packages() {
 		echo -e "--AUR Packages--\n${aur_packages}\n"
 	fi
 
-	if [ -z "${packages}" ] && [ -z "${aur_packages}" ]; then
+	if [ -n "${flatpak_packages}" ]; then
+		echo -e "--Flatpak Packages--\n${flatpak_packages}\n"
+	fi
+
+	if [ -z "${packages}" ] && [ -z "${aur_packages}" ] && [ -z "${flatpak_packages}" ]; then
 		icon_up_to_date
 		echo -e "No update available\n"
 		orphan_packages
@@ -180,6 +191,14 @@ update() {
 		fi
 	fi
 
+	if [ -n "${flatpak_packages}" ]; then
+		if ! flatpak update; then
+			icon_updates_available
+			echo -e >&2 "\nAn error has occurred\nThe update has been aborted\n" && read -n 1 -r -s -p $'Press \"enter\" to quit\n'
+			exit 5
+		fi
+	fi
+
 	icon_up_to_date
 	echo -e "\nThe update has been applied\n"
 
@@ -190,6 +209,10 @@ update() {
 # Definition of the orphan_packages function: Print orphan packages and offer to remove them if there are (used in the "list_packages" and "update" functions)
 orphan_packages() {
 	orphan_packages=$(pacman -Qtdq)
+
+	if [ -n "${flatpak}" ]; then
+		flatpak_unused=$(flatpak remove --unused | awk '{print $2}' | grep -v '^$' | sed '$d')
+	fi
 
 	if [ -n "${orphan_packages}" ]; then
 		echo -e "--Orphan Packages--\n${orphan_packages}\n"
@@ -211,6 +234,28 @@ orphan_packages() {
 		esac
 	else
 		echo -e "No orphan package found\n"
+	fi
+
+	if [ -n "${flatpak_unused}" ]; then
+		echo -e "--Flatpak Unused Packages--\n${flatpak_unused}\n"
+
+		if [ "$(echo "${flatpak_unused}" | wc -l)" -eq 1 ]; then
+			read -rp $'Would you like to remove this flatpak unused package now? [y/N] ' answer
+		else
+			read -rp $'Would you like to remove these flatpak unused packages now? [y/N] ' answer
+		fi
+
+		case "${answer}" in
+			[Yy])
+				echo
+				flatpak remove --unused && echo -e "\nThe removal has been applied\n" || echo -e >&2 "\nAn error has occurred\nThe removal has been aborted\n"
+			;;
+			*)
+				echo -e "The removal hasn't been applied\n"
+			;;
+		esac
+	else
+		echo -e "No flatpak unused package found\n"
 	fi
 }
 
@@ -248,8 +293,12 @@ pacnew_files() {
 check() {
 	icon_checking
 
-	if [ -n "${aur_helper}" ]; then
+	if [ -n "${aur_helper}" ] && [ -n ${flatpak} ]; then
+		update_number=$( (checkupdates ; "${aur_helper}" -Qua ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d') | wc -l )
+	elif [ -n "${aur_helper}" ] && [ -z ${flatpak} ]; then
 		update_number=$( (checkupdates ; "${aur_helper}" -Qua) | wc -l )
+	elif [ -z "${aur_helper}" ] && [ -n ${flatpak} ]; then
+		update_number=$( (checkupdates ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d') | wc -l )
 	else
 		update_number=$(checkupdates | wc -l)
 	fi


### PR DESCRIPTION
This PR aims to bring *optional* Flatpak support to `arch-update`:

- Include Flatpak packages in the count/listing of available updates and update them during the `update` function.  
- Also offer to remove unused Flatpak packages after an update.
- Documentation updated accordingly.

Obviously requires the [`flatpak` cli](https://archlinux.org/packages/extra/x86_64/flatpak/).

Fixes #52 