### PR TITLE
Licensing: Precise that Arch-Update is licensed under GPL3+

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -2,7 +2,7 @@
 
 # arch-update: An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.
 # https://github.com/Antiz96/arch-update
-# Licensed under the GPL-3.0 license
+# Licensed under the GPL-3.0 license (or any later version of that license).
 
 # General variables
 name="arch-update"


### PR DESCRIPTION
Arch-Update is licensed under the GPL-3.0 license or any later version of that same license. 
SPDX identifier: GPL-3.0-or-later