### PR TITLE
Correction of documentation regarding how to change the auto-check cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ If you want to change the check cycle, run `systemctl --user edit arch-update.ti
 
 ```text
 [Timer]
+OnUnitActiveSec=
 OnUnitActiveSec=10m
 ```
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -92,6 +92,8 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 
 .B [Timer]
 .br
+.B OnUnitActiveSec=
+.br
 .B OnUnitActiveSec=10m
 
 .br


### PR DESCRIPTION
`OnUnitActiveSec` parameter first has to be reset before adding a custom configuration, otherwise the custom parameter will be **added** to the already existing one instead of acting as a replacement.

Fixes https://github.com/Antiz96/arch-update/issues/96