### PR TITLE
French translation for the documentation (README + Man pages)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
         run: actionlint -ignore 'label "CI-CD" is unknown' .github/workflows/CI.yml
 
       - name: Run codespell
-        run: codespell --enable-colors
+        run: codespell --exclude-file=README-fr.md --enable-colors
 
       - name: Run mdl
         run: mdl --style .github/workflows/mdl_style.rb .

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
         run: actionlint -ignore 'label "CI-CD" is unknown' .github/workflows/CI.yml
 
       - name: Run codespell
-        run: codespell --skip="README-fr.md,doc/man/fr/*" --enable-colors
+        run: codespell --skip="README-fr.md,./doc/man/fr/*" --enable-colors
 
       - name: Run mdl
         run: mdl --style .github/workflows/mdl_style.rb .

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
         run: actionlint -ignore 'label "CI-CD" is unknown' .github/workflows/CI.yml
 
       - name: Run codespell
-        run: codespell --skip="README-fr.md,./doc/man/fr/*" --enable-colors
+        run: codespell --skip="README-fr.md,./doc/man/fr" --enable-colors
 
       - name: Run mdl
         run: mdl --style .github/workflows/mdl_style.rb .

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
         run: actionlint -ignore 'label "CI-CD" is unknown' .github/workflows/CI.yml
 
       - name: Run codespell
-        run: codespell --exclude-file=README-fr.md --enable-colors
+        run: codespell --skip="README-fr.md,doc/man/fr/*" --enable-colors
 
       - name: Run mdl
         run: mdl --style .github/workflows/mdl_style.rb .

--- a/Makefile
+++ b/Makefile
@@ -20,22 +20,36 @@ install:
 	install -Dm 644 "res/systemd/${pkgname}.service" "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.service"
 	install -Dm 644 "res/systemd/${pkgname}.timer" "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
 	
-	gzip -c "doc/man/${pkgname}.1" > "${pkgname}.1.gz"
-	gzip -c "doc/man/${pkgname}.conf.5" > "${pkgname}.conf.5.gz"
-	install -Dm 644 "${pkgname}.1.gz" "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
-	install -Dm 644 "${pkgname}.conf.5.gz" "${DESTDIR}${PREFIX}/share/man/man5/${pkgname}.conf.5.gz"
-	rm -f "${pkgname}.1.gz"
-	rm -f "${pkgname}.conf.5.gz"
+	gzip -c "doc/man/${pkgname}.1" > "doc/man/${pkgname}.1.gz"
+	gzip -c "doc/man/${pkgname}.conf.5" > "doc/man/${pkgname}.conf.5.gz"
+	gzip -c "doc/man/fr/${pkgname}.1" > "doc/man/fr/${pkgname}.1.gz"
+	gzip -c "doc/man/fr/${pkgname}.conf.5" > "doc/man/fr/${pkgname}.conf.5.gz"
+	install -Dm 644 "doc/man/${pkgname}.1.gz" "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
+	install -Dm 644 "doc/man/${pkgname}.conf.5.gz" "${DESTDIR}${PREFIX}/share/man/man5/${pkgname}.conf.5.gz"
+	install -Dm 644 "doc/man/fr/${pkgname}.1.gz" "${DESTDIR}${PREFIX}/share/man/fr/man1/${pkgname}.1.gz"
+	install -Dm 644 "doc/man/fr/${pkgname}.conf.5.gz" "${DESTDIR}${PREFIX}/share/man/fr/man5/${pkgname}.conf.5.gz"
+	rm -f "doc/man/${pkgname}.1.gz"
+	rm -f "doc/man/${pkgname}.conf.5.gz"
+	rm -f "doc/man/fr/${pkgname}.1.gz"
+	rm -f "doc/man/fr/${pkgname}.conf.5.gz"
 	
 	install -Dm 644 README.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/README.md"
 
 uninstall:
 	rm -f "${DESTDIR}${PREFIX}/bin/${pkgname}"
+
 	rm -rf "${DESTDIR}/usr/share/icons/${pkgname}/" 
+
 	rm -f "${DESTDIR}${PREFIX}/share/applications/${pkgname}.desktop"
+
 	rm -f "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.service"
 	rm -f "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
+
 	rm -f "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
+	rm -f "${DESTDIR}${PREFIX}/share/man/man5/${pkgname}.conf.5.gz"
+	rm -f "${DESTDIR}${PREFIX}/share/man/fr/man1/${pkgname}.1.gz"
+	rm -f "${DESTDIR}${PREFIX}/share/man/fr/man5/${pkgname}.conf.5.gz"
+
 	rm -rf "${DESTDIR}${PREFIX}/share/doc/${pkgname}/"
 
 test:

