### PR TITLE
Make Flatpak packages updates detection more robust to avoid false positives

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -165,11 +165,11 @@ check() {
 	icon_checking
 
 	if [ -n "${aur_helper}" ] && [ -n "${flatpak}" ]; then
-		update_available=$(checkupdates ; "${aur_helper}" -Qua ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d')
+		update_available=$(checkupdates ; "${aur_helper}" -Qua ; flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 	elif [ -n "${aur_helper}" ] && [ -z "${flatpak}" ]; then
 		update_available=$(checkupdates ; "${aur_helper}" -Qua)
 	elif [ -z "${aur_helper}" ] && [ -n "${flatpak}" ]; then
-		update_available=$(checkupdates ; flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d')
+		update_available=$(checkupdates ; flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 	else
 		update_available=$(checkupdates)
 	fi
@@ -222,7 +222,7 @@ list_packages() {
 	fi
 
 	if [ -n "${flatpak}" ]; then
-		flatpak_packages=$(flatpak update | awk '{print $2}' | grep -v '^$' | sed '1d;$d')
+		flatpak_packages=$(flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 	fi
 
 	if [ -n "${packages}" ]; then


### PR DESCRIPTION
This commit aims to make the Flatpak updates detection more robust by filtering the 'flatpak update' command output to remove everything placed before the listing of available updates.
This avoid potential false positives in Arch-Update's listing as it ensure that everything placed above the listing of available updates in the 'flatpak update' output will not be included in the list (such as info, warning, etc...).

The complete output is still shown when the Flatpak updates are actually applied during the script, so users are still aware of potential info/warnings.

Fixes https://github.com/Antiz96/arch-update/issues/103