### PR TITLE
Update version number in Arch-Update manual

### DIFF
--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "December 2023" "Arch-Update v1" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "December 2023" "Arch-Update 1.9.1" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 


### PR DESCRIPTION
Changes the script version in the man page (`v1` => `1.9.1`) to be consistent with the version in `src/script/arch-update.sh`.