### PR TITLE
Only send desktop notification if the list of available updates differs from the last check

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -307,19 +307,21 @@ check() {
 		update_available=$(checkupdates)
 	fi
 	
+	if [ -n "${notif}" ]; then
+		statedir="${XDG_STATE_HOME:-${HOME}/.local/state}/${name}"
+		mkdir -p "${statedir}"
+
+		if [ -f "${statedir}/current_check" ]; then
+			mv -f "${statedir}/current_check" "${statedir}/last_check"
+		fi
+
+		echo "${update_available}" > "${statedir}/current_check"
+	fi
+
 	if [ -n "${update_available}" ]; then
 		icon_updates_available
 
 		if [ -n "${notif}" ]; then
-			statedir="${XDG_STATE_HOME:-${HOME}/.local/state}/${name}"
-			mkdir -p "${statedir}" && touch "${statedir}/last_check"
-
-			if [ -f "${statedir}/current_check" ]; then
-				mv -f "${statedir}/current_check" "${statedir}/last_check"
-			fi
-
-			echo "${update_available}" > "${statedir}/current_check"
-
 			if ! diff "${statedir}/current_check" "${statedir}/last_check" &>/dev/null; then
 				update_number=$(wc -l "${statedir}/current_check" | awk '{print $1}')
 

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -296,13 +296,6 @@ pacnew_files() {
 # Definition of the check function: Check for available updates, change the icon accordingly and send a desktop notification containing the number of available updates
 check() {
 	icon_checking
-	
-	statedir="${XDG_STATE_HOME:-${HOME}/.local/state}/${name}"
-	mkdir -p "${statedir}" && touch "${statedir}/last_check"
-
-	if [ -f "${statedir}/current_check" ]; then
-		mv -f "${statedir}/current_check" "${statedir}/last_check"
-	fi
 
 	if [ -n "${aur_helper}" ] && [ -n "${flatpak}" ]; then
 		update_available=$(checkupdates ; "${aur_helper}" -Qua ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d')
@@ -318,6 +311,13 @@ check() {
 		icon_updates_available
 
 		if [ -n "${notif}" ]; then
+			statedir="${XDG_STATE_HOME:-${HOME}/.local/state}/${name}"
+			mkdir -p "${statedir}" && touch "${statedir}/last_check"
+
+			if [ -f "${statedir}/current_check" ]; then
+				mv -f "${statedir}/current_check" "${statedir}/last_check"
+			fi
+
 			echo "${update_available}" > "${statedir}/current_check"
 
 			if ! diff "${statedir}/current_check" "${statedir}/last_check" &>/dev/null; then

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -4,7 +4,7 @@
 # https://github.com/Antiz96/arch-update
 # Licensed under the GPL-3.0 license
 
-# Variables definition
+# General variables
 name="arch-update"
 version="1.6.2"
 option="${1}"
@@ -296,24 +296,36 @@ pacnew_files() {
 # Definition of the check function: Check for available updates, change the icon accordingly and send a desktop notification containing the number of available updates
 check() {
 	icon_checking
+	
+	statedir="${XDG_STATE_HOME:-${HOME}/.local/state}/${name}"
+	mkdir -p "${statedir}" && touch "${statedir}/last_check"
 
-	if [ -n "${aur_helper}" ] && [ -n "${flatpak}" ]; then
-		update_number=$( (checkupdates ; "${aur_helper}" -Qua ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d') | wc -l )
-	elif [ -n "${aur_helper}" ] && [ -z "${flatpak}" ]; then
-		update_number=$( (checkupdates ; "${aur_helper}" -Qua) | wc -l )
-	elif [ -z "${aur_helper}" ] && [ -n "${flatpak}" ]; then
-		update_number=$( (checkupdates ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d') | wc -l )
-	else
-		update_number=$(checkupdates | wc -l)
+	if [ -f "${statedir}/current_check" ]; then
+		mv -f "${statedir}/current_check" "${statedir}/last_check"
 	fi
 
-	if [ "${update_number}" -ne 0 ]; then
+	if [ -n "${aur_helper}" ] && [ -n "${flatpak}" ]; then
+		update_available=$(checkupdates ; "${aur_helper}" -Qua ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d')
+	elif [ -n "${aur_helper}" ] && [ -z "${flatpak}" ]; then
+		update_available=$(checkupdates ; "${aur_helper}" -Qua)
+	elif [ -z "${aur_helper}" ] && [ -n "${flatpak}" ]; then
+		update_available=$(checkupdates ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d')
+	else
+		update_available=$(checkupdates)
+	fi
+	
+	if [ -n "${update_available}" ]; then
 		icon_updates_available
-		if [ -n "${notif}" ]; then
-			if [ "${update_number}" -eq 1 ]; then
-				notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch Update" "${update_number} update available"
-			else
-				notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch Update" "${update_number} updates available"
+		echo "${update_available}" > "${statedir}/current_check"
+
+		if ! diff "${statedir}/current_check" "${statedir}/last_check" &>/dev/null; then
+			if [ -n "${notif}" ]; then
+				update_number=$(wc -l "${statedir}/current_check" | awk '{print $1}')
+				if [ "${update_number}" -eq 1 ]; then
+					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch Update" "${update_number} update available"
+				else
+					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch Update" "${update_number} updates available"
+				fi
 			fi
 		fi
 	else

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -316,11 +316,13 @@ check() {
 	
 	if [ -n "${update_available}" ]; then
 		icon_updates_available
-		echo "${update_available}" > "${statedir}/current_check"
 
-		if ! diff "${statedir}/current_check" "${statedir}/last_check" &>/dev/null; then
-			if [ -n "${notif}" ]; then
+		if [ -n "${notif}" ]; then
+			echo "${update_available}" > "${statedir}/current_check"
+
+			if ! diff "${statedir}/current_check" "${statedir}/last_check" &>/dev/null; then
 				update_number=$(wc -l "${statedir}/current_check" | awk '{print $1}')
+
 				if [ "${update_number}" -eq 1 ]; then
 					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch Update" "${update_number} update available"
 				else

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -316,6 +316,7 @@ check() {
 		fi
 
 		echo "${update_available}" > "${statedir}/current_check"
+		sed -i '/^\s*$/d' "${statedir}/current_check"
 	fi
 
 	if [ -n "${update_available}" ]; then


### PR DESCRIPTION
Currently, the desktop notification included in the `check()` function is sent whenever there are update available without any sort of filter. 
That means that, with the systemd timer triggering the `check()` function each hour,  you will get a notification for the same exact available updates each hour over and over until you actually apply them (in the eventuality that there's no other available updates in the mean time).

This commit makes the `check()` function verify that the current list of available updates differs from the one obtained by the last check before re-sending a notification. 
That way, a new notification is sent only if there are new available updates compared to the last check so you don't get multiple notifications for the exact same update over time.