### PR TITLE
Fix false positive and intempestive 'pending kernel update' messages on EndeavourOS with systemd-boot

### DIFF
--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -137,6 +137,7 @@ sudo sed -i "s/packages=$(checkupdates)/packages=$(checkupdates | awk '{print $1
 .BR sed (1),
 .BR file (1),
 .BR grep (1),
+.BR find (1),
 .BR mkdir (1),
 .BR mv (1),
 .BR curl (1),

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -372,7 +372,11 @@ pacnew_files() {
 
 # Definition of the kernel_reboot function: Verify if there's a kernel update waiting for a reboot to be applied
 kernel_reboot() {
-	kernel_compare=$(file /boot/vmlinuz* | sed 's/^.*version\ //' | awk '{print $1}' | grep "$(uname -r)")
+	if [ -f /boot/vmlinuz* ]; then
+		kernel_compare=$(file /boot/vmlinuz* | sed 's/^.*version\ //' | awk '{print $1}' | grep "$(uname -r)")
+	else
+		kernel_compare=$(file /usr/lib/modules/*/vmlinuz* | sed 's/^.*version\ //' | awk '{print $1}' | grep "$(uname -r)")
+	fi
 
 	if [ -z "${kernel_compare}" ]; then
 		echo -e "--Reboot required--\nThere's a pending kernel update on your system requiring a reboot to be applied\n"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -372,7 +372,7 @@ pacnew_files() {
 
 # Definition of the kernel_reboot function: Verify if there's a kernel update waiting for a reboot to be applied
 kernel_reboot() {
-	if [ -f /boot/vmlinuz* ]; then
+	if find /boot/vmlinuz* &> /dev/null; then
 		kernel_compare=$(file /boot/vmlinuz* | sed 's/^.*version\ //' | awk '{print $1}' | grep "$(uname -r)")
 	else
 		kernel_compare=$(file /usr/lib/modules/*/vmlinuz* | sed 's/^.*version\ //' | awk '{print $1}' | grep "$(uname -r)")


### PR DESCRIPTION
EndeavourOS does not use `/boot` to store `vmlinuz*` files when using systemd-boot (I couldn't find much details about a specific reason for that, attempts at analyses [here](https://github.com/Antiz96/arch-update/issues/74#issuecomment-1839544849).

This PR aims to make the script fallback to `/usr/lib/modules/*/vmlinuz*` if `vmlinuz*` files are not found under `/boot`. This prevents false positive and intempestive 'pending kernel update' messages on EndeavourOS + systemd-boot.

Fixes https://github.com/Antiz96/arch-update/issues/74