### PR TITLE
Add the missing space in the 'kernel_reboot' function to keep a consistent style

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -375,7 +375,7 @@ kernel_reboot() {
 	kernel_compare=$(file /boot/vmlinuz* | sed 's/^.*version\ //' | awk '{print $1}' | grep "$(uname -r)")
 
 	if [ -z "${kernel_compare}" ]; then
-		echo -e "--Reboot required--\nThere's a pending kernel update on your system requiring a reboot to be applied"
+		echo -e "--Reboot required--\nThere's a pending kernel update on your system requiring a reboot to be applied\n"
 		read -rp $'Would you like to reboot now? [y/N] ' answer
 
 		case "${answer}" in


### PR DESCRIPTION
Just adding a missing space between the description and the question (asking user to proceed with the reboot) in the 'kernel_reboot' function to keep a consistent style accros the whole script