### PR TITLE
Add colour to checkupdates output

### DIFF
--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "December 2023" "Arch-Update 1.9.1" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "December 2023" "Arch-Update 1.9.2" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 


### PR DESCRIPTION
Improved 'checkupdates' output. I don't know if it's normal that there's no colour difference between the two versions of the packages, but I found it sad when compared with the AUR manager, which has colours everywhere .

Example:
![20231231-160527Z](https://github.com/Antiz96/arch-update/assets/71098898/c862e28b-3bff-48e5-9c25-16db73d1804d)