--- a/README-fr.md
+++ b/README-fr.md
@@ -1,0 +1,243 @@
+# Arch-Update
+
+[![lang-en](https://img.shields.io/badge/lang-en-blue.svg)](https://github.com/Antiz96/arch-update/blob/main/README.md)
+
+## Table des matières
+
+- [Description](#description)
+- [Installation](#installation)
+- [Utilisation](#utilisation)
+- [Documentation](#documentation)
+- [Trucs et astuces](#trucs-et-astuces)
+- [Contribuer](#contribuer)
+
+## Description
+
+Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour et qui inclut une icône cliquable (.desktop) qui peut facilement être intégrée à n'importe quel environnement de bureau/gestionnaire de fenêtres, dock, barre d'état, barre de lancement ou menu d'application.  
+Prise en charge optionnelle des mises à jour des paquets AUR/Flatpak et des notifications de bureau.
+
+Fonctionnalités :
+
+- Inclut une icône cliquable (.desktop) qui change automatiquement pour agir comme un notificateur/applicateur de mise à jour. Facile à intégrer avec n'importe quel DE/WM, dock, barre d'état/lancement, menu d'application, etc...
+- Vérification et listing automatiques de tous les paquets disponibles pour la mise à jour (via [checkupdates](https://archlinux.org/packages/extra/x86_64/pacman-contrib/ "pacman-contrib package")).
+- Propose d'afficher les news récentes d'Arch Linux avant d'appliquer les mises à jour (via [curl](https://archlinux.org/packages/core/x86_64/curl/ "curl package") et [htmlq](https://archlinux.org/packages/extra/x86_64/htmlq/ "package htmlq")).
+- Vérification et listing automatiques des paquets orphelins et propose de les supprimer.
+- Vérification automatique de la présence d'anciens paquets et/ou paquets désinstallés dans le cache de `pacman` et propose de les supprimer (via [paccache](https://archlinux.org/packages/extra/x86_64/pacman-contrib/ "package pacman-contrib")).
+- Vous aide à traiter les fichiers pacnew/pacsave (via [pacdiff](https://archlinux.org/packages/extra/x86_64/pacman-contrib/ "pacman-contrib package"), nécessite optionnellement [vim](https://archlinux.org/packages/extra/x86_64/vim/ "vim package") comme [programme de fusion par défaut](https://wiki.archlinux.org/title/Pacman/Pacnew_and_Pacsave#pacdiff "programme de fusion pacdiff")).
+- Vérification automatique des mises à jour du noyau en attente nécessitant un redémarrage et propose de redémarrer s'il y en a une.
+- Fonctionne avec [sudo](https://archlinux.org/packages/core/x86_64/sudo/ "sudo package") et [doas](https://archlinux.org/packages/extra/x86_64/opendoas/ "opendoas package").
+- Prise en charge optionnelle de la mise à jour des paquets AUR (via [yay](https://aur.archlinux.org/packages/yay "yay AUR package") ou [paru](https://aur.archlinux.org/packages/paru "paru AUR package")).
+- Prise en charge optionnelle de la mise à jour des paquets Flatpak (via [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak "Flatpak Package")).
+- Prise en charge optionnelle des notifications de bureau (via [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify "libnotify package"), voir <https://wiki.archlinux.org/title/Desktop_notifications>).
+
+## Installation
+
+### AUR
+
+Installez le paquet AUR [arch-update](https://aur.archlinux.org/packages/arch-update "arch-update AUR package").
+
+### Depuis la source
+
+Installer les dépendances :
+
+```bash
+sudo pacman -S --needed pacman-contrib curl htmlq diffutils
+```
+
+Téléchargez l'archive de la [dernière version stable](https://github.com/Antiz96/arch-update/releases/latest) et extrayez-la *(vous pouvez également cloner ce référentiel via `git`)*.
+
+Pour installer `arch-update`, allez dans le répertoire extrait/cloné et exécutez la commande suivante :
+
+```bash
+sudo make install
+```
+
+Pour désinstaller `arch-update`, allez dans le répertoire extrait/cloné et exécutez la commande suivante :
+
+```bash
+sudo make uninstall
+```
+
+## Utilisation
+
+L'utilisation consiste à intégrer [le fichier .desktop](#le-fichier-desktop) quelque part (cela peut être votre bureau, votre dock, votre barre d'état/de lancement ou votre menu d'application) et à activer le [timer systemd](#le-timer-systemd).
+
+Voici une petite présentation/revue YouTube de `arch-update` que [Cardiac](https://github.com/Cardiacman13) et moi-même avons réalisée sur [sa chaîne YouTube](https://www.youtube.com/@Cardiacman) :
+
+*Attention : les fonctionnalités et le comportement par défaut d'Arch-Update peuvent avoir changé/évolué depuis !*
+
+[![youtube_presentation](https://github.com/Antiz96/arch-update/assets/53110319/23af5180-1881-486d-bd5a-3edd48ed1a08)](https://www.youtube.com/watch?v=QkOkX70SEmo)
+
+### Le fichier .desktop
+
+Le fichier .desktop se trouve dans `/usr/share/applications/arch-update.desktop` (ou `/usr/local/share/applications/arch-update.desktop` si vous avez installé `arch-update` [depuis la source](#depuis-la-source)).  
+Son icône changera automatiquement en fonction des différents états (vérification des mises à jour, mises à jour disponibles, installation des mises à jour, à jour).  
+Il lancera la série de fonctions adéquates pour effectuer une mise à jour complète et correcte lorsque vous cliquez dessus (voir le chapitre [Documentation](#documentation)). Il est facile à intégrer à n’importe quel DE/WM, dock, barre d’état/lancement ou menu d’application.
+
+### Le timer systemd
+
+Il existe un service systemd dans `/usr/lib/systemd/user/arch-update.service` (ou dans `/usr/local/lib/systemd/user/arch-update.service` si vous avez installé `arch-update` [depuis la source](#depuis-la-source)) qui exécute la fonction `check` quand il est démarré (voir le chapitre [Documentation](#documentation)).  
+Pour le démarrer automatiquement **au démarrage du système puis une fois toutes les heures**, activez le timer systemd associé (vous pouvez modifier le cycle de vérification automatique à votre guise, voir les [Trucs et astuces - Modifier le cycle de vérification automatique](#modifier-le-cycle-de-vérification-automatique)) :
+
+```bash
+systemctl --user enable --now arch-update.timer
+```
+
+### Capture d'écran
+
+Personnellement, j'ai intégré l'icône .desktop dans ma barre supérieure.  
+C'est la première icône en partant de la gauche.
+
+![icon](https://github.com/Antiz96/arch-update/assets/53110319/25f3d2ca-b9d3-4a32-ace3-b0fa785662c2)
+
+Lorsque `arch-update` vérifie les mises à jour, l'icône change en conséquence (la fonction `check` est automatiquement déclenchée au démarrage du système puis une fois toutes les heures si vous avez activé le [timer systemd](#le-timer-systemd) et peut être déclenchée manuellement en exécutant la commande `arch-update -c`) :
+
+![icon-checking](https://github.com/Antiz96/arch-update/assets/53110319/f4c09898-7b21-430f-84be-431a31e25c3f)
+
+Si de nouvelles mises à jour sont disponibles, l'icône affichera une cloche et une notification de bureau indiquant le nombre de mises à jour disponibles sera envoyée (nécessite [libnotify/notify-send](https://archlinux.org/packages/extra/x86_64/libnotify/ "paquet libnotify")) :
+
+![icon-update-available](https://github.com/Antiz96/arch-update/assets/53110319/c1526ce7-5f94-41b8-a8fa-3587b9d00a9d)
+![notification](https://github.com/Antiz96/arch-update/assets/53110319/631b8e67-487a-441a-84b4-6cce95223729)
+
+Lorsque l'on clique sur l'icône, cela lance la série de fonctions adéquates pour effectuer une mise à jour complète et correcte, en commençant par actualiser la liste des paquets disponibles pour la mise à jour, en l'affichant dans un terminal et en demandant la confirmation de l'utilisateur pour procéder à l'installation (elle peut également être lancée en exécutant la commande `arch-update`, nécessite [yay](https://aur.archlinux.org/packages/yay "yay") ou [paru](https://aur.archlinux.org/packages/paru "paru") pour la prise en charge de la mise à jour des paquets AUR et [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak/) pour la prise en charge de la mise à jour des paquets Flatpak) :
+
+*La sortie colorée peut être désactivée avec l'option `NoColor` dans le fichier de configuration `arch-update.conf`.*  
+*Les changements de versions dans la listing des paquets peuvent être masqués avec l'option `NoVersion` dans le fichier de configuration `arch-update.conf`.*  
+*Voir le [chapitre de documentation arch-update.conf](#Fichier-de-configuration-arch-update) pour plus de détails.*
+
+![listing-packages](https://github.com/Antiz96/arch-update/assets/53110319/43a990c8-ed93-420f-8c46-d50d60bff03f)
+
+Une fois que vous avez donné la confirmation pour procéder, `arch-update` propose d'afficher les dernières Arch news.  
+Les Arch news publiées au cours des 15 derniers jours sont étiquetées comme « [NEW] ».  
+Sélectionnez la news à lire en tapant le numéro associé.  
+Après avoir lu une news, `arch-update` vous proposera à nouveau d'afficher les dernières Arch news, afin que vous puissiez lire plusieurs news à la fois.  
+Appuyez simplement sur « Entrée » sans saisir de chiffre pour procéder à la mise à jour :
+
+*Le listing/affichage des Arch news peut être ignoré avec l'option `NoNews` dans le fichier de configuration `arch-update.conf`.*  
+*Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.*  
+*Voir le [chapitre de documentation arch-update.conf](#Fichier-de-configuration-arch-update) pour plus de détails.*
+
+![list-news](https://github.com/Antiz96/arch-update/assets/53110319/b6883ec4-8c44-4b97-86d9-4d0a304b748b)
+
+Pendant que `arch-update` effectue des mises à jour, l'icône change en conséquence :
+
+![icon-installing](https://github.com/Antiz96/arch-update/assets/53110319/7c74ce84-7de4-4e09-aa2a-66afad9e61d7)
+
+Une fois la mise à jour terminée, l'icône change en conséquence :
+
+![icon-up-to-date](https://github.com/Antiz96/arch-update/assets/53110319/03f224a5-5fcf-450d-9aa5-bae90e7d2e8a)
+
+`arch-update` recherchera ensuite les paquets orphelins/paquets Flatpak inutilisés et proposera de les supprimer (s'il y en a) :
+
+![paquets-orphelins](https://github.com/Antiz96/arch-update/assets/53110319/76b795e5-076e-4070-9fe2-73165503011b)
+
+![flatpak-unused-packages](https://github.com/Antiz96/arch-update/assets/53110319/cd4053bb-623e-44c2-8c74-9f87710f4074)
+
+`arch-update` recherchera également les anciens paquets et/ou paquets désinstallés mis en cache et proposera de les supprimer (s'il y en a) :
+
+*Le comportement par défaut consiste à conserver les 3 dernières versions en cache des paquets installés et à supprimer toutes les versions en cache des paquets désinstallés.*  
+*Vous pouvez modifier le nombre d'anciennes versions de paquets et de versions de paquets désinstallés à conserver respectivement dans le cache de pacman avec les options `KeepOldPackages=Num` et `KeepUninstalledPackages=Num` dans le fichier de configuration `arch-update.conf`.*  
+*Voir le [chapitre de documentation arch-update.conf](#Fichier-de-configuration-arch-update) pour plus de détails.*
+
+![cached-packages](https://github.com/Antiz96/arch-update/assets/53110319/7199bbf1-acd8-49a1-80eb-e9874b94fba6)
+
+De plus, `arch-update` recherchera les fichiers pacnew/pacsave et proposera de les traiter via `pacdiff` (s'il y en a) :
+
+![pacnew-files](https://github.com/Antiz96/arch-update/assets/53110319/5ee627ee-f7b7-4528-bf41-435d3c5892ac)
+
+Enfin, `arch-update` vérifiera s'il y a une mise à jour du noyau en attente nécessitant un redémarrage et vous proposera de le faire (s'il y en a une) :
+
+![kernel-pending-update](https://github.com/Antiz96/arch-update/assets/53110319/14aef5b2-db32-4296-8a60-bc840c09d457)
+
+## Documentation
+
+### arch-update
+
+```text
+Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les
+tâches importantes d'avant/après mise à jour.
+
+Lancez arch-update pour exécuter la fonction principale « update » :
+Afficher la liste des paquets disponibles pour mise à jour, puis demander la confirmation de l'utilisateur
+pour procéder à l'installation.
+Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news.
+Après la mise à jour, vérification de la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache,
+de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, propose de les traiter.
+
+Options :
+-c, --check    Vérifier les mises à jour disponibles, envoyer une notification de bureau contenant le nombre de mises à jour disponibles (si libnotify est installé)
+-h, --help     Afficher ce message et quitter
+-V, --version  Afficher les informations de version et quitter
+
+Codes de sortie :
+0  OK
+1  Option invalide
+2  Aucune méthode d'élévation de privilège (sudo ou doas) n'est installée
+3  Erreur lors du changement d'icône
+4  L'utilisateur n'a pas donné la confirmation de procéder
+5  Erreur lors de la mise à jour des paquets
+6  Erreur lors de l'appel de la commande reboot pour appliquer une mise à jour du noyau en attente
+```
+
+Pour plus d'informations, consultez la page de manuel arch-update(1).  
+Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration arch-update.conf, voir la page de manuel arch-update.conf(5).
+
+### Fichier de configuration arch-update
+
+```text
+Le fichier arch-update.conf est un fichier de configuration facultatif pour arch-update permettant
+d'activer/désactiver ou modifier certaines options dans le script.
+
+Ce fichier de configuration doit se trouver dans "${XDG_CONFIG_HOME}/arch-update/arch-update.conf"
+ou "${HOME}/.config/arch-update/arch-update.conf".
+
+Les options prises en charge sont :
+
+- NoColor # Ne pas coloriser la sortie.
+- NoVersion # Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente.
+- NoNews # Ne pas afficher les Arch news. Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.
+- KeepOldPackages=Num # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
+- KeepUninstalledPackages=Num # Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
+
+Les options sont sensibles à la casse, les majuscules doivent donc être respectées.
+```
+
+Pour plus d'informations, consultez la page de manuel arch-update(5).
+
+## Trucs et astuces
+
+### Prise en charge du AUR
+
+Arch-Update prend en charge la mise à jour des paquets AUR lors de la vérification et de l'installation des mises à jour si **yay** ou **paru** est installé :  
+Voir <https://github.com/Jguer/yay> et <https://aur.archlinux.org/packages/yay>  
+Voir <https://github.com/morganamilo/paru> et <https://aur.archlinux.org/packages/paru>
+
+### Prise en charge de Flatpak
+
+Arch-Update prend en charge la mise à jour des paquets Flatpak lors de la vérification et de l'installation des mises à jour (ainsi que de la suppression des packages Flatpak inutilisés) si **flatpak** est installé :  
+Voir <https://www.flatpak.org/> et <https://archlinux.org/packages/extra/x86_64/flatpak/>
+
+### Notifications de bureau
+
+Arch-Update prend en charge les notifications de bureau lors de l'exécution de la fonction `--check` si **libnotify (notify-send)** est installé :  
+Voir <https://wiki.archlinux.org/title/Desktop_notifications>
+
+### Modifier le cycle de vérification automatique
+
+Si vous avez activé le [timer systemd](#le-timer-systemd), l'option `--check` est automatiquement lancée au démarrage du système puis une fois par heure.
+
+Si vous souhaitez modifier le cycle de vérification, exécutez la commande `systemctl --user edit arch-update.timer` pour créer une configuration de remplacement pour le timer et saisissez ce qui suit :
+
+```text
+[Timer]
+OnUnitActiveSec=
+OnUnitActiveSec=10m
+```
+
+Les unités de temps sont `s` pour secondes, `m` pour minutes, `h` pour heures, `d` pour jours...  
+Voir <https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans> pour plus de détails.
+
+## Contribuer
+
+Vous pouvez soulever vos problèmes, commentaires et suggestions dans l'onglet [Issues](https://github.com/Antiz96/arch-update/issues).  
+Les [Pull requests](https://github.com/Antiz96/arch-update/pulls) sont également les bienvenues !

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Arch-Update
 
+[![lang-fr](https://img.shields.io/badge/lang-fr-blue.svg)](https://github.com/Antiz96/arch-update/blob/main/README-fr.md)
+
 ## Table of contents
 
 - [Description](#description)

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -160,4 +160,3 @@ Please report bugs to the GitHub page: https://github.com/Antiz96/arch-update/is
 
 .SH AUTHOR
 Robin Candau <robincandau@protonmail.com>
-Optionel

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -160,3 +160,4 @@ Please report bugs to the GitHub page: https://github.com/Antiz96/arch-update/is
 
 .SH AUTHOR
 Robin Candau <robincandau@protonmail.com>
+Optionel

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -1,93 +1,93 @@
-.TH "ARCH-UPDATE" "1" "January 2024" "Arch-Update 1.10.1" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "Janvier 2024" "Arch-Update 1.10.1" "Manuel de Arch-Update"
 
 .SH NAME
-arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
+arch-update \- Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour.
 
 .SH SYNOPSIS
 .B arch-update
 [\fI\,OPTION\/\fR]
 
 .SH DESCRIPTION
-An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu.
+Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour et qui inclut une icône cliquable (.desktop) qui peut facilement être intégrée à n'importe quel environnement de bureau/gestionnaire de fenêtres, dock, barre d'état, barre de lancement ou menu d'application.
 .br
-.RB "Optional support for AUR packages update (through " "yay " "or " "paru" "), Flatpak packages update (through " "flatpak" ") and desktop notifications (through " "libnotify" ")."
+.RB "Prise en charge optionnelle des mises à jour des paquets AUR (via " "yay " "or " "paru" "), des mises à jour des paquets Flatpak (via " "flatpak" ") et des notifications de bureau (via " "libnotify" ")."
 
 .SH OPTIONS
 .PP
-.RB "If no option is passed, launch the relevant series of functions to perform a complete and proper update starting by printing the list of packages available for update, then ask for the user's confirmation to proceed with the installation."
+.RB "Si aucune option n'est passée, lance la série de fonctions adéquates pour effectuer une mise à jour complète et correcte, en commençant par afficher la liste des paquets disponibles pour la mise à jour et en demandant la confirmation de l'utilisateur pour procéder à l'installation." 
 .br
-.RB "It also supports AUR packages update (if " "yay " "or " "paru " "is installed) and Flatpak packages update (if " "flatpak " "is installed)."
+.RB "Supporte les mises à jour des paquets AUR (si " "yay " "ou " "paru " "est installé) et des paquets Flatpak (si " "flatpak " "est installé)."
 .br
-.RB "Before performing the update, it offers to print the latest Arch Linux news to the user. Arch news that have been published within the last 15 days are tagged as '[NEW]'."
+.RB "Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news à l'utilisateur. Les Arch news publiées au cours des 15 derniers jours sont étiquetées comme '[NEW]'."
 .br
-.RB "It also checks for orphan packages, unused Flatpak packages, old and/or uninstalled cached packages in pacman's cache, pacnew/pacsave files and pending kernel update requiring a reboot to be applied and, if there are, offers to process them."
+.RB "Arch-Update vérifie aussi la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache, de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, propose de les traiter."
 .br
-.RB "Those functions are launched when you click on the (.desktop) icon."
+.RB "Ces fonctions sont lancées quand vous cliquez sur l'icône (.desktop)"
 
 .PP
 
 .TP
 .B \-c, \-\-check
-.RB "Check for available updates and change the (.desktop) icon accordingly if there are."
+.RB "Vérifier les mises à jour disponibles and changer l'icône (.desktop) en conséquence s'il y en a."
 .br
-.RB "It sends a desktop notification containing the number of available updates if " "libnotify " "is installed."
+.RB "Cela envoie une notification de bureau contenant le nombre de mise à jour disponibles si " "libnotify " "est installé."
 .br
-.RB "It supports AUR packages update (if " "yay " "or " "paru " "is installed) and Flatpak packages update (if " "flatpak " "is installed)."
+.RB "Supporte les mises à jour des paquets AUR (si " "yay " "ou " "paru " "est installé) et les mises à jour des paquets Flatpak (si " "flatpak " "est installé)."
 .br
-.RB "The " "\-\-check " "option is automatically launched at boot and then every hour if you enabled the " "systemd.timer " "with the following command:" 
+.RB "L'option " "\-\-check " "est automatiquement lancée au démarrage du système puis une fois chaque heure si vous avez activé le " "systemd.timer " "avec la commande suivante:" 
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
 
 .TP
 .B \-v, \-\-version
-Print the current version.
+Afficher les informations de version et quitter.
 
 .TP
 .B \-h, \-\-help
-Print the help message.
+Afficher le message d'aide.
 
 .TP
-.RB "Certain options can be enabled/disabled or modified via the " "arch-update.conf " "configuration file, see the " "arch-update.conf(5) " "man page."
+.RB "Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration " "arch-update.conf " ", voir la page de manuel " "arch-update.conf(5)".
 
-.SH USAGE
+.SH UTILISATION
 .TP
-.B The (.desktop) icon
-.RB "The (.desktop) icon is located in " "/usr/share/applications/arch-update.desktop " "(or in " "/etc/local/share/applications/arch-update.desktop " "if you installed arch-update from source)." 
+.B L'icône (.desktop)
+.RB "Le fichier .desktop se trouve dans " "/usr/share/applications/arch-update.desktop " "(ou dans " "/etc/local/share/applications/arch-update.desktop " "si vous avez installé arch-update depuis la source)." 
 .br
-.RB "It will automatically change depending on different states (checking for updates, updates available, installing updates, up to date). It will launch the main " "update " "function when clicked. It is easy to integrate with any DE/WM, docks, launch bars or app menus."
+.RB "Son icône changera automatiquement en fonction des différents états (vérification des mises à jour, mises à jour disponibles, installation des mises à jour, à jour). Il lancera la série de fonctions adéquates pour effectuer une mise à jour complète et correcte lorsque vous cliquez dessus. Il est facile à intégrer à n’importe quel DE/WM, dock, barre d’état/lancement ou menu d’application."
 
 .TP
-.B The systemd timer
-.RB "There is a systemd service in " "/usr/lib/systemd/user/arch-update.service " "(or in " "/etc/systemd/user/arch-update.service " "if you installed arch-update from source) that executes the " "\-\-check " "function when launched. To launch it automatically " "at boot and then once every hour " "enable the associated systemd timer (the auto-check cycle can be modified to your liking. See the TIPS AND TRICKS chapter below):"
+.B Le timer systemd
+.RB "Il existe un service systemd dans " "/usr/lib/systemd/user/arch-update.service " "(ou dans " "/etc/systemd/user/arch-update.service " "si vous avez installé arch-update depuis la source) qui exécute la fonction " "\-\-check " "quand il est démarré. Pour le démarrer automatiquement " "au démarrage du système puis une fois toutes les heures, " "activez le timer systemd associé (vous pouvez modifier le cycle de vérification automatique à votre guise, voir le chapitre TRUCS ET ASTUCES ci-dessous):"
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
 
-.SH TIPS AND TRICKS 
+.SH TRUCS ET ASTUCES
 .TP
-.B AUR Support
-.RB "Arch-Update supports AUR packages update when checking and installing updates if " "yay " "or " "paru " "is installed."
+.B Prise en charge du AUR
+.RB "Arch-Update prend en charge la mise à jour des paquets AUR lors de la vérification et de l'installation des mises à jour si " "yay " "ou " "paru " "est installé."
 .br
-See https://github.com/Jguer/yay and https://aur.archlinux.org/packages/yay
+Voir https://github.com/Jguer/yay et https://aur.archlinux.org/packages/yay
 .br
-See https://github.com/morganamilo/paru and https://aur.archlinux.org/packages/paru
+Voir https://github.com/morganamilo/paru et https://aur.archlinux.org/packages/paru
 
 .TP
-.B Flatpak Support
-.RB "Arch-Update supports Flatpak packages update when checking and installing updates (as well as removing unused Flatpak packages) if " "flatpak " "is installed."
+.B Prise en charge de Flatpak
+.RB "Arch-Update prend en charge la mise à jour des paquets Flatpak lors de la vérification et de l'installation des mises à jour (ainsi que de la suppression des packages Flatpak inutilisés) si " "flatpak " "est installé."
 .br
-See https://www.flatpak.org/ and https://archlinux.org/packages/extra/x86_64/flatpak/
+Voir https://www.flatpak.org/ et https://archlinux.org/packages/extra/x86_64/flatpak/
 
 .TP
-.B Desktop notifications Support
-.RB "Arch-Update supports desktop notifications when performing the " "--check " "function if " "libnotify (notify-send) " "is installed."
+.B Notifications de bureau
+.RB "Arch-Update prend en charge les notifications de bureau lors de l'exécution de la fonction " "--check " "si " "libnotify (notify-send) " "est installé."
 .br
-See https://wiki.archlinux.org/title/Desktop_notifications
+Voir https://wiki.archlinux.org/title/Desktop_notifications
 
 .TP
-.B Modify the auto-check cycle
-.RB "If you enabled the " "systemd.timer" ", the " "--check " "option is automatically launched at boot and then once per hour."
+.B Modifier le cycle de vérification automatique
+.RB "Si vous avez activé le " "systemd.timer" ", l'option " "--check " "est automatiquement lancée au démarrage du système puis une fois par heure."
 .br
-.RB "If you want to change the check cycle, run " "systemctl --user edit arch-update.timer " "to create an override configuration for the timer and input the following in it:"
+.RB "Si vous souhaitez modifier le cycle de vérification, exécutez la commande " "systemctl --user edit arch-update.timer " "pour créer une configuration de remplacement pour le timer et saisissez ce qui suit :"
 .br
 
 .B [Timer]
@@ -97,9 +97,9 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 .B OnUnitActiveSec=10m
 
 .br
-.RB "Time units are " "s " "for seconds, " "m " "for minutes, " "h " "for hours, " "d " "for days..."
+.RB "Les unités de temps sont " "s " "pour secondes, " "m " "pour minutes, " "h " "pour heures, " "d " "pour jours..."
 .br
-See https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans for more details.
+Voir https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans pour plus de détails.
 
 .SH EXIT STATUS
 .TP
@@ -108,29 +108,29 @@ OK
 
 .TP
 .B 1
-Invalid option
+Option invalide
 
 .TP
 .B 2
-No privilege elevation method (sudo or doas) is installed
+Aucune méthode d'élévation de privilège (sudo ou doas) n'est installée
 
 .TP
 .B 3
-Error when changing icon
+Erreur lors du changement d'icône
 
 .TP
 .B 4
-User didn't gave the confirmation to proceed
+L'utilisateur n'a pas donné la confirmation de procéder
 
 .TP
 .B 5
-Error when updating the packages
+Erreur lors de la mise à jour des paquets
 
 .TP
 .B 6
-Error when calling the reboot command to apply a pending kernel update
+Erreur lors de l'appel de la commande reboot pour appliquer une mise à jour du noyau en attente
 
-.SH SEE ALSO
+.SH VOIR AUSSI
 .BR cp (1),
 .BR checkupdates (8),
 .BR echo (1),
@@ -156,7 +156,7 @@ Error when calling the reboot command to apply a pending kernel update
 .BR arch-update.conf (5)
 
 .SH BUGS
-Please report bugs to the GitHub page: https://github.com/Antiz96/arch-update/issues
+Signalez les bugs sur la page GitHub: https://github.com/Antiz96/arch-update/issues
 
 .SH AUTHOR
 Robin Candau <robincandau@protonmail.com>

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -1,0 +1,162 @@
+.TH "ARCH-UPDATE" "1" "January 2024" "Arch-Update 1.10.1" "Arch-Update Manual"
+
+.SH NAME
+arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
+
+.SH SYNOPSIS
+.B arch-update
+[\fI\,OPTION\/\fR]
+
+.SH DESCRIPTION
+An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a (.desktop) clickeable icon that can easily be integrated with any DE/WM, dock, status/launch bar or app menu.
+.br
+.RB "Optional support for AUR packages update (through " "yay " "or " "paru" "), Flatpak packages update (through " "flatpak" ") and desktop notifications (through " "libnotify" ")."
+
+.SH OPTIONS
+.PP
+.RB "If no option is passed, launch the relevant series of functions to perform a complete and proper update starting by printing the list of packages available for update, then ask for the user's confirmation to proceed with the installation."
+.br
+.RB "It also supports AUR packages update (if " "yay " "or " "paru " "is installed) and Flatpak packages update (if " "flatpak " "is installed)."
+.br
+.RB "Before performing the update, it offers to print the latest Arch Linux news to the user. Arch news that have been published within the last 15 days are tagged as '[NEW]'."
+.br
+.RB "It also checks for orphan packages, unused Flatpak packages, old and/or uninstalled cached packages in pacman's cache, pacnew/pacsave files and pending kernel update requiring a reboot to be applied and, if there are, offers to process them."
+.br
+.RB "Those functions are launched when you click on the (.desktop) icon."
+
+.PP
+
+.TP
+.B \-c, \-\-check
+.RB "Check for available updates and change the (.desktop) icon accordingly if there are."
+.br
+.RB "It sends a desktop notification containing the number of available updates if " "libnotify " "is installed."
+.br
+.RB "It supports AUR packages update (if " "yay " "or " "paru " "is installed) and Flatpak packages update (if " "flatpak " "is installed)."
+.br
+.RB "The " "\-\-check " "option is automatically launched at boot and then every hour if you enabled the " "systemd.timer " "with the following command:" 
+.br
+.B systemctl \-\-user enable \-\-now arch-update.timer
+
+.TP
+.B \-v, \-\-version
+Print the current version.
+
+.TP
+.B \-h, \-\-help
+Print the help message.
+
+.TP
+.RB "Certain options can be enabled/disabled or modified via the " "arch-update.conf " "configuration file, see the " "arch-update.conf(5) " "man page."
+
+.SH USAGE
+.TP
+.B The (.desktop) icon
+.RB "The (.desktop) icon is located in " "/usr/share/applications/arch-update.desktop " "(or in " "/etc/local/share/applications/arch-update.desktop " "if you installed arch-update from source)." 
+.br
+.RB "It will automatically change depending on different states (checking for updates, updates available, installing updates, up to date). It will launch the main " "update " "function when clicked. It is easy to integrate with any DE/WM, docks, launch bars or app menus."
+
+.TP
+.B The systemd timer
+.RB "There is a systemd service in " "/usr/lib/systemd/user/arch-update.service " "(or in " "/etc/systemd/user/arch-update.service " "if you installed arch-update from source) that executes the " "\-\-check " "function when launched. To launch it automatically " "at boot and then once every hour " "enable the associated systemd timer (the auto-check cycle can be modified to your liking. See the TIPS AND TRICKS chapter below):"
+.br
+.B systemctl \-\-user enable \-\-now arch-update.timer
+
+.SH TIPS AND TRICKS 
+.TP
+.B AUR Support
+.RB "Arch-Update supports AUR packages update when checking and installing updates if " "yay " "or " "paru " "is installed."
+.br
+See https://github.com/Jguer/yay and https://aur.archlinux.org/packages/yay
+.br
+See https://github.com/morganamilo/paru and https://aur.archlinux.org/packages/paru
+
+.TP
+.B Flatpak Support
+.RB "Arch-Update supports Flatpak packages update when checking and installing updates (as well as removing unused Flatpak packages) if " "flatpak " "is installed."
+.br
+See https://www.flatpak.org/ and https://archlinux.org/packages/extra/x86_64/flatpak/
+
+.TP
+.B Desktop notifications Support
+.RB "Arch-Update supports desktop notifications when performing the " "--check " "function if " "libnotify (notify-send) " "is installed."
+.br
+See https://wiki.archlinux.org/title/Desktop_notifications
+
+.TP
+.B Modify the auto-check cycle
+.RB "If you enabled the " "systemd.timer" ", the " "--check " "option is automatically launched at boot and then once per hour."
+.br
+.RB "If you want to change the check cycle, run " "systemctl --user edit arch-update.timer " "to create an override configuration for the timer and input the following in it:"
+.br
+
+.B [Timer]
+.br
+.B OnUnitActiveSec=
+.br
+.B OnUnitActiveSec=10m
+
+.br
+.RB "Time units are " "s " "for seconds, " "m " "for minutes, " "h " "for hours, " "d " "for days..."
+.br
+See https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans for more details.
+
+.SH EXIT STATUS
+.TP
+.B 0
+OK
+
+.TP
+.B 1
+Invalid option
+
+.TP
+.B 2
+No privilege elevation method (sudo or doas) is installed
+
+.TP
+.B 3
+Error when changing icon
+
+.TP
+.B 4
+User didn't gave the confirmation to proceed
+
+.TP
+.B 5
+Error when updating the packages
+
+.TP
+.B 6
+Error when calling the reboot command to apply a pending kernel update
+
+.SH SEE ALSO
+.BR cp (1),
+.BR checkupdates (8),
+.BR echo (1),
+.BR sudo (8),
+.BR doas (1),
+.BR sed (1),
+.BR file (1),
+.BR grep (1),
+.BR find (1),
+.BR mkdir (1),
+.BR mv (1),
+.BR curl (1),
+.BR tr (1),
+.BR pacman (8),
+.BR pacdiff (8),
+.BR paccache (8),
+.BR systemd.service (5),
+.BR systemd.timer (5),
+.BR yay (8),
+.BR paru (8),
+.BR flatpak (1),
+.BR notify-send (1),
+.BR arch-update.conf (5)
+
+.SH BUGS
+Please report bugs to the GitHub page: https://github.com/Antiz96/arch-update/issues
+
+.SH AUTHOR
+Robin Candau <robincandau@protonmail.com>

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -22,7 +22,7 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 .br
 .RB "Arch-Update vérifie aussi la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache, de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, propose de les traiter."
 .br
-.RB "Ces fonctions sont lancées quand vous cliquez sur l'icône (.desktop)"
+.RB "Ces fonctions sont lancées quand vous cliquez sur l'icône (.desktop)."
 
 .PP
 
@@ -34,7 +34,7 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 .br
 .RB "Supporte les mises à jour des paquets AUR (si " "yay " "ou " "paru " "est installé) et les mises à jour des paquets Flatpak (si " "flatpak " "est installé)."
 .br
-.RB "L'option " "\-\-check " "est automatiquement lancée au démarrage du système puis une fois chaque heure si vous avez activé le " "systemd.timer " "avec la commande suivante:" 
+.RB "L'option " "\-\-check " "est automatiquement lancée au démarrage du système puis une fois chaque heure si vous avez activé le " "systemd.timer " "avec la commande suivante :"
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
 
@@ -58,7 +58,7 @@ Afficher le message d'aide.
 
 .TP
 .B Le timer systemd
-.RB "Il existe un service systemd dans " "/usr/lib/systemd/user/arch-update.service " "(ou dans " "/etc/systemd/user/arch-update.service " "si vous avez installé arch-update depuis la source) qui exécute la fonction " "\-\-check " "quand il est démarré. Pour le démarrer automatiquement " "au démarrage du système puis une fois toutes les heures, " "activez le timer systemd associé (vous pouvez modifier le cycle de vérification automatique à votre guise, voir le chapitre TRUCS ET ASTUCES ci-dessous):"
+.RB "Il existe un service systemd dans " "/usr/lib/systemd/user/arch-update.service " "(ou dans " "/etc/systemd/user/arch-update.service " "si vous avez installé arch-update depuis la source) qui exécute la fonction " "\-\-check " "quand il est démarré. Pour le démarrer automatiquement " "au démarrage du système puis une fois toutes les heures, " "activez le timer systemd associé (vous pouvez modifier le cycle de vérification automatique à votre guise, voir le chapitre TRUCS ET ASTUCES ci-dessous) :"
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
 
@@ -156,7 +156,7 @@ Erreur lors de l'appel de la commande reboot pour appliquer une mise à jour du 
 .BR arch-update.conf (5)
 
 .SH BUGS
-Signalez les bugs sur la page GitHub: https://github.com/Antiz96/arch-update/issues
+Signalez les bugs sur la page GitHub : https://github.com/Antiz96/arch-update/issues
 
 .SH AUTHOR
 Robin Candau <robincandau@protonmail.com>

--- a/doc/man/fr/arch-update.conf.5
+++ b/doc/man/fr/arch-update.conf.5
@@ -1,47 +1,47 @@
-.TH "ARCH-UPDATE.CONF" "5" "January 2024" "Arch-Update 1.10.1" "Arch-Update Manual"
+.TH "ARCH-UPDATE.CONF" "5" "Janvier 2024" "Arch-Update 1.10.1" "Manuel de Arch-Update"
 
 .SH NAME
-arch-update.conf \- arch-update configuration file.
+arch-update.conf \- fichier de configuration pour arch-update.
 
 .SH SYNOPSIS
 $XDG_CONFIG_HOME/arch-update/arch-update.conf, $HOME/.config/arch-update/arch-update.conf
 
 .SH DESCRIPTION
-.RI "Arch-Update's " "optional " "configuration file."
+.RI "Fichier de configuration " "optionel " "pour Arch-Update."
 
-.RB "Arch-Update first attempts to read the file at " "$XDG_CONFIG_HOME/arch-update/arch-update.conf " "then at " "$HOME/.config/arch-update/arch-update.conf " "if " "$XDG_CONFIG_HOME " "is not set, or the file doesn't exist."
+.RB "Arch-Update tente d'abord de lire le fichier sous " "$XDG_CONFIG_HOME/arch-update/arch-update.conf " "puis sous " "$HOME/.config/arch-update/arch-update.conf " "si " "$XDG_CONFIG_HOME " "n'est pas paramétré, ou que le fichier n'existe pas."
 
 .SH OPTIONS
 .PP
-Options are case sensitive, so capital letters have to be respected.
+Les options sont sensibles à la casse, les majuscules doivent donc être respectées.
 
 .PP
 
 .TP
 .B NoColor
-Do not colorize output.
+Ne pas coloriser la sortie.
 
 .TP
 .B NoVersion
-Do not show versions changes for packages when listing pending updates.
+Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente.
 
 .TP
 .B NoNews
-Do not print Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
+Ne pas afficher les Arch news. Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.
 
 .TP
 .B KeepOldPackages=Num
-Number of old packages' versions to keep in pacman's cache. Defaults to 3.
+Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
 
 .TP
 .B KeepUninstalledPackages=Num
-Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
+Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
 
-.SH SEE ALSO
+.SH VOIR AUSSI
 .BR arch-update (1)
 
 .SH BUGS
-Please report bugs to the GitHub page: https://github.com/Antiz96/arch-update/issues
+Signalez les bugs sur la page GitHub: https://github.com/Antiz96/arch-update/issues
 
-.SH AUTHOR
+.SH AUTEUR
 Robin Candau <robincandau@protonmail.com>

--- a/doc/man/fr/arch-update.conf.5
+++ b/doc/man/fr/arch-update.conf.5
@@ -1,0 +1,47 @@
+.TH "ARCH-UPDATE.CONF" "5" "January 2024" "Arch-Update 1.10.1" "Arch-Update Manual"
+
+.SH NAME
+arch-update.conf \- arch-update configuration file.
+
+.SH SYNOPSIS
+$XDG_CONFIG_HOME/arch-update/arch-update.conf, $HOME/.config/arch-update/arch-update.conf
+
+.SH DESCRIPTION
+.RI "Arch-Update's " "optional " "configuration file."
+
+.RB "Arch-Update first attempts to read the file at " "$XDG_CONFIG_HOME/arch-update/arch-update.conf " "then at " "$HOME/.config/arch-update/arch-update.conf " "if " "$XDG_CONFIG_HOME " "is not set, or the file doesn't exist."
+
+.SH OPTIONS
+.PP
+Options are case sensitive, so capital letters have to be respected.
+
+.PP
+
+.TP
+.B NoColor
+Do not colorize output.
+
+.TP
+.B NoVersion
+Do not show versions changes for packages when listing pending updates.
+
+.TP
+.B NoNews
+Do not print Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
+
+.TP
+.B KeepOldPackages=Num
+Number of old packages' versions to keep in pacman's cache. Defaults to 3.
+
+.TP
+.B KeepUninstalledPackages=Num
+Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
+
+.SH SEE ALSO
+.BR arch-update (1)
+
+.SH BUGS
+Please report bugs to the GitHub page: https://github.com/Antiz96/arch-update/issues
+
+.SH AUTHOR
+Robin Candau <robincandau@protonmail.com>

--- a/doc/man/fr/arch-update.conf.5
+++ b/doc/man/fr/arch-update.conf.5
@@ -41,7 +41,7 @@ Nombre de versions de paquets désinstallés à conserver dans le cache de pacma
 .BR arch-update (1)
 
 .SH BUGS
-Signalez les bugs sur la page GitHub: https://github.com/Antiz96/arch-update/issues
+Signalez les bugs sur la page GitHub : https://github.com/Antiz96/arch-update/issues
 
 .SH AUTEUR
 Robin Candau <robincandau@protonmail.com>


### PR DESCRIPTION
This PR aims to bring a french translation for the `Arch-Update` documentation (namely the README and the man pages).

Both READMEs (english and french) have a link back and forth between each other.
Once a new release is tagged, the french version of the man pages will be the default one for system set up with french language.

The french translation of the script itself will follow.