### PR TITLE
Add an optional configuration file to enable/disable or modify certain options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,11 @@ install:
 	install -Dm 644 "res/systemd/${pkgname}.timer" "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
 	
 	gzip -c "doc/man/${pkgname}.1" > "${pkgname}.1.gz"
+	gzip -c "doc/man/${pkgname}.conf.5" > "${pkgname}.conf.5.gz"
 	install -Dm 644 "${pkgname}.1.gz" "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
+	install -Dm 644 "${pkgname}.conf.5.gz" "${DESTDIR}${PREFIX}/share/man/man5/${pkgname}.conf.5.gz"
 	rm -f "${pkgname}.1.gz"
+	rm -f "${pkgname}.conf.5.gz"
 	
 	install -Dm 644 README.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/README.md"
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ It will launch the relevant series of functions to perform a complete and proper
 
 ### The systemd timer
 
-There is a systemd service in `/usr/lib/systemd/user/arch-update.service` (or in `/etc/systemd/user/arch-update.service` if you installed `arch-update` [from source](#from-source)) that executes the `check` function when launched (see the [Documentation](#documentation) chapter).  
-To launch it automatically **at boot and then once every hour**, enable the associated systemd timer (you can modify the auto-check cycle to your liking, see the [Tips and tricks - Modify the auto-check cycle](#modify-the-auto-check-cycle) chapter):
+There is a systemd service in `/usr/lib/systemd/user/arch-update.service` (or in `/usr/local/lib/systemd/user/arch-update.service` if you installed `arch-update` [from source](#from-source)) that executes the `check` function when started (see the [Documentation](#documentation) chapter).  
+To start it automatically **at boot and then once every hour**, enable the associated systemd timer (you can modify the auto-check cycle to your liking, see the [Tips and tricks - Modify the auto-check cycle](#modify-the-auto-check-cycle) chapter):
 
 ```bash
 systemctl --user enable --now arch-update.timer
@@ -92,12 +92,16 @@ When `arch-update` is checking for updates, the icon changes accordingly (the `c
 
 ![icon-checking](https://github.com/Antiz96/arch-update/assets/53110319/f4c09898-7b21-430f-84be-431a31e25c3f)
 
-If there are available updates, the icon will show a bell sign and a desktop notification indicating the number of available updates will be sent (requires [libnotify/notify-send](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package")):
+If there are new available updates, the icon will show a bell sign and a desktop notification indicating the number of available updates will be sent (requires [libnotify/notify-send](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package")):
 
 ![icon-update-available](https://github.com/Antiz96/arch-update/assets/53110319/c1526ce7-5f94-41b8-a8fa-3587b9d00a9d)
 ![notification](https://github.com/Antiz96/arch-update/assets/53110319/631b8e67-487a-441a-84b4-6cce95223729)
 
 When the icon is clicked, it launches the relevant series of functions to perform a complete and proper update starting by refreshing the list of packages available for updates, print it inside a terminal window and asks for the user's confirmation to proceed with the installation (it can also be launched by running the `arch-update` command, requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR packages update support and [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak/) for Flatpak packages update support):
+
+*The colored output can be disabled with the `NoColor` option in the `arch-update.conf` configuration file.*  
+*The versions changes in the packages listing can be hidden with the `NoVersion` option in the `arch-update.conf` configuration file.*  
+*See the [arch-update.conf documentation chapter](#arch-update.conf) for more details.*
 
 ![listing-packages](https://github.com/Antiz96/arch-update/assets/53110319/43a990c8-ed93-420f-8c46-d50d60bff03f)
 
@@ -106,6 +110,10 @@ Arch news that have been published within the last 15 days are tagged as `[NEW]`
 Select which news to read by typing its associated number.  
 After your read a news, `arch-update` will once again offers to print latest Arch Linux news, so you can read multiple news at once.  
 Simply press "enter" without typing any number to proceed with update:
+
+*The Arch news listing/printing can be skipped with the "NoNews" option in the `arch-update.conf` configuration file.*  
+*Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.*  
+*See the [arch-update.conf documentation chapter](#arch-update.conf) for more details.*
 
 ![list-news](https://github.com/Antiz96/arch-update/assets/53110319/b6883ec4-8c44-4b97-86d9-4d0a304b748b)
 
@@ -123,8 +131,11 @@ When the update is over, the icon changes accordingly:
 
 ![flatpak-unused-packages](https://github.com/Antiz96/arch-update/assets/53110319/cd4053bb-623e-44c2-8c74-9f87710f4074)
 
-`arch-update` will also search for old and/or uninstalled cached packages and offers to remove them (if there are):  
-*The default behavior is to keep the last 3 cached versions of installed packages and remove every cached versions of uninstalled packages*
+`arch-update` will also search for old and/or uninstalled cached packages and offers to remove them (if there are):
+
+*The default behavior is to keep the last 3 cached versions of installed packages and remove every cached versions of uninstalled packages.*  
+*You can modify the number of old packages' versions and uninstalled packages' versions to keep in pacman's cache respectively with the `KeepOldPackages=Num` and `KeepUninstalledPackages=Num` options in the `arch-update.conf` configuration file.  
+*See the [arch-update.conf documentation chapter](#arch-update.conf) for more details.*
 
 ![cached-packages](https://github.com/Antiz96/arch-update/assets/53110319/7199bbf1-acd8-49a1-80eb-e9874b94fba6)
 
@@ -137,6 +148,8 @@ Finally, `arch-update` will check if there's a pending kernel update requiring a
 ![kernel-pending-update](https://github.com/Antiz96/arch-update/assets/53110319/14aef5b2-db32-4296-8a60-bc840c09d457)
 
 ## Documentation
+
+### arch-update
 
 ```text
 An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.
@@ -161,7 +174,29 @@ Exit Codes:
 6  Error when calling the reboot command to apply a pending kernel update
 ```
 
-For more information, see the arch-update(1) man page
+For more information, see the arch-update(1) man page.  
+Certain options can be enabled/disabled or modified via the arch-update.conf configuration file, see the arch-update.conf(5) man page.
+
+### arch-update.conf
+
+```text
+The arch-update.conf file is an optional configuration file for arch-update to enable/disable or modify certain options within the script.
+
+This configuration file has to be located in "${XDG_CONFIG_HOME}/arch-update/arch-update.conf" or "${HOME}/.config/arch-update/arch-update.conf".
+
+The supported options are:
+
+- NoColor # Do not colorize output.
+- NoVersion # Do not show versions changes for packages when listing pending updates.
+- NoNews # Do not print Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
+- KeepOldPackages=Num # Number of old packages' versions to keep in pacman's cache. Defaults to 3.
+- KeepUninstalledPackages=Num # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
+
+Options are case sensitive, so capital letters have to be respected.
+
+```
+
+For more information, see the arch-update(5) man page.
 
 ## Tips and tricks
 
@@ -194,16 +229,6 @@ OnUnitActiveSec=10m
 
 Time units are `s` for seconds, `m` for minutes, `h` for hours, `d` for days...  
 See <https://www.freedesktop.org/software/systemd/man/systemd.time.html> for more details.
-
-### Do not show package version changes
-
-If you don't want `arch-update` to show the packages version changes in the main `update` function, run the following command:
-
-```bash
-sudo sed -i "s/packages=\$(checkupdates)/packages=\$(checkupdates | awk '{print \$1}')/g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null ; sudo sed -i "s/aur_packages=\$(\"\${aur_helper}\" -Qua)/aur_packages=\$(\"\${aur_helper}\" -Qua | awk '{print \$1}')/g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null || true
-```
-
-**Be aware that you'll have to relaunch that command at each `arch-update`'s new release.**
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ When the update is over, the icon changes accordingly:
 
 *The default behavior is to keep the last 3 cached versions of installed packages and remove every cached versions of uninstalled packages.*  
 *You can modify the number of old packages' versions and uninstalled packages' versions to keep in pacman's cache respectively with the `KeepOldPackages=Num` and `KeepUninstalledPackages=Num` options in the `arch-update.conf` configuration file.*  
-*See the [arch-update.conf documentation chapter](##arch-update-configuration-file) for more details.*
+*See the [arch-update.conf documentation chapter](#arch-update-configuration-file) for more details.*
 
 ![cached-packages](https://github.com/Antiz96/arch-update/assets/53110319/7199bbf1-acd8-49a1-80eb-e9874b94fba6)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ When the icon is clicked, it launches the relevant series of functions to perfor
 
 *The colored output can be disabled with the `NoColor` option in the `arch-update.conf` configuration file.*  
 *The versions changes in the packages listing can be hidden with the `NoVersion` option in the `arch-update.conf` configuration file.*  
-*See the [arch-update.conf documentation chapter](#arch-update-conf) for more details.*
+*See the [arch-update.conf documentation chapter](#arch-update-configuration-file) for more details.*
 
 ![listing-packages](https://github.com/Antiz96/arch-update/assets/53110319/43a990c8-ed93-420f-8c46-d50d60bff03f)
 
@@ -113,7 +113,7 @@ Simply press "enter" without typing any number to proceed with update:
 
 *The Arch news listing/printing can be skipped with the `NoNews`  option in the `arch-update.conf` configuration file.*  
 *Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.*  
-*See the [arch-update.conf documentation chapter](#arch-update-conf) for more details.*
+*See the [arch-update.conf documentation chapter](#arch-update-configuration-file) for more details.*
 
 ![list-news](https://github.com/Antiz96/arch-update/assets/53110319/b6883ec4-8c44-4b97-86d9-4d0a304b748b)
 
@@ -135,7 +135,7 @@ When the update is over, the icon changes accordingly:
 
 *The default behavior is to keep the last 3 cached versions of installed packages and remove every cached versions of uninstalled packages.*  
 *You can modify the number of old packages' versions and uninstalled packages' versions to keep in pacman's cache respectively with the `KeepOldPackages=Num` and `KeepUninstalledPackages=Num` options in the `arch-update.conf` configuration file.*  
-*See the [arch-update.conf documentation chapter](#arch-update-conf) for more details.*
+*See the [arch-update.conf documentation chapter](##arch-update-configuration-file) for more details.*
 
 ![cached-packages](https://github.com/Antiz96/arch-update/assets/53110319/7199bbf1-acd8-49a1-80eb-e9874b94fba6)
 
@@ -177,7 +177,7 @@ Exit Codes:
 For more information, see the arch-update(1) man page.  
 Certain options can be enabled/disabled or modified via the arch-update.conf configuration file, see the arch-update.conf(5) man page.
 
-### arch-update.conf
+### arch-update configuration file
 
 ```text
 The arch-update.conf file is an optional configuration file for arch-update to enable/disable or modify certain options within the script.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ When the icon is clicked, it launches the relevant series of functions to perfor
 
 *The colored output can be disabled with the `NoColor` option in the `arch-update.conf` configuration file.*  
 *The versions changes in the packages listing can be hidden with the `NoVersion` option in the `arch-update.conf` configuration file.*  
-*See the [arch-update.conf documentation chapter](#arch-update.conf) for more details.*
+*See the [arch-update.conf documentation chapter](#arch-update-conf) for more details.*
 
 ![listing-packages](https://github.com/Antiz96/arch-update/assets/53110319/43a990c8-ed93-420f-8c46-d50d60bff03f)
 
@@ -111,9 +111,9 @@ Select which news to read by typing its associated number.
 After your read a news, `arch-update` will once again offers to print latest Arch Linux news, so you can read multiple news at once.  
 Simply press "enter" without typing any number to proceed with update:
 
-*The Arch news listing/printing can be skipped with the "NoNews" option in the `arch-update.conf` configuration file.*  
+*The Arch news listing/printing can be skipped with the `NoNews`  option in the `arch-update.conf` configuration file.*  
 *Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.*  
-*See the [arch-update.conf documentation chapter](#arch-update.conf) for more details.*
+*See the [arch-update.conf documentation chapter](#arch-update-conf) for more details.*
 
 ![list-news](https://github.com/Antiz96/arch-update/assets/53110319/b6883ec4-8c44-4b97-86d9-4d0a304b748b)
 
@@ -134,8 +134,8 @@ When the update is over, the icon changes accordingly:
 `arch-update` will also search for old and/or uninstalled cached packages and offers to remove them (if there are):
 
 *The default behavior is to keep the last 3 cached versions of installed packages and remove every cached versions of uninstalled packages.*  
-*You can modify the number of old packages' versions and uninstalled packages' versions to keep in pacman's cache respectively with the `KeepOldPackages=Num` and `KeepUninstalledPackages=Num` options in the `arch-update.conf` configuration file.  
-*See the [arch-update.conf documentation chapter](#arch-update.conf) for more details.*
+*You can modify the number of old packages' versions and uninstalled packages' versions to keep in pacman's cache respectively with the `KeepOldPackages=Num` and `KeepUninstalledPackages=Num` options in the `arch-update.conf` configuration file.*  
+*See the [arch-update.conf documentation chapter](#arch-update-conf) for more details.*
 
 ![cached-packages](https://github.com/Antiz96/arch-update/assets/53110319/7199bbf1-acd8-49a1-80eb-e9874b94fba6)
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "December 2023" "Arch-Update 1.9.1" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "January 2024" "Arch-Update 1.9.1" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
@@ -39,11 +39,63 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 
 .TP
 .B \-v, \-\-version
-Print the current version
+Print the current version.
 
 .TP
 .B \-h, \-\-help
-Print the help
+Print the help message.
+
+.RB "Certain options can be enabled/disabled or modified via the " "arch-update.conf configuration file " ", see the " "arch-update.conf(5) " "man page."
+
+.SH USAGE
+.TP
+.B The (.desktop) icon
+.RB "The (.desktop) icon is located in " "/usr/share/applications/arch-update.desktop " "(or in " "/etc/local/share/applications/arch-update.desktop " "if you installed arch-update from source)." 
+.br
+.RB "It will automatically change depending on different states (checking for updates, updates available, installing updates, up to date). It will launch the main " "update " "function when clicked. It is easy to integrate with any DE/WM, docks, launch bars or app menus."
+
+.TP
+.B The systemd timer
+.RB "There is a systemd service in " "/usr/lib/systemd/user/arch-update.service " "(or in " "/etc/systemd/user/arch-update.service " "if you installed arch-update from source) that executes the " "\-\-check " "function when launched. To launch it automatically " "at boot and then once every hour " "enable the associated systemd timer (the auto-check cycle can be modified to your liking. See the TIPS AND TRICKS chapter below):"
+.br
+.B systemctl \-\-user enable \-\-now arch-update.timer
+
+.SH TIPS AND TRICKS 
+.TP
+.B AUR Support
+.RB "Arch-Update supports AUR packages update when checking and installing updates if " "yay " "or " "paru " "is installed."
+.br
+See https://github.com/Jguer/yay and https://aur.archlinux.org/packages/yay
+.br
+See https://github.com/morganamilo/paru and https://aur.archlinux.org/packages/paru
+
+.TP
+.B Flatpak Support
+.RB "Arch-Update supports Flatpak packages update when checking and installing updates (as well as removing unused Flatpak packages) if " "flatpak " "is installed."
+.br
+See https://www.flatpak.org/ and https://archlinux.org/packages/extra/x86_64/flatpak/
+
+.TP
+.B Desktop notifications Support
+.RB "Arch-Update supports desktop notifications when performing the " "--check " "function if " "libnotify (notify-send) " "is installed."
+.br
+See https://wiki.archlinux.org/title/Desktop_notifications
+
+.TP
+.B Modify the auto-check cycle
+.RB "If you enabled the " "systemd.timer" ", the " "--check " "option is automatically launched at boot and then once per hour."
+.br
+.RB "If you want to change the check cycle, run " "systemctl --user edit arch-update.timer " "to create an override configuration for the timer and input the following in it:"
+.br
+
+.B [Timer]
+.br
+.B OnUnitActiveSec=10m
+
+.br
+.RB "Time units are " "s " "for seconds, " "m " "for minutes, " "h " "for hours, " "d " "for days..."
+.br
+See https://www.freedesktop.org/software/systemd/man/systemd.time.html for more details.
 
 .SH EXIT STATUS
 .TP
@@ -74,64 +126,6 @@ Error when updating the packages
 .B 6
 Error when calling the reboot command to apply a pending kernel update
 
-.SH USAGE
-.TP
-.B The (.desktop) icon
-.RB "The (.desktop) icon is located in " "/usr/share/applications/arch-update.desktop " "(or in " "/etc/local/share/applications/arch-update.desktop " "if you installed arch-update from source)." 
-.br
-.RB "It will automatically change depending on different states (checking for updates, updates available, installing updates, up to date). It will launch the main " "update " "function when clicked. It is easy to integrate with any DE/WM, docks, launch bars or app menus."
-
-.TP
-.B The systemd timer
-.RB "There is a systemd service in " "/usr/lib/systemd/user/arch-update.service " "(or in " "/etc/systemd/user/arch-update.service " "if you installed arch-update from source) that executes the " "\-\-check " "function when launched. To launch it automatically " "at boot and then once every hour " "enable the associated systemd timer (the auto-check cycle can be modified to your liking. See the TIPS AND TRICKS chapter below):"
-.br
-.B systemctl \-\-user enable \-\-now arch-update.timer
-
-.SH TIPS AND TRICKS 
-.TP
-.B AUR Support
-.RB "Arch-Update supports AUR packages update when checking and installing updates if " "yay " "or " "paru " "is installed"
-.br
-See https://github.com/Jguer/yay and https://aur.archlinux.org/packages/yay
-.br
-See https://github.com/morganamilo/paru and https://aur.archlinux.org/packages/paru
-
-.TP
-.B Flatpak Support
-.RB "Arch-Update supports Flatpak packages update when checking and installing updates (as well as removing unused Flatpak packages) if " "flatpak " "is installed"
-.br
-See https://www.flatpak.org/ and https://archlinux.org/packages/extra/x86_64/flatpak/
-
-.TP
-.B Desktop notifications Support
-.RB "Arch-Update supports desktop notifications when performing the " "--check " "function if " "libnotify (notify-send) " "is installed"
-.br
-See https://wiki.archlinux.org/title/Desktop_notifications
-
-.TP
-.B Modify the auto-check cycle
-.RB "If you enabled the " "systemd.timer" ", the " "--check " "option is automatically launched at boot and then once per hour."
-.br
-.RB "If you want to change the check cycle, run " "systemctl --user edit arch-update.timer " "to create an override configuration for the timer and input the following in it:"
-.br
-
-.B [Timer]
-.br
-.B OnUnitActiveSec=10m
-
-.br
-.RB "Time units are " "s " "for seconds, " "m " "for minutes, " "h " "for hours, " "d " "for days..."
-.br
-See https://www.freedesktop.org/software/systemd/man/systemd.time.html for more details.
-
-.TP
-.B Do not show packages version changes
-.RB "If you don't want Arch-Update to show the packages version changes in the main " "update " "function, launch the following command:" 
-.br
-sudo sed -i "s/packages=$(checkupdates)/packages=$(checkupdates | awk '{print $1}')/g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null ; sudo sed -i "s/aur_packages=$("${aur_helper}" -Qua)/aur_packages=$("${aur_helper}" -Qua | awk '{print $1}')/g" /usr/bin/arch-update /usr/local/bin/arch-update 2>/dev/null || true
-.br
-.B Be aware that you'll have to relaunch that command at each arch-update's new release.
-
 .SH SEE ALSO
 .BR cp (1),
 .BR checkupdates (8),
@@ -145,6 +139,7 @@ sudo sed -i "s/packages=$(checkupdates)/packages=$(checkupdates | awk '{print $1
 .BR mkdir (1),
 .BR mv (1),
 .BR curl (1),
+.BR tr (1),
 .BR pacman (8),
 .BR pacdiff (8),
 .BR paccache (8),
@@ -154,6 +149,7 @@ sudo sed -i "s/packages=$(checkupdates)/packages=$(checkupdates | awk '{print $1
 .BR paru (8),
 .BR flatpak (1),
 .BR notify-send (1)
+.BR arch-update.conf (5)
 
 .SH BUGS
 Please report bugs to the GitHub page https://github.com/Antiz96/arch-update/issues

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -45,7 +45,8 @@ Print the current version.
 .B \-h, \-\-help
 Print the help message.
 
-.RB "Certain options can be enabled/disabled or modified via the " "arch-update.conf configuration file " ", see the " "arch-update.conf(5) " "man page."
+.TP
+.RB "Certain options can be enabled/disabled or modified via the " "arch-update.conf " "configuration file, see the " "arch-update.conf(5) " "man page."
 
 .SH USAGE
 .TP
@@ -148,7 +149,7 @@ Error when calling the reboot command to apply a pending kernel update
 .BR yay (8),
 .BR paru (8),
 .BR flatpak (1),
-.BR notify-send (1)
+.BR notify-send (1),
 .BR arch-update.conf (5)
 
 .SH BUGS

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -153,7 +153,7 @@ Error when calling the reboot command to apply a pending kernel update
 .BR arch-update.conf (5)
 
 .SH BUGS
-Please report bugs to the GitHub page https://github.com/Antiz96/arch-update/issues
+Please report bugs to the GitHub page: https://github.com/Antiz96/arch-update/issues
 
 .SH AUTHOR
 Robin Candau <robincandau@protonmail.com>

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -23,6 +23,7 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .RB "It also checks for orphan packages, unused Flatpak packages, old and/or uninstalled cached packages in pacman's cache, pacnew/pacsave files and pending kernel update requiring a reboot to be applied and, if there are, offers to process them."
 .br
 .RB "Those functions are launched when you click on the (.desktop) icon."
+
 .PP
 
 .TP

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -14,6 +14,7 @@ $XDG_CONFIG_HOME/arch-update/arch-update.conf, $HOME/.config/arch-update/arch-up
 .SH OPTIONS
 .PP
 Options are case sensitive, so capital letters have to be respected.
+
 .PP
 
 .TP
@@ -40,7 +41,7 @@ Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 
 .BR arch-update (1)
 
 .SH BUGS
-Please report bugs to the GitHub page https://github.com/Antiz96/arch-update/issues
+Please report bugs to the GitHub page: https://github.com/Antiz96/arch-update/issues
 
 .SH AUTHOR
 Robin Candau <robincandau@protonmail.com>

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -1,0 +1,46 @@
+.TH "ARCH-UPDATE.CONF" "5" "January 2024" "Arch-Update 1.9.1" "Arch-Update Manual"
+
+.SH NAME
+arch-update.conf \- arch-update configuration file.
+
+.SH SYNOPSIS
+$XDG_CONFIG_HOME/arch-update/arch-update.conf, $HOME/.config/arch-update/arch-update.conf
+
+.SH DESCRIPTION
+.RI "Arch-Update's " "optional " "configuration file."
+
+.RB "Arch-Update first attempts to read the file at " "$XDG_CONFIG_HOME/arch-update/arch-update.conf " "then at " "$HOME/.config/arch-update/arch-update.conf " "if " "$XDG_CONFIG_HOME " "is not set, or the file doesn't exist."
+
+.SH OPTIONS
+.PP
+Options are case sensitive, so capital letters have to be respected.
+.PP
+
+.TP
+.B NoColor
+Do not colorize output.
+
+.TP
+.B NoVersion
+Do not show versions changes for packages when listing pending updates.
+
+.TP
+.B NoNews
+Do not print Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
+
+.TP
+.B KeepOldPackages=Num
+Number of old packages' versions to keep in pacman's cache. Defaults to 3.
+
+.TP
+.B KeepUninstalledPackages=Num
+Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
+
+.SH SEE ALSO
+.BR arch-update (1)
+
+.SH BUGS
+Please report bugs to the GitHub page https://github.com/Antiz96/arch-update/issues
+
+.SH AUTHOR
+Robin Candau <robincandau@protonmail.com>

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -124,7 +124,8 @@ Options:
   -h, --help     Display this message and exit
   -V, --version  Display version information and exit
 
-For more information, see the ${name}(1) man page
+For more information, see the ${name}(1) man page.
+Certain options can be enabled/disabled or modified via the ${name}.conf configuration file, see the ${name}.conf(5) man page.
 EOF
 }
 

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -568,7 +568,7 @@ case "${option}" in
 				list_news
 			else
 				echo
-				warning_msg "NoNews option detected\nPlease, keep in mind that users are expected to check the latest Arch news to be aware of eventual required manual interventions before updating the system"
+				warning_msg "NoNews option detected\nPlease, keep in mind that users are expected to check the latest Arch news before updating their system, to be aware of eventual required manual interventions"
 			fi
 			update
 		fi

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -422,8 +422,8 @@ orphan_packages() {
 
 # Definition of the packages_cache function: Search for old package archives in the pacman cache and offer to remove them if there are
 packages_cache() {
-	pacman_cache_old=$(paccache -dk3 | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
-	pacman_cache_uninstalled=$(paccache -duk0 | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
+	pacman_cache_old=$(paccache -dk"${old_packages_num}" | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
+	pacman_cache_uninstalled=$(paccache -duk"${uninstalled_packages_num}" | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
 
 	[ -z "${pacman_cache_old}" ] && pacman_cache_old="0"
 	[ -z "${pacman_cache_uninstalled}" ] && pacman_cache_uninstalled="0"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -567,7 +567,8 @@ case "${option}" in
 			if [ -z "${no_news}" ]; then
 				list_news
 			else
-				warning_msg "NoNews option detected\nPlease, keep in mind that users are expected to check the latest Arch news to be aware of eventual required manual interventions before updating the system\n"
+				echo
+				warning_msg "NoNews option detected\nPlease, keep in mind that users are expected to check the latest Arch news to be aware of eventual required manual interventions before updating the system"
 			fi
 			update
 		fi


### PR DESCRIPTION
This PR aims to add an *optional* configuration file for `arch-update` to enable/disable or modify certain options within the script.

The configuration file has to be located in `${XDG_CONFIG_HOME}/arch-update/arch-update.conf` or `${HOME}/.config/arch-update/arch-update.conf`.

As of now, the supported options are:

- NoColor # Do not colorize output.
- NoVersion # Do not show versions changes for packages when listing pending updates.
- NoNews # Do not print Arch news. Note that using this option will generate a warning message as reminder that users are expected to regularly check Arch news.
- KeepOldPackages=Num # Number of old packages' versions to keep in pacman's cache. Default is 3.
- KeepUninstalledPackages=Num # Number of uninstalled packages' versions to keep in pacman's cache. Default is 0.

Options are case sensitive, so capital letters have to be respected.

Full documentation for the `arch-update.conf` file is available in the new `arch-update.conf(5)` man page.

Closes https://github.com/Antiz96/arch-update/issues/83
