### PR TITLE
If both paru and yay are installed, use paru by default

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -20,10 +20,10 @@ else
 fi
 
 # Definition of the AUR helper to use (depending on if/which one is installed on the system) for the optional AUR packages support
-if command -v yay > /dev/null; then
-	aur_helper="yay"
-elif command -v paru > /dev/null; then
+if command -v paru > /dev/null; then
 	aur_helper="paru"
+elif command -v yay > /dev/null; then
+	aur_helper="yay"
 fi
 
 # Check if flatpak is installed for the optional Flatpak support


### PR DESCRIPTION
paru's default behavior is to show PKGBUILDs' diffs and ask the user to accept changes before applying updates (where yay's default behavior is to not show PKGBUILDs' changes).
This feels like a saner/safer default behavior, so if both yay and paru are installed, arch-update will now use paru instead of yay.