### PR TITLE
French translation for the main script

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
         run: actionlint -ignore 'label "CI-CD" is unknown' .github/workflows/CI.yml
 
       - name: Run codespell
-        run: codespell --skip="README-fr.md,./doc/man/fr" --enable-colors
+        run: codespell --skip="README-fr.md,./doc/man/fr,./po" --enable-colors
 
       - name: Run mdl
         run: mdl --style .github/workflows/mdl_style.rb .

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ install:
 
 	# Install documentation
 	install -Dm 644 README.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/README.md"
+	install -Dm 644 README-fr.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/fr/README-fr.md"
 
 uninstall:
 	# Delete the main script

--- a/Makefile
+++ b/Makefile
@@ -7,23 +7,30 @@ PREFIX ?= /usr/local
 all:
 
 install:
+	# Install the main script
 	install -Dm 755 "src/script/${pkgname}.sh" "${DESTDIR}${PREFIX}/bin/${pkgname}"
-	
+
+	# Install icons
 	install -Dm 666 "src/icons/${pkgname}.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}.svg"
 	install -Dm 666 "src/icons/${pkgname}_checking.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}_checking.svg"
 	install -Dm 666 "src/icons/${pkgname}_installing.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}_installing.svg"
 	install -Dm 666 "src/icons/${pkgname}_up-to-date.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}_up-to-date.svg"
 	install -Dm 666 "src/icons/${pkgname}_updates-available.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}_updates-available.svg"
-	
+
+	# Install the .desktop file
 	install -Dm 644 "res/desktop/${pkgname}.desktop" "${DESTDIR}${PREFIX}/share/applications/${pkgname}.desktop"
-	
+
+	# Install systemd units
 	install -Dm 644 "res/systemd/${pkgname}.service" "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.service"
 	install -Dm 644 "res/systemd/${pkgname}.timer" "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
-
+	
+	# Generate and install .mo files for translations
+	# .mo files are installed as "ARCH-UPDATE.mo" to avoid conflicting with the "arch-update.mo" files shipped by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
 	msgfmt po/fr.po -o po/fr.mo
-	install -Dm 644 po/fr.mo "${DESTDIR}${PREFIX}/share/locale/fr/LC_MESSAGES/${pkgname}.mo"
+	install -Dm 644 po/fr.mo "${DESTDIR}${PREFIX}/share/locale/fr/LC_MESSAGES/${pkgname^^}.mo"
 	rm -f po/fr.mo
 
+	# Archive and install man pages
 	gzip -c "doc/man/${pkgname}.1" > "doc/man/${pkgname}.1.gz"
 	gzip -c "doc/man/${pkgname}.conf.5" > "doc/man/${pkgname}.conf.5.gz"
 	gzip -c "doc/man/fr/${pkgname}.1" > "doc/man/fr/${pkgname}.1.gz"
@@ -36,27 +43,36 @@ install:
 	rm -f "doc/man/${pkgname}.conf.5.gz"
 	rm -f "doc/man/fr/${pkgname}.1.gz"
 	rm -f "doc/man/fr/${pkgname}.conf.5.gz"
-	
+
+	# Install documentation
 	install -Dm 644 README.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/README.md"
 
 uninstall:
+	# Delete the main script
 	rm -f "${DESTDIR}${PREFIX}/bin/${pkgname}"
 
+	# Delete icons
 	rm -rf "${DESTDIR}/usr/share/icons/${pkgname}/" 
 
+	# Delete the .desktop file
 	rm -f "${DESTDIR}${PREFIX}/share/applications/${pkgname}.desktop"
 
+	# Delete systemd units
 	rm -f "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.service"
 	rm -f "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
 
-	rm -f "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${pkgname}.mo"
+	# Delete .mo files
+	rm -f "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${pkgname^^}.mo"
 
+	# Delete man pages
 	rm -f "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
 	rm -f "${DESTDIR}${PREFIX}/share/man/man5/${pkgname}.conf.5.gz"
 	rm -f "${DESTDIR}${PREFIX}/share/man/fr/man1/${pkgname}.1.gz"
 	rm -f "${DESTDIR}${PREFIX}/share/man/fr/man5/${pkgname}.conf.5.gz"
-
+	
+	# Delete documentation
 	rm -rf "${DESTDIR}${PREFIX}/share/doc/${pkgname}/"
 
 test:
+	# Run the help function of the main script as a simple test
 	"src/script/${pkgname}.sh" --help

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install:
 	install -Dm 644 "res/systemd/${pkgname}.timer" "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
 
 	msgfmt po/fr.po -o po/fr.mo
-	install -Dm 644 po/fr.mo "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${pkgname}.mo"
+	install -Dm 644 po/fr.mo "${DESTDIR}${PREFIX}/share/locale/fr/LC_MESSAGES/${pkgname}.mo"
 	rm -f po/fr.mo
 
 	gzip -c "doc/man/${pkgname}.1" > "doc/man/${pkgname}.1.gz"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 pkgname=arch-update
+PKGNAME=ARCH-UPDATE
 
 PREFIX ?= /usr/local
 
@@ -27,7 +28,7 @@ install:
 	# Generate and install .mo files for translations
 	# .mo files are installed as "ARCH-UPDATE.mo" to avoid conflicting with the "arch-update.mo" files shipped by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
 	msgfmt po/fr.po -o po/fr.mo
-	install -Dm 644 po/fr.mo "${DESTDIR}${PREFIX}/share/locale/fr/LC_MESSAGES/${pkgname^^}.mo"
+	install -Dm 644 po/fr.mo "${DESTDIR}${PREFIX}/share/locale/fr/LC_MESSAGES/${PKGNAME}.mo"
 	rm -f po/fr.mo
 
 	# Archive and install man pages
@@ -62,7 +63,7 @@ uninstall:
 	rm -f "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
 
 	# Delete .mo files
-	rm -f "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${pkgname^^}.mo"
+	rm -f "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${PKGNAME}.mo"
 
 	# Delete man pages
 	rm -f "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 pkgname=arch-update
-PKGNAME=ARCH-UPDATE
+_pkgname=Arch-Update
 
 PREFIX ?= /usr/local
 
@@ -12,11 +12,11 @@ install:
 	install -Dm 755 "src/script/${pkgname}.sh" "${DESTDIR}${PREFIX}/bin/${pkgname}"
 
 	# Install icons
-	install -Dm 666 "src/icons/${pkgname}.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}.svg"
-	install -Dm 666 "src/icons/${pkgname}_checking.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}_checking.svg"
-	install -Dm 666 "src/icons/${pkgname}_installing.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}_installing.svg"
-	install -Dm 666 "src/icons/${pkgname}_up-to-date.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}_up-to-date.svg"
-	install -Dm 666 "src/icons/${pkgname}_updates-available.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}_updates-available.svg"
+	install -Dm 666 "src/icons/${pkgname}.svg" "${DESTDIR}${PREFIX}/share/icons/${pkgname}/${pkgname}.svg"
+	install -Dm 666 "src/icons/${pkgname}_checking.svg" "${DESTDIR}${PREFIX}/share/icons/${pkgname}/${pkgname}_checking.svg"
+	install -Dm 666 "src/icons/${pkgname}_installing.svg" "${DESTDIR}${PREFIX}/share/icons/${pkgname}/${pkgname}_installing.svg"
+	install -Dm 666 "src/icons/${pkgname}_up-to-date.svg" "${DESTDIR}${PREFIX}/share/icons/${pkgname}/${pkgname}_up-to-date.svg"
+	install -Dm 666 "src/icons/${pkgname}_updates-available.svg" "${DESTDIR}${PREFIX}/share/icons/${pkgname}/${pkgname}_updates-available.svg"
 
 	# Install the .desktop file
 	install -Dm 644 "res/desktop/${pkgname}.desktop" "${DESTDIR}${PREFIX}/share/applications/${pkgname}.desktop"
@@ -26,9 +26,9 @@ install:
 	install -Dm 644 "res/systemd/${pkgname}.timer" "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
 	
 	# Generate and install .mo files for translations
-	# .mo files are installed as "ARCH-UPDATE.mo" to avoid conflicting with the "arch-update.mo" files shipped by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
+	# .mo files are installed as "Arch-Update.mo" to avoid conflicting with the "arch-update.mo" files shipped by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
 	msgfmt po/fr.po -o po/fr.mo
-	install -Dm 644 po/fr.mo "${DESTDIR}${PREFIX}/share/locale/fr/LC_MESSAGES/${PKGNAME}.mo"
+	install -Dm 644 po/fr.mo "${DESTDIR}${PREFIX}/share/locale/fr/LC_MESSAGES/${_pkgname}.mo"
 	rm -f po/fr.mo
 
 	# Archive and install man pages
@@ -53,7 +53,7 @@ uninstall:
 	rm -f "${DESTDIR}${PREFIX}/bin/${pkgname}"
 
 	# Delete icons
-	rm -rf "${DESTDIR}/usr/share/icons/${pkgname}/" 
+	rm -rf "${DESTDIR}${PREFIX}/share/icons/${pkgname}/"
 
 	# Delete the .desktop file
 	rm -f "${DESTDIR}${PREFIX}/share/applications/${pkgname}.desktop"
@@ -63,7 +63,7 @@ uninstall:
 	rm -f "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
 
 	# Delete .mo files
-	rm -f "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${PKGNAME}.mo"
+	rm -f "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${_pkgname}.mo"
 
 	# Delete man pages
 	rm -f "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ install:
 	
 	install -Dm 644 "res/systemd/${pkgname}.service" "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.service"
 	install -Dm 644 "res/systemd/${pkgname}.timer" "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
-	
+
+	msgfmt po/fr.po -o po/fr.mo
+	install -Dm 644 po/fr.mo "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${pkgname}.mo"
+	rm -f po/fr.mo
+
 	gzip -c "doc/man/${pkgname}.1" > "doc/man/${pkgname}.1.gz"
 	gzip -c "doc/man/${pkgname}.conf.5" > "doc/man/${pkgname}.conf.5.gz"
 	gzip -c "doc/man/fr/${pkgname}.1" > "doc/man/fr/${pkgname}.1.gz"
@@ -44,6 +48,8 @@ uninstall:
 
 	rm -f "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.service"
 	rm -f "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.timer"
+
+	rm -f "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${pkgname}.mo"
 
 	rm -f "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
 	rm -f "${DESTDIR}${PREFIX}/share/man/man5/${pkgname}.conf.5.gz"

--- a/README-fr.md
+++ b/README-fr.md
@@ -85,7 +85,7 @@ systemctl --user enable --now arch-update.timer
 
 ### Captures d'écran
 
-*Les captures d'écran montrent le retour du script en anglais, mais `Arch-Update` possède désormais une traduction française!*
+*Les captures d'écran montrent le retour du script en anglais, mais `Arch-Update` possède désormais une **traduction française** !*
 
 Personnellement, j'ai intégré l'icône .desktop dans ma barre supérieure.  
 C'est la première icône en partant de la gauche.

--- a/README-fr.md
+++ b/README-fr.md
@@ -83,7 +83,9 @@ Pour le démarrer automatiquement **au démarrage du système puis une fois tout
 systemctl --user enable --now arch-update.timer
 ```
 
-### Capture d'écran
+### Captures d'écran
+
+*Les captures d'écran montrent le retour du script en anglais, mais `Arch-Update` possède désormais une traduction française!*
 
 Personnellement, j'ai intégré l'icône .desktop dans ma barre supérieure.  
 C'est la première icône en partant de la gauche.
@@ -108,7 +110,7 @@ Lorsque l'on clique sur l'icône, cela lance la série de fonctions adéquates p
 ![listing-packages](https://github.com/Antiz96/arch-update/assets/53110319/43a990c8-ed93-420f-8c46-d50d60bff03f)
 
 Une fois que vous avez donné la confirmation pour procéder, `arch-update` propose d'afficher les dernières Arch news.  
-Les Arch news publiées au cours des 15 derniers jours sont étiquetées comme « [NEW] ».  
+Les Arch news publiées au cours des 15 derniers jours sont étiquetées comme « [NOUVEAU] ».  
 Sélectionnez la news à lire en tapant le numéro associé.  
 Après avoir lu une news, `arch-update` vous proposera à nouveau d'afficher les dernières Arch news, afin que vous puissiez lire plusieurs news à la fois.  
 Appuyez simplement sur « Entrée » sans saisir de chiffre pour procéder à la mise à jour :

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -153,6 +153,11 @@ msgstr ""
 msgid "The update has been aborted\\n"
 msgstr ""
 
+#: src/script/arch-update.sh:286
+#, sh-format
+msgid "Arch News:"
+msgstr ""
+
 #: src/script/arch-update.sh:291
 #, sh-format
 msgid "[NEW]"

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -236,9 +236,9 @@ msgstr ""
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:392 src/script/arch-update.sh:468
-#: src/script/arch-update.sh:478 src/script/arch-update.sh:488
-#: src/script/arch-update.sh:497
+#: src/script/arch-update.sh:392 src/script/arch-update.sh:425
+#: src/script/arch-update.sh:468 src/script/arch-update.sh:478
+#: src/script/arch-update.sh:488 src/script/arch-update.sh:497
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -279,12 +279,6 @@ msgstr ""
 #: src/script/arch-update.sh:421
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
-msgstr ""
-
-#: src/script/arch-update.sh:425
-#, sh-format
-msgid ""
-"An error has occurred the removal process\\nThe removal has been aborted\\n"
 msgstr ""
 
 #: src/script/arch-update.sh:436

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -145,7 +145,14 @@ msgstr ""
 #: src/script/arch-update.sh:421 src/script/arch-update.sh:463
 #: src/script/arch-update.sh:530 src/script/arch-update.sh:560
 #, sh-format
-msgid "[Yy]"
+msgid "Y"
+msgstr ""
+
+#: src/script/arch-update.sh:266 src/script/arch-update.sh:388
+#: src/script/arch-update.sh:421 src/script/arch-update.sh:463
+#: src/script/arch-update.sh:530 src/script/arch-update.sh:560
+#, sh-format
+msgid "y"
 msgstr ""
 
 #: src/script/arch-update.sh:270

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -1,0 +1,402 @@
+# Arch-Update translation template
+# Copyright (C) 2024 Robin Candau <robincandau@protonmail.com>
+# This file is distributed under the same license as the Arch-Update package.
+#
+# Translators:
+# AUTHOR <EMAIL@ADDRESS>, YEAR
+msgid ""
+msgstr ""
+"Project-Id-Version: Arch-Update 1.10.1\n"
+"Report-Msgid-Bugs-To: https://github.com/Antiz96/arch-update/issues\n"
+"POT-Creation-Date: 2024-02-09 01:21+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/script/arch-update.sh:82
+#, sh-format
+msgid "Press \"enter\" to continue "
+msgstr ""
+
+#: src/script/arch-update.sh:88
+#, sh-format
+msgid "Press \"enter\" to quit "
+msgstr ""
+
+#: src/script/arch-update.sh:98
+#, sh-format
+msgid ""
+"A privilege elevation method is required\\nPlease, install sudo or doas\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:120
+#, sh-format
+msgid ""
+"An update notifier/applier for Arch Linux that assists you with important "
+"pre/post update tasks."
+msgstr ""
+
+#: src/script/arch-update.sh:122
+#, sh-format
+msgid "Run arch-update to perform the main 'update' function:"
+msgstr ""
+
+#: src/script/arch-update.sh:123
+#, sh-format
+msgid ""
+"Print the list of packages available for update, then ask for the user's "
+"confirmation to proceed with the installation."
+msgstr ""
+
+#: src/script/arch-update.sh:124
+#, sh-format
+msgid ""
+"Before performing the update, offer to print the latest Arch Linux news."
+msgstr ""
+
+#: src/script/arch-update.sh:125
+#, sh-format
+msgid ""
+"Post update, check for orphan/unused packages, old cached packages, pacnew/"
+"pacsave files and pending kernel update and, if there are, offers to process "
+"them."
+msgstr ""
+
+#: src/script/arch-update.sh:127
+#, sh-format
+msgid "Options:"
+msgstr ""
+
+#: src/script/arch-update.sh:128
+#, sh-format
+msgid ""
+"  -c, --check    Check for available updates, send a desktop notification "
+"containing the number of available updates (if libnotify is installed)"
+msgstr ""
+
+#: src/script/arch-update.sh:129
+#, sh-format
+msgid "  -h, --help     Display this message and exit"
+msgstr ""
+
+#: src/script/arch-update.sh:130
+#, sh-format
+msgid "  -V, --version  Display version information and exit"
+msgstr ""
+
+#: src/script/arch-update.sh:132
+#, sh-format
+msgid "For more information, see the ${name}(1) man page."
+msgstr ""
+
+#: src/script/arch-update.sh:133
+#, sh-format
+msgid ""
+"Certain options can be enabled/disabled or modified via the ${name}.conf "
+"configuration file, see the ${name}.conf(5) man page."
+msgstr ""
+
+#: src/script/arch-update.sh:144
+#, sh-format
+msgid ""
+"${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
+"information."
+msgstr ""
+
+#: src/script/arch-update.sh:196
+#, sh-format
+msgid "${update_number} update available"
+msgstr ""
+
+#: src/script/arch-update.sh:198
+#, sh-format
+msgid "${update_number} updates available"
+msgstr ""
+
+#: src/script/arch-update.sh:234
+#, sh-format
+msgid "Packages:"
+msgstr ""
+
+#: src/script/arch-update.sh:239
+#, sh-format
+msgid "AUR Packages:"
+msgstr ""
+
+#: src/script/arch-update.sh:244
+#, sh-format
+msgid "Flatpak Packages:"
+msgstr ""
+
+#: src/script/arch-update.sh:250
+#, sh-format
+msgid "No update available\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:253
+#, sh-format
+msgid "Proceed with update? [Y/n]"
+msgstr ""
+
+#: src/script/arch-update.sh:256 src/script/arch-update.sh:377
+#: src/script/arch-update.sh:410 src/script/arch-update.sh:452
+#: src/script/arch-update.sh:519 src/script/arch-update.sh:549
+#, sh-format
+msgid "[Yy]"
+msgstr ""
+
+#: src/script/arch-update.sh:260
+#, sh-format
+msgid "The update has been aborted\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:282
+#, sh-format
+msgid "[NEW]"
+msgstr ""
+
+#: src/script/arch-update.sh:291
+#, sh-format
+msgid ""
+"Select the news to read (or just press \"enter\" to proceed with update):"
+msgstr ""
+
+#: src/script/arch-update.sh:302
+#, sh-format
+msgid "Title:"
+msgstr ""
+
+#: src/script/arch-update.sh:303
+#, sh-format
+msgid "Author:"
+msgstr ""
+
+#: src/script/arch-update.sh:304
+#, sh-format
+msgid "Publication date:"
+msgstr ""
+
+#: src/script/arch-update.sh:320
+#, sh-format
+msgid "Updating Packages...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:325 src/script/arch-update.sh:337
+#: src/script/arch-update.sh:348
+#, sh-format
+msgid ""
+"An error has occurred during the update process\\nThe update has been "
+"aborted\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:332
+#, sh-format
+msgid "Updating AUR Packages...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:344
+#, sh-format
+msgid "Updating Flatpak Packages...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:355
+#, sh-format
+msgid "The update has been applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:367
+#, sh-format
+msgid "Orphan Packages:"
+msgstr ""
+
+#: src/script/arch-update.sh:371
+#, sh-format
+msgid ""
+"Would you like to remove this orphan package (and its potential "
+"dependencies) now? [y/N]"
+msgstr ""
+
+#: src/script/arch-update.sh:373
+#, sh-format
+msgid ""
+"Would you like to remove these orphan packages (and their potential "
+"dependencies) now? [y/N]"
+msgstr ""
+
+#: src/script/arch-update.sh:379
+#, sh-format
+msgid "Removing Orphan Packages...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:383 src/script/arch-update.sh:459
+#: src/script/arch-update.sh:469 src/script/arch-update.sh:479
+#: src/script/arch-update.sh:488
+#, sh-format
+msgid ""
+"An error has occurred during the removal process\\nThe removal has been "
+"aborted\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:386 src/script/arch-update.sh:419
+#, sh-format
+msgid "The removal has been applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:391 src/script/arch-update.sh:423
+#: src/script/arch-update.sh:496
+#, sh-format
+msgid "The removal hasn't been applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:395
+#, sh-format
+msgid "No orphan package found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:400
+#, sh-format
+msgid "Flatpak Unused Packages:"
+msgstr ""
+
+#: src/script/arch-update.sh:404
+#, sh-format
+msgid "Would you like to remove this Flatpak unused package now? [y/N]"
+msgstr ""
+
+#: src/script/arch-update.sh:406
+#, sh-format
+msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
+msgstr ""
+
+#: src/script/arch-update.sh:412
+#, sh-format
+msgid "Removing Flatpak Unused Packages..."
+msgstr ""
+
+#: src/script/arch-update.sh:416
+#, sh-format
+msgid ""
+"An error has occurred the removal process\\nThe removal has been aborted\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:427
+#, sh-format
+msgid "No Flatpak unused package found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:444
+#, sh-format
+msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:445
+#, sh-format
+msgid "Would you like to remove it from the cache now? [Y/n]"
+msgstr ""
+
+#: src/script/arch-update.sh:447
+#, sh-format
+msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:448
+#, sh-format
+msgid "Would you like to remove them from the cache now? [Y/n]"
+msgstr ""
+
+#: src/script/arch-update.sh:455 src/script/arch-update.sh:475
+#, sh-format
+msgid "Removing old cached packages..."
+msgstr ""
+
+#: src/script/arch-update.sh:465 src/script/arch-update.sh:484
+#, sh-format
+msgid "Removing uninstalled cached packages..."
+msgstr ""
+
+#: src/script/arch-update.sh:500
+#, sh-format
+msgid "No old or uninstalled cached package found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:509
+#, sh-format
+msgid "Pacnew Files:"
+msgstr ""
+
+#: src/script/arch-update.sh:513
+#, sh-format
+msgid "Would you like to process this file now? [Y/n]"
+msgstr ""
+
+#: src/script/arch-update.sh:515
+#, sh-format
+msgid "Would you like to process these files now? [Y/n]"
+msgstr ""
+
+#: src/script/arch-update.sh:521
+#, sh-format
+msgid "Processing Pacnew Files...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:525
+#, sh-format
+msgid "The pacnew file(s) processing has been applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:528
+#, sh-format
+msgid "The pacnew file(s) processing hasn't been applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:532
+#, sh-format
+msgid "No pacnew file found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:545
+#, sh-format
+msgid ""
+"Reboot required:\\nThere's a pending kernel update on your system requiring "
+"a reboot to be applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:546
+#, sh-format
+msgid "Would you like to reboot now? [y/N]"
+msgstr ""
+
+#: src/script/arch-update.sh:551
+#, sh-format
+msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
+msgstr ""
+
+#: src/script/arch-update.sh:555
+#, sh-format
+msgid ""
+"An error has occurred during the reboot process\\nThe reboot has been "
+"aborted\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:563
+#, sh-format
+msgid ""
+"The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
+"the pending kernel update\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:567
+#, sh-format
+msgid "No pending kernel update found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:580
+#, sh-format
+msgid ""
+"NoNews option detected\\nPlease, keep in mind that users are expected to "
+"check the latest Arch news before updating their system, to be aware of "
+"eventual required manual interventions"
+msgstr ""

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -141,9 +141,9 @@ msgstr ""
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:266 src/script/arch-update.sh:387
-#: src/script/arch-update.sh:420 src/script/arch-update.sh:462
-#: src/script/arch-update.sh:529 src/script/arch-update.sh:559
+#: src/script/arch-update.sh:266 src/script/arch-update.sh:388
+#: src/script/arch-update.sh:421 src/script/arch-update.sh:463
+#: src/script/arch-update.sh:530 src/script/arch-update.sh:560
 #, sh-format
 msgid "[Yy]"
 msgstr ""
@@ -184,215 +184,220 @@ msgstr ""
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:330
+#: src/script/arch-update.sh:315
+#, sh-format
+msgid "URL:"
+msgstr ""
+
+#: src/script/arch-update.sh:331
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:335 src/script/arch-update.sh:347
-#: src/script/arch-update.sh:358
+#: src/script/arch-update.sh:336 src/script/arch-update.sh:348
+#: src/script/arch-update.sh:359
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:342
+#: src/script/arch-update.sh:343
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:354
+#: src/script/arch-update.sh:355
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:365
+#: src/script/arch-update.sh:366
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:377
+#: src/script/arch-update.sh:378
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:381
+#: src/script/arch-update.sh:382
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:383
+#: src/script/arch-update.sh:384
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:389
+#: src/script/arch-update.sh:390
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:393 src/script/arch-update.sh:426
-#: src/script/arch-update.sh:469 src/script/arch-update.sh:479
-#: src/script/arch-update.sh:489 src/script/arch-update.sh:498
+#: src/script/arch-update.sh:394 src/script/arch-update.sh:427
+#: src/script/arch-update.sh:470 src/script/arch-update.sh:480
+#: src/script/arch-update.sh:490 src/script/arch-update.sh:499
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:396 src/script/arch-update.sh:429
+#: src/script/arch-update.sh:397 src/script/arch-update.sh:430
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:401 src/script/arch-update.sh:433
-#: src/script/arch-update.sh:506
+#: src/script/arch-update.sh:402 src/script/arch-update.sh:434
+#: src/script/arch-update.sh:507
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:405
+#: src/script/arch-update.sh:406
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:410
+#: src/script/arch-update.sh:411
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:414
+#: src/script/arch-update.sh:415
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:416
+#: src/script/arch-update.sh:417
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:422
+#: src/script/arch-update.sh:423
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:437
+#: src/script/arch-update.sh:438
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:454
+#: src/script/arch-update.sh:455
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:455
+#: src/script/arch-update.sh:456
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:457
+#: src/script/arch-update.sh:458
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:458
+#: src/script/arch-update.sh:459
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:465 src/script/arch-update.sh:485
+#: src/script/arch-update.sh:466 src/script/arch-update.sh:486
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:475 src/script/arch-update.sh:494
+#: src/script/arch-update.sh:476 src/script/arch-update.sh:495
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:510
+#: src/script/arch-update.sh:511
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:519
+#: src/script/arch-update.sh:520
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:523
+#: src/script/arch-update.sh:524
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:525
+#: src/script/arch-update.sh:526
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:531
+#: src/script/arch-update.sh:532
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:535
+#: src/script/arch-update.sh:536
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:538
+#: src/script/arch-update.sh:539
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:542
+#: src/script/arch-update.sh:543
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:555
+#: src/script/arch-update.sh:556
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:556
+#: src/script/arch-update.sh:557
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:561
+#: src/script/arch-update.sh:562
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:565
+#: src/script/arch-update.sh:566
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:573
+#: src/script/arch-update.sh:574
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:577
+#: src/script/arch-update.sh:578
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:590
+#: src/script/arch-update.sh:591
 #, sh-format
 msgid ""
 "NoNews option detected\\nPlease, keep in mind that users are expected to "

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,48 +16,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:83
+#: src/script/arch-update.sh:87
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/script/arch-update.sh:89
+#: src/script/arch-update.sh:93
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/script/arch-update.sh:99
+#: src/script/arch-update.sh:103
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:121
+#: src/script/arch-update.sh:125
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:123
+#: src/script/arch-update.sh:127
 #, sh-format
-msgid "Run arch-update to perform the main 'update' function:"
+msgid "Run ${name} to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:124
+#: src/script/arch-update.sh:128
 #, sh-format
 msgid ""
 "Print the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:125
+#: src/script/arch-update.sh:129
 #, sh-format
 msgid ""
 "Before performing the update, offer to print the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:126
+#: src/script/arch-update.sh:130
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -65,335 +65,335 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:128
+#: src/script/arch-update.sh:132
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:129
+#: src/script/arch-update.sh:133
 #, sh-format
 msgid ""
 "  -c, --check    Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
 
-#: src/script/arch-update.sh:130
+#: src/script/arch-update.sh:134
 #, sh-format
 msgid "  -h, --help     Display this message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:131
+#: src/script/arch-update.sh:135
 #, sh-format
 msgid "  -V, --version  Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:133
+#: src/script/arch-update.sh:137
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:134
+#: src/script/arch-update.sh:138
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:145
+#: src/script/arch-update.sh:149
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:197
+#: src/script/arch-update.sh:205
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:199
+#: src/script/arch-update.sh:207
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:235
+#: src/script/arch-update.sh:243
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:240
+#: src/script/arch-update.sh:248
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:245
+#: src/script/arch-update.sh:253
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:251
+#: src/script/arch-update.sh:259
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:254
+#: src/script/arch-update.sh:262
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:257 src/script/arch-update.sh:378
-#: src/script/arch-update.sh:411 src/script/arch-update.sh:453
-#: src/script/arch-update.sh:520 src/script/arch-update.sh:550
+#: src/script/arch-update.sh:265 src/script/arch-update.sh:386
+#: src/script/arch-update.sh:419 src/script/arch-update.sh:461
+#: src/script/arch-update.sh:528 src/script/arch-update.sh:558
 #, sh-format
 msgid "[Yy]"
 msgstr ""
 
-#: src/script/arch-update.sh:261
+#: src/script/arch-update.sh:269
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:283
+#: src/script/arch-update.sh:291
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:292
+#: src/script/arch-update.sh:300
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:303
+#: src/script/arch-update.sh:311
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:304
+#: src/script/arch-update.sh:312
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:305
+#: src/script/arch-update.sh:313
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:321
+#: src/script/arch-update.sh:329
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:326 src/script/arch-update.sh:338
-#: src/script/arch-update.sh:349
+#: src/script/arch-update.sh:334 src/script/arch-update.sh:346
+#: src/script/arch-update.sh:357
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:333
+#: src/script/arch-update.sh:341
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:345
+#: src/script/arch-update.sh:353
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:356
+#: src/script/arch-update.sh:364
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:368
+#: src/script/arch-update.sh:376
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:372
+#: src/script/arch-update.sh:380
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:382
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:380
+#: src/script/arch-update.sh:388
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:384 src/script/arch-update.sh:460
-#: src/script/arch-update.sh:470 src/script/arch-update.sh:480
-#: src/script/arch-update.sh:489
+#: src/script/arch-update.sh:392 src/script/arch-update.sh:468
+#: src/script/arch-update.sh:478 src/script/arch-update.sh:488
+#: src/script/arch-update.sh:497
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:387 src/script/arch-update.sh:420
+#: src/script/arch-update.sh:395 src/script/arch-update.sh:428
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:392 src/script/arch-update.sh:424
-#: src/script/arch-update.sh:497
+#: src/script/arch-update.sh:400 src/script/arch-update.sh:432
+#: src/script/arch-update.sh:505
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:396
+#: src/script/arch-update.sh:404
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:401
+#: src/script/arch-update.sh:409
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:405
+#: src/script/arch-update.sh:413
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:407
+#: src/script/arch-update.sh:415
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:413
+#: src/script/arch-update.sh:421
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:417
+#: src/script/arch-update.sh:425
 #, sh-format
 msgid ""
 "An error has occurred the removal process\\nThe removal has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:428
+#: src/script/arch-update.sh:436
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:445
+#: src/script/arch-update.sh:453
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:446
+#: src/script/arch-update.sh:454
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:448
+#: src/script/arch-update.sh:456
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:449
+#: src/script/arch-update.sh:457
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:456 src/script/arch-update.sh:476
+#: src/script/arch-update.sh:464 src/script/arch-update.sh:484
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:466 src/script/arch-update.sh:485
+#: src/script/arch-update.sh:474 src/script/arch-update.sh:493
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:501
+#: src/script/arch-update.sh:509
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:510
+#: src/script/arch-update.sh:518
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:514
+#: src/script/arch-update.sh:522
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:516
+#: src/script/arch-update.sh:524
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:522
+#: src/script/arch-update.sh:530
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:526
+#: src/script/arch-update.sh:534
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:529
+#: src/script/arch-update.sh:537
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:533
+#: src/script/arch-update.sh:541
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:546
+#: src/script/arch-update.sh:554
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:547
+#: src/script/arch-update.sh:555
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:552
+#: src/script/arch-update.sh:560
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:556
+#: src/script/arch-update.sh:564
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:564
+#: src/script/arch-update.sh:572
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:568
+#: src/script/arch-update.sh:576
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:581
+#: src/script/arch-update.sh:589
 #, sh-format
 msgid ""
 "NoNews option detected\\nPlease, keep in mind that users are expected to "

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,48 +16,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:87
+#: src/script/arch-update.sh:88
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/script/arch-update.sh:93
+#: src/script/arch-update.sh:94
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/script/arch-update.sh:103
+#: src/script/arch-update.sh:104
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:125
+#: src/script/arch-update.sh:126
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:127
+#: src/script/arch-update.sh:128
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:128
+#: src/script/arch-update.sh:129
 #, sh-format
 msgid ""
 "Print the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:129
+#: src/script/arch-update.sh:130
 #, sh-format
 msgid ""
 "Before performing the update, offer to print the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:130
+#: src/script/arch-update.sh:131
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -65,334 +65,334 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:132
+#: src/script/arch-update.sh:133
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:133
+#: src/script/arch-update.sh:134
 #, sh-format
 msgid ""
 "  -c, --check    Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
 
-#: src/script/arch-update.sh:134
+#: src/script/arch-update.sh:135
 #, sh-format
 msgid "  -h, --help     Display this message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:135
+#: src/script/arch-update.sh:136
 #, sh-format
 msgid "  -V, --version  Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:137
+#: src/script/arch-update.sh:138
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:138
+#: src/script/arch-update.sh:139
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:149
+#: src/script/arch-update.sh:150
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:205
+#: src/script/arch-update.sh:206
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:207
+#: src/script/arch-update.sh:208
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:243
+#: src/script/arch-update.sh:244
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:248
+#: src/script/arch-update.sh:249
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:253
+#: src/script/arch-update.sh:254
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:259
+#: src/script/arch-update.sh:260
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:262
+#: src/script/arch-update.sh:263
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:265 src/script/arch-update.sh:386
-#: src/script/arch-update.sh:419 src/script/arch-update.sh:461
-#: src/script/arch-update.sh:528 src/script/arch-update.sh:558
+#: src/script/arch-update.sh:266 src/script/arch-update.sh:387
+#: src/script/arch-update.sh:420 src/script/arch-update.sh:462
+#: src/script/arch-update.sh:529 src/script/arch-update.sh:559
 #, sh-format
 msgid "[Yy]"
 msgstr ""
 
-#: src/script/arch-update.sh:269
+#: src/script/arch-update.sh:270
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:286
+#: src/script/arch-update.sh:287
 #, sh-format
 msgid "Arch News:"
 msgstr ""
 
-#: src/script/arch-update.sh:291
+#: src/script/arch-update.sh:292
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:300
+#: src/script/arch-update.sh:301
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:311
+#: src/script/arch-update.sh:312
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:312
+#: src/script/arch-update.sh:313
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:313
+#: src/script/arch-update.sh:314
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:329
+#: src/script/arch-update.sh:330
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:334 src/script/arch-update.sh:346
-#: src/script/arch-update.sh:357
+#: src/script/arch-update.sh:335 src/script/arch-update.sh:347
+#: src/script/arch-update.sh:358
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:341
+#: src/script/arch-update.sh:342
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:353
+#: src/script/arch-update.sh:354
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:364
+#: src/script/arch-update.sh:365
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:376
+#: src/script/arch-update.sh:377
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:380
+#: src/script/arch-update.sh:381
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:382
+#: src/script/arch-update.sh:383
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:388
+#: src/script/arch-update.sh:389
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:392 src/script/arch-update.sh:425
-#: src/script/arch-update.sh:468 src/script/arch-update.sh:478
-#: src/script/arch-update.sh:488 src/script/arch-update.sh:497
+#: src/script/arch-update.sh:393 src/script/arch-update.sh:426
+#: src/script/arch-update.sh:469 src/script/arch-update.sh:479
+#: src/script/arch-update.sh:489 src/script/arch-update.sh:498
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:395 src/script/arch-update.sh:428
+#: src/script/arch-update.sh:396 src/script/arch-update.sh:429
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:400 src/script/arch-update.sh:432
-#: src/script/arch-update.sh:505
+#: src/script/arch-update.sh:401 src/script/arch-update.sh:433
+#: src/script/arch-update.sh:506
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:404
+#: src/script/arch-update.sh:405
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:409
+#: src/script/arch-update.sh:410
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:413
+#: src/script/arch-update.sh:414
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:415
+#: src/script/arch-update.sh:416
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:421
+#: src/script/arch-update.sh:422
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:436
+#: src/script/arch-update.sh:437
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:453
+#: src/script/arch-update.sh:454
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:454
+#: src/script/arch-update.sh:455
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:456
+#: src/script/arch-update.sh:457
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:457
+#: src/script/arch-update.sh:458
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:464 src/script/arch-update.sh:484
+#: src/script/arch-update.sh:465 src/script/arch-update.sh:485
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:474 src/script/arch-update.sh:493
+#: src/script/arch-update.sh:475 src/script/arch-update.sh:494
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:509
+#: src/script/arch-update.sh:510
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:518
+#: src/script/arch-update.sh:519
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:522
+#: src/script/arch-update.sh:523
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:524
+#: src/script/arch-update.sh:525
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:530
+#: src/script/arch-update.sh:531
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:534
+#: src/script/arch-update.sh:535
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:537
+#: src/script/arch-update.sh:538
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:541
+#: src/script/arch-update.sh:542
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:554
+#: src/script/arch-update.sh:555
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:555
+#: src/script/arch-update.sh:556
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:560
+#: src/script/arch-update.sh:561
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:564
+#: src/script/arch-update.sh:565
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:572
+#: src/script/arch-update.sh:573
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:576
+#: src/script/arch-update.sh:577
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:589
+#: src/script/arch-update.sh:590
 #, sh-format
 msgid ""
 "NoNews option detected\\nPlease, keep in mind that users are expected to "

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,48 +16,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:82
+#: src/script/arch-update.sh:83
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/script/arch-update.sh:88
+#: src/script/arch-update.sh:89
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/script/arch-update.sh:98
+#: src/script/arch-update.sh:99
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:120
+#: src/script/arch-update.sh:121
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:122
+#: src/script/arch-update.sh:123
 #, sh-format
 msgid "Run arch-update to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:123
+#: src/script/arch-update.sh:124
 #, sh-format
 msgid ""
 "Print the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:124
+#: src/script/arch-update.sh:125
 #, sh-format
 msgid ""
 "Before performing the update, offer to print the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:125
+#: src/script/arch-update.sh:126
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -65,335 +65,335 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:127
+#: src/script/arch-update.sh:128
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:128
+#: src/script/arch-update.sh:129
 #, sh-format
 msgid ""
 "  -c, --check    Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
 
-#: src/script/arch-update.sh:129
+#: src/script/arch-update.sh:130
 #, sh-format
 msgid "  -h, --help     Display this message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:130
+#: src/script/arch-update.sh:131
 #, sh-format
 msgid "  -V, --version  Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:132
+#: src/script/arch-update.sh:133
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:133
+#: src/script/arch-update.sh:134
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:144
+#: src/script/arch-update.sh:145
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:196
+#: src/script/arch-update.sh:197
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:198
+#: src/script/arch-update.sh:199
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:234
+#: src/script/arch-update.sh:235
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:239
+#: src/script/arch-update.sh:240
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:244
+#: src/script/arch-update.sh:245
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:250
+#: src/script/arch-update.sh:251
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:253
+#: src/script/arch-update.sh:254
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:256 src/script/arch-update.sh:377
-#: src/script/arch-update.sh:410 src/script/arch-update.sh:452
-#: src/script/arch-update.sh:519 src/script/arch-update.sh:549
+#: src/script/arch-update.sh:257 src/script/arch-update.sh:378
+#: src/script/arch-update.sh:411 src/script/arch-update.sh:453
+#: src/script/arch-update.sh:520 src/script/arch-update.sh:550
 #, sh-format
 msgid "[Yy]"
 msgstr ""
 
-#: src/script/arch-update.sh:260
+#: src/script/arch-update.sh:261
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:282
+#: src/script/arch-update.sh:283
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:291
+#: src/script/arch-update.sh:292
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:302
+#: src/script/arch-update.sh:303
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:303
+#: src/script/arch-update.sh:304
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:304
+#: src/script/arch-update.sh:305
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:320
+#: src/script/arch-update.sh:321
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:325 src/script/arch-update.sh:337
-#: src/script/arch-update.sh:348
+#: src/script/arch-update.sh:326 src/script/arch-update.sh:338
+#: src/script/arch-update.sh:349
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:332
+#: src/script/arch-update.sh:333
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:344
+#: src/script/arch-update.sh:345
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:355
+#: src/script/arch-update.sh:356
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:367
+#: src/script/arch-update.sh:368
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:371
+#: src/script/arch-update.sh:372
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:373
+#: src/script/arch-update.sh:374
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:379
+#: src/script/arch-update.sh:380
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:383 src/script/arch-update.sh:459
-#: src/script/arch-update.sh:469 src/script/arch-update.sh:479
-#: src/script/arch-update.sh:488
+#: src/script/arch-update.sh:384 src/script/arch-update.sh:460
+#: src/script/arch-update.sh:470 src/script/arch-update.sh:480
+#: src/script/arch-update.sh:489
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:386 src/script/arch-update.sh:419
+#: src/script/arch-update.sh:387 src/script/arch-update.sh:420
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:391 src/script/arch-update.sh:423
-#: src/script/arch-update.sh:496
+#: src/script/arch-update.sh:392 src/script/arch-update.sh:424
+#: src/script/arch-update.sh:497
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:395
+#: src/script/arch-update.sh:396
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:400
+#: src/script/arch-update.sh:401
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:404
+#: src/script/arch-update.sh:405
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:406
+#: src/script/arch-update.sh:407
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:412
+#: src/script/arch-update.sh:413
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:416
+#: src/script/arch-update.sh:417
 #, sh-format
 msgid ""
 "An error has occurred the removal process\\nThe removal has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:427
+#: src/script/arch-update.sh:428
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:444
+#: src/script/arch-update.sh:445
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:445
+#: src/script/arch-update.sh:446
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:447
+#: src/script/arch-update.sh:448
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:448
+#: src/script/arch-update.sh:449
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:455 src/script/arch-update.sh:475
+#: src/script/arch-update.sh:456 src/script/arch-update.sh:476
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:465 src/script/arch-update.sh:484
+#: src/script/arch-update.sh:466 src/script/arch-update.sh:485
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:500
+#: src/script/arch-update.sh:501
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:509
+#: src/script/arch-update.sh:510
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:513
+#: src/script/arch-update.sh:514
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:515
+#: src/script/arch-update.sh:516
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:521
+#: src/script/arch-update.sh:522
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:525
+#: src/script/arch-update.sh:526
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:528
+#: src/script/arch-update.sh:529
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:532
+#: src/script/arch-update.sh:533
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:545
+#: src/script/arch-update.sh:546
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:546
+#: src/script/arch-update.sh:547
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:551
+#: src/script/arch-update.sh:552
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:555
+#: src/script/arch-update.sh:556
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:563
+#: src/script/arch-update.sh:564
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:567
+#: src/script/arch-update.sh:568
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:580
+#: src/script/arch-update.sh:581
 #, sh-format
 msgid ""
 "NoNews option detected\\nPlease, keep in mind that users are expected to "

--- a/po/fr.po
+++ b/po/fr.po
@@ -161,7 +161,7 @@ msgstr "Procéder à la mise à jour ? [O/n]"
 #: src/script/arch-update.sh:530 src/script/arch-update.sh:560
 #, sh-format
 msgid "[Yy]"
-msgstr "[Yy]|[Oo]"
+msgstr "[Oo]"
 
 #: src/script/arch-update.sh:270
 #, sh-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -85,7 +85,7 @@ msgid ""
 "  -c, --check    Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
-"  -c, --check    Vérifier les mises à jour disponibles, envoyer une notification de bureau "
+" -c, --check    Vérifier les mises à jour disponibles, envoyer une notification de bureau "
 "contenant le nombre de mises à jour disponibles (si libnotify est installé)"
 
 #: src/script/arch-update.sh:135

--- a/po/fr.po
+++ b/po/fr.po
@@ -156,9 +156,9 @@ msgstr "Aucune mise à jour disponible\\n"
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:266 src/script/arch-update.sh:387
-#: src/script/arch-update.sh:420 src/script/arch-update.sh:462
-#: src/script/arch-update.sh:529 src/script/arch-update.sh:559
+#: src/script/arch-update.sh:266 src/script/arch-update.sh:388
+#: src/script/arch-update.sh:421 src/script/arch-update.sh:463
+#: src/script/arch-update.sh:530 src/script/arch-update.sh:560
 #, sh-format
 msgid "[Yy]"
 msgstr "[Yy]|[Oo]"
@@ -200,13 +200,18 @@ msgstr "Auteur :"
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:330
+#: src/script/arch-update.sh:315
+#, sh-format
+msgid "URL:"
+msgstr "URL :"
+
+#: src/script/arch-update.sh:331
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:335 src/script/arch-update.sh:347
-#: src/script/arch-update.sh:358
+#: src/script/arch-update.sh:336 src/script/arch-update.sh:348
+#: src/script/arch-update.sh:359
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -215,27 +220,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:342
+#: src/script/arch-update.sh:343
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:354
+#: src/script/arch-update.sh:355
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:365
+#: src/script/arch-update.sh:366
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:377
+#: src/script/arch-update.sh:378
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:381
+#: src/script/arch-update.sh:382
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -244,7 +249,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:383
+#: src/script/arch-update.sh:384
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -253,14 +258,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:389
+#: src/script/arch-update.sh:390
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:393 src/script/arch-update.sh:426
-#: src/script/arch-update.sh:469 src/script/arch-update.sh:479
-#: src/script/arch-update.sh:489 src/script/arch-update.sh:498
+#: src/script/arch-update.sh:394 src/script/arch-update.sh:427
+#: src/script/arch-update.sh:470 src/script/arch-update.sh:480
+#: src/script/arch-update.sh:490 src/script/arch-update.sh:499
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -269,118 +274,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:396 src/script/arch-update.sh:429
+#: src/script/arch-update.sh:397 src/script/arch-update.sh:430
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:401 src/script/arch-update.sh:433
-#: src/script/arch-update.sh:506
+#: src/script/arch-update.sh:402 src/script/arch-update.sh:434
+#: src/script/arch-update.sh:507
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:405
+#: src/script/arch-update.sh:406
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:410
+#: src/script/arch-update.sh:411
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:414
+#: src/script/arch-update.sh:415
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:416
+#: src/script/arch-update.sh:417
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:422
+#: src/script/arch-update.sh:423
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:437
+#: src/script/arch-update.sh:438
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:454
+#: src/script/arch-update.sh:455
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:455
+#: src/script/arch-update.sh:456
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:457
+#: src/script/arch-update.sh:458
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:458
+#: src/script/arch-update.sh:459
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:465 src/script/arch-update.sh:485
+#: src/script/arch-update.sh:466 src/script/arch-update.sh:486
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:475 src/script/arch-update.sh:494
+#: src/script/arch-update.sh:476 src/script/arch-update.sh:495
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:510
+#: src/script/arch-update.sh:511
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:519
+#: src/script/arch-update.sh:520
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:523
+#: src/script/arch-update.sh:524
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:525
+#: src/script/arch-update.sh:526
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:531
+#: src/script/arch-update.sh:532
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:535
+#: src/script/arch-update.sh:536
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:538
+#: src/script/arch-update.sh:539
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:542
+#: src/script/arch-update.sh:543
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:555
+#: src/script/arch-update.sh:556
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -389,17 +394,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:556
+#: src/script/arch-update.sh:557
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:561
+#: src/script/arch-update.sh:562
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr "Redémarrage dans 5 secondes...\\nAppuyez sur ctrl+c pour annuler"
 
-#: src/script/arch-update.sh:565
+#: src/script/arch-update.sh:566
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -408,7 +413,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:573
+#: src/script/arch-update.sh:574
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -417,12 +422,12 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:577
+#: src/script/arch-update.sh:578
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"
 
-#: src/script/arch-update.sh:590
+#: src/script/arch-update.sh:591
 #, sh-format
 msgid ""
 "NoNews option detected\\nPlease, keep in mind that users are expected to "

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,0 +1,402 @@
+# Arch-Update French translation
+# Copyright (C) 2024 Robin Candau <robincandau@protonmail.com>
+# This file is distributed under the same license as the Arch-Update package.
+#
+# Translators:
+# AUTHOR <EMAIL@ADDRESS>, YEAR
+msgid ""
+msgstr ""
+"Project-Id-Version: Arch-Update 1.10.1\n"
+"Report-Msgid-Bugs-To: https://github.com/Antiz96/arch-update/issues\n"
+"POT-Creation-Date: 2024-02-09 01:21+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/script/arch-update.sh:82
+#, sh-format
+msgid "Press \"enter\" to continue "
+msgstr ""
+
+#: src/script/arch-update.sh:88
+#, sh-format
+msgid "Press \"enter\" to quit "
+msgstr ""
+
+#: src/script/arch-update.sh:98
+#, sh-format
+msgid ""
+"A privilege elevation method is required\\nPlease, install sudo or doas\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:120
+#, sh-format
+msgid ""
+"An update notifier/applier for Arch Linux that assists you with important "
+"pre/post update tasks."
+msgstr ""
+
+#: src/script/arch-update.sh:122
+#, sh-format
+msgid "Run arch-update to perform the main 'update' function:"
+msgstr ""
+
+#: src/script/arch-update.sh:123
+#, sh-format
+msgid ""
+"Print the list of packages available for update, then ask for the user's "
+"confirmation to proceed with the installation."
+msgstr ""
+
+#: src/script/arch-update.sh:124
+#, sh-format
+msgid ""
+"Before performing the update, offer to print the latest Arch Linux news."
+msgstr ""
+
+#: src/script/arch-update.sh:125
+#, sh-format
+msgid ""
+"Post update, check for orphan/unused packages, old cached packages, pacnew/"
+"pacsave files and pending kernel update and, if there are, offers to process "
+"them."
+msgstr ""
+
+#: src/script/arch-update.sh:127
+#, sh-format
+msgid "Options:"
+msgstr ""
+
+#: src/script/arch-update.sh:128
+#, sh-format
+msgid ""
+"  -c, --check    Check for available updates, send a desktop notification "
+"containing the number of available updates (if libnotify is installed)"
+msgstr ""
+
+#: src/script/arch-update.sh:129
+#, sh-format
+msgid "  -h, --help     Display this message and exit"
+msgstr ""
+
+#: src/script/arch-update.sh:130
+#, sh-format
+msgid "  -V, --version  Display version information and exit"
+msgstr ""
+
+#: src/script/arch-update.sh:132
+#, sh-format
+msgid "For more information, see the ${name}(1) man page."
+msgstr ""
+
+#: src/script/arch-update.sh:133
+#, sh-format
+msgid ""
+"Certain options can be enabled/disabled or modified via the ${name}.conf "
+"configuration file, see the ${name}.conf(5) man page."
+msgstr ""
+
+#: src/script/arch-update.sh:144
+#, sh-format
+msgid ""
+"${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
+"information."
+msgstr ""
+
+#: src/script/arch-update.sh:196
+#, sh-format
+msgid "${update_number} update available"
+msgstr ""
+
+#: src/script/arch-update.sh:198
+#, sh-format
+msgid "${update_number} updates available"
+msgstr ""
+
+#: src/script/arch-update.sh:234
+#, sh-format
+msgid "Packages:"
+msgstr ""
+
+#: src/script/arch-update.sh:239
+#, sh-format
+msgid "AUR Packages:"
+msgstr ""
+
+#: src/script/arch-update.sh:244
+#, sh-format
+msgid "Flatpak Packages:"
+msgstr ""
+
+#: src/script/arch-update.sh:250
+#, sh-format
+msgid "No update available\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:253
+#, sh-format
+msgid "Proceed with update? [Y/n]"
+msgstr ""
+
+#: src/script/arch-update.sh:256 src/script/arch-update.sh:377
+#: src/script/arch-update.sh:410 src/script/arch-update.sh:452
+#: src/script/arch-update.sh:519 src/script/arch-update.sh:549
+#, sh-format
+msgid "[Yy]"
+msgstr ""
+
+#: src/script/arch-update.sh:260
+#, sh-format
+msgid "The update has been aborted\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:282
+#, sh-format
+msgid "[NEW]"
+msgstr ""
+
+#: src/script/arch-update.sh:291
+#, sh-format
+msgid ""
+"Select the news to read (or just press \"enter\" to proceed with update):"
+msgstr ""
+
+#: src/script/arch-update.sh:302
+#, sh-format
+msgid "Title:"
+msgstr ""
+
+#: src/script/arch-update.sh:303
+#, sh-format
+msgid "Author:"
+msgstr ""
+
+#: src/script/arch-update.sh:304
+#, sh-format
+msgid "Publication date:"
+msgstr ""
+
+#: src/script/arch-update.sh:320
+#, sh-format
+msgid "Updating Packages...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:325 src/script/arch-update.sh:337
+#: src/script/arch-update.sh:348
+#, sh-format
+msgid ""
+"An error has occurred during the update process\\nThe update has been "
+"aborted\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:332
+#, sh-format
+msgid "Updating AUR Packages...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:344
+#, sh-format
+msgid "Updating Flatpak Packages...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:355
+#, sh-format
+msgid "The update has been applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:367
+#, sh-format
+msgid "Orphan Packages:"
+msgstr ""
+
+#: src/script/arch-update.sh:371
+#, sh-format
+msgid ""
+"Would you like to remove this orphan package (and its potential "
+"dependencies) now? [y/N]"
+msgstr ""
+
+#: src/script/arch-update.sh:373
+#, sh-format
+msgid ""
+"Would you like to remove these orphan packages (and their potential "
+"dependencies) now? [y/N]"
+msgstr ""
+
+#: src/script/arch-update.sh:379
+#, sh-format
+msgid "Removing Orphan Packages...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:383 src/script/arch-update.sh:459
+#: src/script/arch-update.sh:469 src/script/arch-update.sh:479
+#: src/script/arch-update.sh:488
+#, sh-format
+msgid ""
+"An error has occurred during the removal process\\nThe removal has been "
+"aborted\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:386 src/script/arch-update.sh:419
+#, sh-format
+msgid "The removal has been applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:391 src/script/arch-update.sh:423
+#: src/script/arch-update.sh:496
+#, sh-format
+msgid "The removal hasn't been applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:395
+#, sh-format
+msgid "No orphan package found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:400
+#, sh-format
+msgid "Flatpak Unused Packages:"
+msgstr ""
+
+#: src/script/arch-update.sh:404
+#, sh-format
+msgid "Would you like to remove this Flatpak unused package now? [y/N]"
+msgstr ""
+
+#: src/script/arch-update.sh:406
+#, sh-format
+msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
+msgstr ""
+
+#: src/script/arch-update.sh:412
+#, sh-format
+msgid "Removing Flatpak Unused Packages..."
+msgstr ""
+
+#: src/script/arch-update.sh:416
+#, sh-format
+msgid ""
+"An error has occurred the removal process\\nThe removal has been aborted\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:427
+#, sh-format
+msgid "No Flatpak unused package found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:444
+#, sh-format
+msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:445
+#, sh-format
+msgid "Would you like to remove it from the cache now? [Y/n]"
+msgstr ""
+
+#: src/script/arch-update.sh:447
+#, sh-format
+msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:448
+#, sh-format
+msgid "Would you like to remove them from the cache now? [Y/n]"
+msgstr ""
+
+#: src/script/arch-update.sh:455 src/script/arch-update.sh:475
+#, sh-format
+msgid "Removing old cached packages..."
+msgstr ""
+
+#: src/script/arch-update.sh:465 src/script/arch-update.sh:484
+#, sh-format
+msgid "Removing uninstalled cached packages..."
+msgstr ""
+
+#: src/script/arch-update.sh:500
+#, sh-format
+msgid "No old or uninstalled cached package found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:509
+#, sh-format
+msgid "Pacnew Files:"
+msgstr ""
+
+#: src/script/arch-update.sh:513
+#, sh-format
+msgid "Would you like to process this file now? [Y/n]"
+msgstr ""
+
+#: src/script/arch-update.sh:515
+#, sh-format
+msgid "Would you like to process these files now? [Y/n]"
+msgstr ""
+
+#: src/script/arch-update.sh:521
+#, sh-format
+msgid "Processing Pacnew Files...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:525
+#, sh-format
+msgid "The pacnew file(s) processing has been applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:528
+#, sh-format
+msgid "The pacnew file(s) processing hasn't been applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:532
+#, sh-format
+msgid "No pacnew file found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:545
+#, sh-format
+msgid ""
+"Reboot required:\\nThere's a pending kernel update on your system requiring "
+"a reboot to be applied\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:546
+#, sh-format
+msgid "Would you like to reboot now? [y/N]"
+msgstr ""
+
+#: src/script/arch-update.sh:551
+#, sh-format
+msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
+msgstr ""
+
+#: src/script/arch-update.sh:555
+#, sh-format
+msgid ""
+"An error has occurred during the reboot process\\nThe reboot has been "
+"aborted\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:563
+#, sh-format
+msgid ""
+"The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
+"the pending kernel update\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:567
+#, sh-format
+msgid "No pending kernel update found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:580
+#, sh-format
+msgid ""
+"NoNews option detected\\nPlease, keep in mind that users are expected to "
+"check the latest Arch news before updating their system, to be aware of "
+"eventual required manual interventions"
+msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -160,8 +160,15 @@ msgstr "Procéder à la mise à jour ? [O/n]"
 #: src/script/arch-update.sh:421 src/script/arch-update.sh:463
 #: src/script/arch-update.sh:530 src/script/arch-update.sh:560
 #, sh-format
-msgid "[Yy]"
-msgstr "[Oo]"
+msgid "Y"
+msgstr "O"
+
+#: src/script/arch-update.sh:266 src/script/arch-update.sh:388
+#: src/script/arch-update.sh:421 src/script/arch-update.sh:463
+#: src/script/arch-update.sh:530 src/script/arch-update.sh:560
+#, sh-format
+msgid "y"
+msgstr "o"
 
 #: src/script/arch-update.sh:270
 #, sh-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -3,15 +3,15 @@
 # This file is distributed under the same license as the Arch-Update package.
 #
 # Translators:
-# AUTHOR <EMAIL@ADDRESS>, YEAR
+# Robin Candau <robincandau@protonmail.com>, 2024
 msgid ""
 msgstr ""
 "Project-Id-Version: Arch-Update 1.10.1\n"
 "Report-Msgid-Bugs-To: https://github.com/Antiz96/arch-update/issues\n"
 "POT-Creation-Date: 2024-02-09 01:21+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: \n"
+"PO-Revision-Date: 2024-02-09 09:07+0100\n"
+"Last-Translator: Robin Candau <robincandau@protonmail.com>\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -19,12 +19,12 @@ msgstr ""
 #: src/script/arch-update.sh:82
 #, sh-format
 msgid "Press \"enter\" to continue "
-msgstr ""
+msgstr "Appuyez sur \"entrée\" pour continuer"
 
 #: src/script/arch-update.sh:88
 #, sh-format
 msgid "Press \"enter\" to quit "
-msgstr ""
+msgstr "Appuyez sur \"entrée\" pour quitter"
 
 #: src/script/arch-update.sh:98
 #, sh-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -31,6 +31,7 @@ msgstr "Appuyez sur \"entrée\" pour quitter "
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
+"Une méthode d'élévation de privilège est requise\\nVeulliez installer sudo ou doas\\n"
 
 #: src/script/arch-update.sh:125
 #, sh-format
@@ -38,11 +39,13 @@ msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
+"Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les "
+"tâches importantes d'avant/après mise à jour."
 
 #: src/script/arch-update.sh:127
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
-msgstr ""
+msgstr "Lancez ${name} pour exécuter la fonction principale 'update' :"
 
 #: src/script/arch-update.sh:128
 #, sh-format
@@ -50,12 +53,15 @@ msgid ""
 "Print the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
+"Afficher la liste des paquets disponibles pour mise à jour, puis demander la confirmation de l'utilisateur "
+"pour procéder à l'installation."
 
 #: src/script/arch-update.sh:129
 #, sh-format
 msgid ""
 "Before performing the update, offer to print the latest Arch Linux news."
 msgstr ""
+"Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news."
 
 #: src/script/arch-update.sh:130
 #, sh-format
@@ -64,11 +70,14 @@ msgid ""
 "pacsave files and pending kernel update and, if there are, offers to process "
 "them."
 msgstr ""
+"Après la mise à jour, vérification de la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache, "
+"de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, "
+"propose de les traiter."
 
 #: src/script/arch-update.sh:132
 #, sh-format
 msgid "Options:"
-msgstr ""
+msgstr "Options :"
 
 #: src/script/arch-update.sh:133
 #, sh-format
@@ -76,21 +85,23 @@ msgid ""
 "  -c, --check    Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
+"  -c, --check    Vérifier les mises à jour disponibles, envoyer une notification de bureau "
+"contenant le nombre de mises à jour disponibles (si libnotify est installé)"
 
 #: src/script/arch-update.sh:134
 #, sh-format
 msgid "  -h, --help     Display this message and exit"
-msgstr ""
+msgstr " -h, --help     Afficher ce message et quitter"
 
 #: src/script/arch-update.sh:135
 #, sh-format
 msgid "  -V, --version  Display version information and exit"
-msgstr ""
+msgstr " -V, --version  Afficher les informations de version et quitter"
 
 #: src/script/arch-update.sh:137
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
-msgstr ""
+msgstr "Pour plus d'informations, consultez la page de manuel ${name}(1)."
 
 #: src/script/arch-update.sh:138
 #, sh-format
@@ -98,6 +109,8 @@ msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
+"Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration ${name}.conf, "
+"voir la page de manuel ${name}.conf(5)."
 
 #: src/script/arch-update.sh:149
 #, sh-format
@@ -105,84 +118,92 @@ msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
+"${name}: option invalide -- '${option}'\\nEssayez '${name} --help' pour plus "
+"d'informations."
 
 #: src/script/arch-update.sh:205
 #, sh-format
 msgid "${update_number} update available"
-msgstr ""
+msgstr "${update_number} mise à jour disponible"
 
 #: src/script/arch-update.sh:207
 #, sh-format
 msgid "${update_number} updates available"
-msgstr ""
+msgstr "${update_number} mises à jour disponibles"
 
 #: src/script/arch-update.sh:243
 #, sh-format
 msgid "Packages:"
-msgstr ""
+msgstr "Paquets :"
 
 #: src/script/arch-update.sh:248
 #, sh-format
 msgid "AUR Packages:"
-msgstr ""
+msgstr "Paquets AUR :"
 
 #: src/script/arch-update.sh:253
 #, sh-format
 msgid "Flatpak Packages:"
-msgstr ""
+msgstr "Paquets Flatpak :"
 
 #: src/script/arch-update.sh:259
 #, sh-format
 msgid "No update available\\n"
-msgstr ""
+msgstr "Aucune mise à jour disponible\\n"
 
 #: src/script/arch-update.sh:262
 #, sh-format
 msgid "Proceed with update? [Y/n]"
-msgstr ""
+msgstr "Procéder à la mise à jour ? [O/n]"
 
 #: src/script/arch-update.sh:265 src/script/arch-update.sh:386
 #: src/script/arch-update.sh:419 src/script/arch-update.sh:461
 #: src/script/arch-update.sh:528 src/script/arch-update.sh:558
 #, sh-format
 msgid "[Yy]"
-msgstr ""
+msgstr "[Yy]|[Oo]"
 
 #: src/script/arch-update.sh:269
 #, sh-format
 msgid "The update has been aborted\\n"
-msgstr ""
+msgstr "La mise à jour a été abandonnée\\n"
+
+#: src/script/arch-update.sh:286
+#, sh-format
+msgid "Arch News:"
+msgstr "Arch News :"
 
 #: src/script/arch-update.sh:291
 #, sh-format
 msgid "[NEW]"
-msgstr ""
+msgstr "[NOUVEAU]"
 
 #: src/script/arch-update.sh:300
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
+"Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour procéder à la mise à jour) :"
 
 #: src/script/arch-update.sh:311
 #, sh-format
 msgid "Title:"
-msgstr ""
+msgstr "Titre :"
 
 #: src/script/arch-update.sh:312
 #, sh-format
 msgid "Author:"
-msgstr ""
+msgstr "Auteur :"
 
 #: src/script/arch-update.sh:313
 #, sh-format
 msgid "Publication date:"
-msgstr ""
+msgstr "Date de publication :"
 
 #: src/script/arch-update.sh:329
 #, sh-format
 msgid "Updating Packages...\\n"
-msgstr ""
+msgstr "Mise à jour des paquets...\\n"
 
 #: src/script/arch-update.sh:334 src/script/arch-update.sh:346
 #: src/script/arch-update.sh:357
@@ -191,26 +212,28 @@ msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
+"Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
+"abandonnée\\n"
 
 #: src/script/arch-update.sh:341
 #, sh-format
 msgid "Updating AUR Packages...\\n"
-msgstr ""
+msgstr "Mise à jour des paquets AUR...\\n"
 
 #: src/script/arch-update.sh:353
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
-msgstr ""
+msgstr "Mise à jour des paquets Flatpak...\\n"
 
 #: src/script/arch-update.sh:364
 #, sh-format
 msgid "The update has been applied\\n"
-msgstr ""
+msgstr "La mise à jour a été appliquée\\n"
 
 #: src/script/arch-update.sh:376
 #, sh-format
 msgid "Orphan Packages:"
-msgstr ""
+msgstr "Paquets orphelins :"
 
 #: src/script/arch-update.sh:380
 #, sh-format
@@ -218,6 +241,8 @@ msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
+"Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
+"dépendances) maintenant ? [o/N]"
 
 #: src/script/arch-update.sh:382
 #, sh-format
@@ -225,137 +250,135 @@ msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
+"Voulez-vous supprimer ces paquets orphelins (et ses potentielles "
+"dépendances) maintenant ? [o/N]"
 
 #: src/script/arch-update.sh:388
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
-msgstr ""
+msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:392 src/script/arch-update.sh:468
-#: src/script/arch-update.sh:478 src/script/arch-update.sh:488
-#: src/script/arch-update.sh:497
+#: src/script/arch-update.sh:392 src/script/arch-update.sh:425
+#: src/script/arch-update.sh:468 src/script/arch-update.sh:478
+#: src/script/arch-update.sh:488 src/script/arch-update.sh:497
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
+"Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
+"abandonnée\\n"
 
 #: src/script/arch-update.sh:395 src/script/arch-update.sh:428
 #, sh-format
 msgid "The removal has been applied\\n"
-msgstr ""
+msgstr "La suppression a été appliquée\\n"
 
 #: src/script/arch-update.sh:400 src/script/arch-update.sh:432
 #: src/script/arch-update.sh:505
 #, sh-format
 msgid "The removal hasn't been applied\\n"
-msgstr ""
+msgstr "La suppression n'a pas été appliquée\\n"
 
 #: src/script/arch-update.sh:404
 #, sh-format
 msgid "No orphan package found\\n"
-msgstr ""
+msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
 #: src/script/arch-update.sh:409
 #, sh-format
 msgid "Flatpak Unused Packages:"
-msgstr ""
+msgstr "Paquets Flatpak inutilisés :"
 
 #: src/script/arch-update.sh:413
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
-msgstr ""
+msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
 #: src/script/arch-update.sh:415
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
-msgstr ""
+msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
 #: src/script/arch-update.sh:421
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
-msgstr ""
-
-#: src/script/arch-update.sh:425
-#, sh-format
-msgid ""
-"An error has occurred the removal process\\nThe removal has been aborted\\n"
-msgstr ""
+msgstr "Suppression des paquets Flatpak inutilisés..."
 
 #: src/script/arch-update.sh:436
 #, sh-format
 msgid "No Flatpak unused package found\\n"
-msgstr ""
+msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé"
 
 #: src/script/arch-update.sh:453
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
-msgstr ""
+msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
 #: src/script/arch-update.sh:454
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
-msgstr ""
+msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
 #: src/script/arch-update.sh:456
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
-msgstr ""
+msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
 #: src/script/arch-update.sh:457
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
-msgstr ""
+msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
 #: src/script/arch-update.sh:464 src/script/arch-update.sh:484
 #, sh-format
 msgid "Removing old cached packages..."
-msgstr ""
+msgstr "Suppression des anciens paquets mis en cache..."
 
 #: src/script/arch-update.sh:474 src/script/arch-update.sh:493
 #, sh-format
 msgid "Removing uninstalled cached packages..."
-msgstr ""
+msgstr "Suppression des paquets désinstallés mis en cache..."
 
 #: src/script/arch-update.sh:509
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
-msgstr ""
+msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
 #: src/script/arch-update.sh:518
 #, sh-format
 msgid "Pacnew Files:"
-msgstr ""
+msgstr "Fichiers Pacnew :"
 
 #: src/script/arch-update.sh:522
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
-msgstr ""
+msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
 #: src/script/arch-update.sh:524
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
-msgstr ""
+msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
 #: src/script/arch-update.sh:530
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
-msgstr ""
+msgstr "Traitement des fichiers pacnew...\\n"
 
 #: src/script/arch-update.sh:534
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
-msgstr ""
+msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
 #: src/script/arch-update.sh:537
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
-msgstr ""
+msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
 #: src/script/arch-update.sh:541
 #, sh-format
 msgid "No pacnew file found\\n"
-msgstr ""
+msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
 #: src/script/arch-update.sh:554
 #, sh-format
@@ -363,16 +386,18 @@ msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
+"Redémarrage requis:\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
+"un redémarrage pour être appliquée\\n"
 
 #: src/script/arch-update.sh:555
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
-msgstr ""
+msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
 #: src/script/arch-update.sh:560
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
-msgstr ""
+msgstr "Redémarrage dans 5 secondes...\\nAppuyez sur ctrl+c pour annuler"
 
 #: src/script/arch-update.sh:564
 #, sh-format
@@ -380,6 +405,8 @@ msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
+"Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
+"abandonné\\n"
 
 #: src/script/arch-update.sh:572
 #, sh-format
@@ -387,11 +414,13 @@ msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
+"Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
+"la mise à jour du noyau en attente\\n"
 
 #: src/script/arch-update.sh:576
 #, sh-format
 msgid "No pending kernel update found\\n"
-msgstr ""
+msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"
 
 #: src/script/arch-update.sh:589
 #, sh-format
@@ -400,3 +429,6 @@ msgid ""
 "check the latest Arch news before updating their system, to be aware of "
 "eventual required manual interventions"
 msgstr ""
+"Option NoNews détectée\\nVeuillez garder à l'esprit que les utilisateurs sont sensés "
+"vérifier les dernières Arch news avant de mettre à jour leur système, afin d'être au courant des "
+"éventuelles interventions manuelles nécessaires"

--- a/po/fr.po
+++ b/po/fr.po
@@ -31,7 +31,7 @@ msgstr "Appuyez sur \"entrée\" pour quitter "
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
-"Une méthode d'élévation de privilège est requise\\nVeulliez installer sudo ou doas\\n"
+"Une méthode d'élévation de privilège est requise\\nVeuillez installer sudo ou doas\\n"
 
 #: src/script/arch-update.sh:126
 #, sh-format
@@ -61,7 +61,7 @@ msgstr ""
 msgid ""
 "Before performing the update, offer to print the latest Arch Linux news."
 msgstr ""
-"Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news."
+"Avant d'effectuer la mise à jour, propose d'afficher les dernières news d'Arch Linux."
 
 #: src/script/arch-update.sh:131
 #, sh-format
@@ -70,8 +70,8 @@ msgid ""
 "pacsave files and pending kernel update and, if there are, offers to process "
 "them."
 msgstr ""
-"Après la mise à jour, vérification de la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache, "
-"de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, "
+"Après la mise à jour, vérification de la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache, de fichiers pacnew/"
+"pacsave et de mise à jour du noyau en attente et, s'il y en a, "
 "propose de les traiter."
 
 #: src/script/arch-update.sh:133
@@ -250,7 +250,7 @@ msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
-"Voulez-vous supprimer ces paquets orphelins (et ses potentielles "
+"Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
 #: src/script/arch-update.sh:389
@@ -308,7 +308,7 @@ msgstr "Suppression des paquets Flatpak inutilisés..."
 #: src/script/arch-update.sh:437
 #, sh-format
 msgid "No Flatpak unused package found\\n"
-msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé"
+msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
 #: src/script/arch-update.sh:454
 #, sh-format
@@ -386,7 +386,7 @@ msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
-"Redémarrage requis:\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
+"Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
 #: src/script/arch-update.sh:556

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,48 +16,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:83
+#: src/script/arch-update.sh:87
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/script/arch-update.sh:89
+#: src/script/arch-update.sh:93
 #, sh-format
 msgid "Press \"enter\" to quit "
-msgstr "Apuyez sur \"entrée\" pour quitter "
+msgstr "Appuyez sur \"entrée\" pour quitter "
 
-#: src/script/arch-update.sh:99
+#: src/script/arch-update.sh:103
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:121
+#: src/script/arch-update.sh:125
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:123
+#: src/script/arch-update.sh:127
 #, sh-format
-msgid "Run arch-update to perform the main 'update' function:"
+msgid "Run ${name} to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:124
+#: src/script/arch-update.sh:128
 #, sh-format
 msgid ""
 "Print the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:125
+#: src/script/arch-update.sh:129
 #, sh-format
 msgid ""
 "Before performing the update, offer to print the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:126
+#: src/script/arch-update.sh:130
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -65,335 +65,335 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:128
+#: src/script/arch-update.sh:132
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:129
+#: src/script/arch-update.sh:133
 #, sh-format
 msgid ""
 "  -c, --check    Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
 
-#: src/script/arch-update.sh:130
+#: src/script/arch-update.sh:134
 #, sh-format
 msgid "  -h, --help     Display this message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:131
+#: src/script/arch-update.sh:135
 #, sh-format
 msgid "  -V, --version  Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:133
+#: src/script/arch-update.sh:137
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:134
+#: src/script/arch-update.sh:138
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:145
+#: src/script/arch-update.sh:149
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:197
+#: src/script/arch-update.sh:205
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:199
+#: src/script/arch-update.sh:207
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:235
+#: src/script/arch-update.sh:243
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:240
+#: src/script/arch-update.sh:248
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:245
+#: src/script/arch-update.sh:253
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:251
+#: src/script/arch-update.sh:259
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:254
+#: src/script/arch-update.sh:262
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:257 src/script/arch-update.sh:378
-#: src/script/arch-update.sh:411 src/script/arch-update.sh:453
-#: src/script/arch-update.sh:520 src/script/arch-update.sh:550
+#: src/script/arch-update.sh:265 src/script/arch-update.sh:386
+#: src/script/arch-update.sh:419 src/script/arch-update.sh:461
+#: src/script/arch-update.sh:528 src/script/arch-update.sh:558
 #, sh-format
 msgid "[Yy]"
 msgstr ""
 
-#: src/script/arch-update.sh:261
+#: src/script/arch-update.sh:269
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:283
+#: src/script/arch-update.sh:291
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:292
+#: src/script/arch-update.sh:300
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:303
+#: src/script/arch-update.sh:311
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:304
+#: src/script/arch-update.sh:312
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:305
+#: src/script/arch-update.sh:313
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:321
+#: src/script/arch-update.sh:329
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:326 src/script/arch-update.sh:338
-#: src/script/arch-update.sh:349
+#: src/script/arch-update.sh:334 src/script/arch-update.sh:346
+#: src/script/arch-update.sh:357
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:333
+#: src/script/arch-update.sh:341
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:345
+#: src/script/arch-update.sh:353
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:356
+#: src/script/arch-update.sh:364
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:368
+#: src/script/arch-update.sh:376
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:372
+#: src/script/arch-update.sh:380
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:382
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:380
+#: src/script/arch-update.sh:388
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:384 src/script/arch-update.sh:460
-#: src/script/arch-update.sh:470 src/script/arch-update.sh:480
-#: src/script/arch-update.sh:489
+#: src/script/arch-update.sh:392 src/script/arch-update.sh:468
+#: src/script/arch-update.sh:478 src/script/arch-update.sh:488
+#: src/script/arch-update.sh:497
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:387 src/script/arch-update.sh:420
+#: src/script/arch-update.sh:395 src/script/arch-update.sh:428
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:392 src/script/arch-update.sh:424
-#: src/script/arch-update.sh:497
+#: src/script/arch-update.sh:400 src/script/arch-update.sh:432
+#: src/script/arch-update.sh:505
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:396
+#: src/script/arch-update.sh:404
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:401
+#: src/script/arch-update.sh:409
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:405
+#: src/script/arch-update.sh:413
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:407
+#: src/script/arch-update.sh:415
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:413
+#: src/script/arch-update.sh:421
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:417
+#: src/script/arch-update.sh:425
 #, sh-format
 msgid ""
 "An error has occurred the removal process\\nThe removal has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:428
+#: src/script/arch-update.sh:436
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:445
+#: src/script/arch-update.sh:453
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:446
+#: src/script/arch-update.sh:454
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:448
+#: src/script/arch-update.sh:456
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:449
+#: src/script/arch-update.sh:457
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:456 src/script/arch-update.sh:476
+#: src/script/arch-update.sh:464 src/script/arch-update.sh:484
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:466 src/script/arch-update.sh:485
+#: src/script/arch-update.sh:474 src/script/arch-update.sh:493
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:501
+#: src/script/arch-update.sh:509
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:510
+#: src/script/arch-update.sh:518
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:514
+#: src/script/arch-update.sh:522
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:516
+#: src/script/arch-update.sh:524
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:522
+#: src/script/arch-update.sh:530
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:526
+#: src/script/arch-update.sh:534
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:529
+#: src/script/arch-update.sh:537
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:533
+#: src/script/arch-update.sh:541
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:546
+#: src/script/arch-update.sh:554
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:547
+#: src/script/arch-update.sh:555
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:552
+#: src/script/arch-update.sh:560
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:556
+#: src/script/arch-update.sh:564
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:564
+#: src/script/arch-update.sh:572
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:568
+#: src/script/arch-update.sh:576
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:581
+#: src/script/arch-update.sh:589
 #, sh-format
 msgid ""
 "NoNews option detected\\nPlease, keep in mind that users are expected to "

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,48 +16,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:82
+#: src/script/arch-update.sh:83
 #, sh-format
 msgid "Press \"enter\" to continue "
-msgstr "Appuyez sur \"entrée\" pour continuer"
+msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/script/arch-update.sh:88
+#: src/script/arch-update.sh:89
 #, sh-format
 msgid "Press \"enter\" to quit "
-msgstr "Appuyez sur \"entrée\" pour quitter"
+msgstr "Apuyez sur \"entrée\" pour quitter "
 
-#: src/script/arch-update.sh:98
+#: src/script/arch-update.sh:99
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:120
+#: src/script/arch-update.sh:121
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:122
+#: src/script/arch-update.sh:123
 #, sh-format
 msgid "Run arch-update to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:123
+#: src/script/arch-update.sh:124
 #, sh-format
 msgid ""
 "Print the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:124
+#: src/script/arch-update.sh:125
 #, sh-format
 msgid ""
 "Before performing the update, offer to print the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:125
+#: src/script/arch-update.sh:126
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -65,335 +65,335 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:127
+#: src/script/arch-update.sh:128
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:128
+#: src/script/arch-update.sh:129
 #, sh-format
 msgid ""
 "  -c, --check    Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
 
-#: src/script/arch-update.sh:129
+#: src/script/arch-update.sh:130
 #, sh-format
 msgid "  -h, --help     Display this message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:130
+#: src/script/arch-update.sh:131
 #, sh-format
 msgid "  -V, --version  Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:132
+#: src/script/arch-update.sh:133
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:133
+#: src/script/arch-update.sh:134
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:144
+#: src/script/arch-update.sh:145
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:196
+#: src/script/arch-update.sh:197
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:198
+#: src/script/arch-update.sh:199
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:234
+#: src/script/arch-update.sh:235
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:239
+#: src/script/arch-update.sh:240
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:244
+#: src/script/arch-update.sh:245
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:250
+#: src/script/arch-update.sh:251
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:253
+#: src/script/arch-update.sh:254
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:256 src/script/arch-update.sh:377
-#: src/script/arch-update.sh:410 src/script/arch-update.sh:452
-#: src/script/arch-update.sh:519 src/script/arch-update.sh:549
+#: src/script/arch-update.sh:257 src/script/arch-update.sh:378
+#: src/script/arch-update.sh:411 src/script/arch-update.sh:453
+#: src/script/arch-update.sh:520 src/script/arch-update.sh:550
 #, sh-format
 msgid "[Yy]"
 msgstr ""
 
-#: src/script/arch-update.sh:260
+#: src/script/arch-update.sh:261
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:282
+#: src/script/arch-update.sh:283
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:291
+#: src/script/arch-update.sh:292
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:302
+#: src/script/arch-update.sh:303
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:303
+#: src/script/arch-update.sh:304
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:304
+#: src/script/arch-update.sh:305
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:320
+#: src/script/arch-update.sh:321
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:325 src/script/arch-update.sh:337
-#: src/script/arch-update.sh:348
+#: src/script/arch-update.sh:326 src/script/arch-update.sh:338
+#: src/script/arch-update.sh:349
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:332
+#: src/script/arch-update.sh:333
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:344
+#: src/script/arch-update.sh:345
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:355
+#: src/script/arch-update.sh:356
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:367
+#: src/script/arch-update.sh:368
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:371
+#: src/script/arch-update.sh:372
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:373
+#: src/script/arch-update.sh:374
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:379
+#: src/script/arch-update.sh:380
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:383 src/script/arch-update.sh:459
-#: src/script/arch-update.sh:469 src/script/arch-update.sh:479
-#: src/script/arch-update.sh:488
+#: src/script/arch-update.sh:384 src/script/arch-update.sh:460
+#: src/script/arch-update.sh:470 src/script/arch-update.sh:480
+#: src/script/arch-update.sh:489
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:386 src/script/arch-update.sh:419
+#: src/script/arch-update.sh:387 src/script/arch-update.sh:420
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:391 src/script/arch-update.sh:423
-#: src/script/arch-update.sh:496
+#: src/script/arch-update.sh:392 src/script/arch-update.sh:424
+#: src/script/arch-update.sh:497
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:395
+#: src/script/arch-update.sh:396
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:400
+#: src/script/arch-update.sh:401
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:404
+#: src/script/arch-update.sh:405
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:406
+#: src/script/arch-update.sh:407
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:412
+#: src/script/arch-update.sh:413
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:416
+#: src/script/arch-update.sh:417
 #, sh-format
 msgid ""
 "An error has occurred the removal process\\nThe removal has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:427
+#: src/script/arch-update.sh:428
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:444
+#: src/script/arch-update.sh:445
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:445
+#: src/script/arch-update.sh:446
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:447
+#: src/script/arch-update.sh:448
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:448
+#: src/script/arch-update.sh:449
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:455 src/script/arch-update.sh:475
+#: src/script/arch-update.sh:456 src/script/arch-update.sh:476
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:465 src/script/arch-update.sh:484
+#: src/script/arch-update.sh:466 src/script/arch-update.sh:485
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:500
+#: src/script/arch-update.sh:501
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:509
+#: src/script/arch-update.sh:510
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:513
+#: src/script/arch-update.sh:514
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:515
+#: src/script/arch-update.sh:516
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:521
+#: src/script/arch-update.sh:522
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:525
+#: src/script/arch-update.sh:526
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:528
+#: src/script/arch-update.sh:529
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:532
+#: src/script/arch-update.sh:533
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:545
+#: src/script/arch-update.sh:546
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:546
+#: src/script/arch-update.sh:547
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:551
+#: src/script/arch-update.sh:552
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:555
+#: src/script/arch-update.sh:556
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:563
+#: src/script/arch-update.sh:564
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:567
+#: src/script/arch-update.sh:568
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:580
+#: src/script/arch-update.sh:581
 #, sh-format
 msgid ""
 "NoNews option detected\\nPlease, keep in mind that users are expected to "

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,24 +16,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:87
+#: src/script/arch-update.sh:88
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/script/arch-update.sh:93
+#: src/script/arch-update.sh:94
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Appuyez sur \"entrée\" pour quitter "
 
-#: src/script/arch-update.sh:103
+#: src/script/arch-update.sh:104
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 "Une méthode d'élévation de privilège est requise\\nVeulliez installer sudo ou doas\\n"
 
-#: src/script/arch-update.sh:125
+#: src/script/arch-update.sh:126
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
@@ -42,12 +42,12 @@ msgstr ""
 "Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les "
 "tâches importantes d'avant/après mise à jour."
 
-#: src/script/arch-update.sh:127
+#: src/script/arch-update.sh:128
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr "Lancez ${name} pour exécuter la fonction principale 'update' :"
 
-#: src/script/arch-update.sh:128
+#: src/script/arch-update.sh:129
 #, sh-format
 msgid ""
 "Print the list of packages available for update, then ask for the user's "
@@ -56,14 +56,14 @@ msgstr ""
 "Afficher la liste des paquets disponibles pour mise à jour, puis demander la confirmation de l'utilisateur "
 "pour procéder à l'installation."
 
-#: src/script/arch-update.sh:129
+#: src/script/arch-update.sh:130
 #, sh-format
 msgid ""
 "Before performing the update, offer to print the latest Arch Linux news."
 msgstr ""
 "Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news."
 
-#: src/script/arch-update.sh:130
+#: src/script/arch-update.sh:131
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -74,12 +74,12 @@ msgstr ""
 "de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, "
 "propose de les traiter."
 
-#: src/script/arch-update.sh:132
+#: src/script/arch-update.sh:133
 #, sh-format
 msgid "Options:"
 msgstr "Options :"
 
-#: src/script/arch-update.sh:133
+#: src/script/arch-update.sh:134
 #, sh-format
 msgid ""
 "  -c, --check    Check for available updates, send a desktop notification "
@@ -88,22 +88,22 @@ msgstr ""
 "  -c, --check    Vérifier les mises à jour disponibles, envoyer une notification de bureau "
 "contenant le nombre de mises à jour disponibles (si libnotify est installé)"
 
-#: src/script/arch-update.sh:134
+#: src/script/arch-update.sh:135
 #, sh-format
 msgid "  -h, --help     Display this message and exit"
 msgstr " -h, --help     Afficher ce message et quitter"
 
-#: src/script/arch-update.sh:135
+#: src/script/arch-update.sh:136
 #, sh-format
 msgid "  -V, --version  Display version information and exit"
 msgstr " -V, --version  Afficher les informations de version et quitter"
 
-#: src/script/arch-update.sh:137
+#: src/script/arch-update.sh:138
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr "Pour plus d'informations, consultez la page de manuel ${name}(1)."
 
-#: src/script/arch-update.sh:138
+#: src/script/arch-update.sh:139
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
@@ -112,7 +112,7 @@ msgstr ""
 "Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration ${name}.conf, "
 "voir la page de manuel ${name}.conf(5)."
 
-#: src/script/arch-update.sh:149
+#: src/script/arch-update.sh:150
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
@@ -121,92 +121,92 @@ msgstr ""
 "${name}: option invalide -- '${option}'\\nEssayez '${name} --help' pour plus "
 "d'informations."
 
-#: src/script/arch-update.sh:205
+#: src/script/arch-update.sh:206
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} mise à jour disponible"
 
-#: src/script/arch-update.sh:207
+#: src/script/arch-update.sh:208
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/script/arch-update.sh:243
+#: src/script/arch-update.sh:244
 #, sh-format
 msgid "Packages:"
 msgstr "Paquets :"
 
-#: src/script/arch-update.sh:248
+#: src/script/arch-update.sh:249
 #, sh-format
 msgid "AUR Packages:"
 msgstr "Paquets AUR :"
 
-#: src/script/arch-update.sh:253
+#: src/script/arch-update.sh:254
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/script/arch-update.sh:259
+#: src/script/arch-update.sh:260
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
 
-#: src/script/arch-update.sh:262
+#: src/script/arch-update.sh:263
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:265 src/script/arch-update.sh:386
-#: src/script/arch-update.sh:419 src/script/arch-update.sh:461
-#: src/script/arch-update.sh:528 src/script/arch-update.sh:558
+#: src/script/arch-update.sh:266 src/script/arch-update.sh:387
+#: src/script/arch-update.sh:420 src/script/arch-update.sh:462
+#: src/script/arch-update.sh:529 src/script/arch-update.sh:559
 #, sh-format
 msgid "[Yy]"
 msgstr "[Yy]|[Oo]"
 
-#: src/script/arch-update.sh:269
+#: src/script/arch-update.sh:270
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
 
-#: src/script/arch-update.sh:286
+#: src/script/arch-update.sh:287
 #, sh-format
 msgid "Arch News:"
 msgstr "Arch News :"
 
-#: src/script/arch-update.sh:291
+#: src/script/arch-update.sh:292
 #, sh-format
 msgid "[NEW]"
 msgstr "[NOUVEAU]"
 
-#: src/script/arch-update.sh:300
+#: src/script/arch-update.sh:301
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour procéder à la mise à jour) :"
 
-#: src/script/arch-update.sh:311
+#: src/script/arch-update.sh:312
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/script/arch-update.sh:312
+#: src/script/arch-update.sh:313
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/script/arch-update.sh:313
+#: src/script/arch-update.sh:314
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:329
+#: src/script/arch-update.sh:330
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:334 src/script/arch-update.sh:346
-#: src/script/arch-update.sh:357
+#: src/script/arch-update.sh:335 src/script/arch-update.sh:347
+#: src/script/arch-update.sh:358
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -215,27 +215,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:341
+#: src/script/arch-update.sh:342
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:353
+#: src/script/arch-update.sh:354
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:364
+#: src/script/arch-update.sh:365
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:376
+#: src/script/arch-update.sh:377
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:380
+#: src/script/arch-update.sh:381
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -244,7 +244,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:382
+#: src/script/arch-update.sh:383
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -253,14 +253,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:388
+#: src/script/arch-update.sh:389
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:392 src/script/arch-update.sh:425
-#: src/script/arch-update.sh:468 src/script/arch-update.sh:478
-#: src/script/arch-update.sh:488 src/script/arch-update.sh:497
+#: src/script/arch-update.sh:393 src/script/arch-update.sh:426
+#: src/script/arch-update.sh:469 src/script/arch-update.sh:479
+#: src/script/arch-update.sh:489 src/script/arch-update.sh:498
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -269,118 +269,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:395 src/script/arch-update.sh:428
+#: src/script/arch-update.sh:396 src/script/arch-update.sh:429
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:400 src/script/arch-update.sh:432
-#: src/script/arch-update.sh:505
+#: src/script/arch-update.sh:401 src/script/arch-update.sh:433
+#: src/script/arch-update.sh:506
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:404
+#: src/script/arch-update.sh:405
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:409
+#: src/script/arch-update.sh:410
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:413
+#: src/script/arch-update.sh:414
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:415
+#: src/script/arch-update.sh:416
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:421
+#: src/script/arch-update.sh:422
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:436
+#: src/script/arch-update.sh:437
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé"
 
-#: src/script/arch-update.sh:453
+#: src/script/arch-update.sh:454
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:454
+#: src/script/arch-update.sh:455
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:456
+#: src/script/arch-update.sh:457
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:457
+#: src/script/arch-update.sh:458
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:464 src/script/arch-update.sh:484
+#: src/script/arch-update.sh:465 src/script/arch-update.sh:485
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:474 src/script/arch-update.sh:493
+#: src/script/arch-update.sh:475 src/script/arch-update.sh:494
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:509
+#: src/script/arch-update.sh:510
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:518
+#: src/script/arch-update.sh:519
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:522
+#: src/script/arch-update.sh:523
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:524
+#: src/script/arch-update.sh:525
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:530
+#: src/script/arch-update.sh:531
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:534
+#: src/script/arch-update.sh:535
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:537
+#: src/script/arch-update.sh:538
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:541
+#: src/script/arch-update.sh:542
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:554
+#: src/script/arch-update.sh:555
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -389,17 +389,17 @@ msgstr ""
 "Redémarrage requis:\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:555
+#: src/script/arch-update.sh:556
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:560
+#: src/script/arch-update.sh:561
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr "Redémarrage dans 5 secondes...\\nAppuyez sur ctrl+c pour annuler"
 
-#: src/script/arch-update.sh:564
+#: src/script/arch-update.sh:565
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -408,7 +408,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:572
+#: src/script/arch-update.sh:573
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -417,12 +417,12 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:576
+#: src/script/arch-update.sh:577
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"
 
-#: src/script/arch-update.sh:589
+#: src/script/arch-update.sh:590
 #, sh-format
 msgid ""
 "NoNews option detected\\nPlease, keep in mind that users are expected to "

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -283,7 +283,7 @@ list_news() {
 		mapfile -t news_dates < <(echo "${news}" | htmlq td | grep -v "class" | grep "[0-9]" | sed "s/<[^>]*>//g" | head -5 | xargs -I{} date -d "{}" "+%s")
 
 		echo
-		main_msg "Arch News:"
+		main_msg "$(eval_gettext "Arch News:")"
 
 		i=1
 		while IFS= read -r line; do

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -9,7 +9,8 @@ name="arch-update"
 version="1.10.1"
 option="${1}"
 
-# Export TEXTDOMAIN env var for translations
+# Declare necessary paramaters for translations
+. gettext.sh
 export TEXTDOMAIN="${name}"
 
 # Checking options in arch-update.conf

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -422,7 +422,7 @@ orphan_packages() {
 
 					if ! flatpak remove --unused; then
 						echo
-						error_msg "$(eval_gettext "An error has occurred the removal process\nThe removal has been aborted\n")"
+						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
 						echo
 						info_msg "$(eval_gettext "The removal has been applied\n")"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -263,7 +263,7 @@ list_packages() {
 		ask_msg "$(eval_gettext "Proceed with update? [Y/n]")"
 
 		case "${answer}" in
-			"$(eval_gettext "[Yy]")"|"")
+			"$(eval_gettext "Y")"|"$(eval_gettext "y")"|"")
 				proceed_with_update="y"
 			;;
 			*)
@@ -385,7 +385,7 @@ orphan_packages() {
 		fi
 
 		case "${answer}" in
-			"$(eval_gettext "[Yy]")")
+			"$(eval_gettext "Y")"|"$(eval_gettext "y")")
 				echo
 				main_msg "$(eval_gettext "Removing Orphan Packages...\n")"
 				
@@ -418,7 +418,7 @@ orphan_packages() {
 			fi
 
 			case "${answer}" in
-				"$(eval_gettext "[Yy]")")
+				"$(eval_gettext "Y")"|"$(eval_gettext "y")")
 					echo
 					main_msg "$(eval_gettext "Removing Flatpak Unused Packages...")"
 
@@ -460,7 +460,7 @@ packages_cache() {
 		fi
 			
 		case "${answer}" in
-			"$(eval_gettext "[Yy]")"|"")
+			"$(eval_gettext "Y")"|"$(eval_gettext "y")"|"")
 				if [ "${pacman_cache_old}" -gt 0 ] && [ "${pacman_cache_uninstalled}" -eq 0 ]; then
 					echo
 					main_msg "$(eval_gettext "Removing old cached packages...")"
@@ -527,7 +527,7 @@ pacnew_files() {
 		fi
 
 		case "${answer}" in
-			"$(eval_gettext "[Yy]")"|"")
+			"$(eval_gettext "Y")"|"$(eval_gettext "y")"|"")
 				echo
 				main_msg "$(eval_gettext "Processing Pacnew Files...\n")"
 
@@ -557,7 +557,7 @@ kernel_reboot() {
 		ask_msg "$(eval_gettext "Would you like to reboot now? [y/N]")"
 
 		case "${answer}" in
-			"$(eval_gettext "[Yy]")")
+			"$(eval_gettext "Y")"|"$(eval_gettext "y")")
 				echo
 				main_msg "$(eval_gettext "Rebooting in 5 seconds...\nPress ctrl+c to abort")"
 				sleep 5

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -11,7 +11,8 @@ version="1.10.1"
 option="${1}"
 
 # Declare necessary parameters for translations
-. gettext.sh # shellcheck disable=SC1091
+# shellcheck disable=SC1091
+. gettext.sh
 export TEXTDOMAIN="${_name}" # Using "Arch-Update" as TEXTDOMAIN to avoid conflicting with the "arch-update" TEXTDOMAIN used by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
 if find /usr/local/share/locale/*/LC_MESSAGES/"${_name}".mo &> /dev/null; then
 	export TEXTDOMAINDIR="/usr/local/share/locale"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -10,7 +10,7 @@ _name="Arch-Update"
 version="1.10.1"
 option="${1}"
 
-# Declare necessary paramaters for translations
+# Declare necessary parameters for translations
 . gettext.sh
 export TEXTDOMAIN="${_name}" # Using "Arch-Update" as TEXTDOMAIN to avoid conflicting with the "arch-update" TEXTDOMAIN used by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
 if find /usr/local/share/locale/*/LC_MESSAGES/"${_name}".mo &> /dev/null; then

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -6,12 +6,16 @@
 
 # General variables
 name="arch-update"
+_name="Arch-Update"
 version="1.10.1"
 option="${1}"
 
 # Declare necessary paramaters for translations
 . gettext.sh
-export TEXTDOMAIN="${name^^}" # Using "ARCH-UPDATE" as TEXTDOMAIN to avoid conflicting with the "arch-update" TEXTDOMAIN used by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
+export TEXTDOMAIN="${_name}" # Using "Arch-Update" as TEXTDOMAIN to avoid conflicting with the "arch-update" TEXTDOMAIN used by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
+if find /usr/local/share/locale/*/LC_MESSAGES/"${_name}".mo &> /dev/null; then
+	export TEXTDOMAINDIR="/usr/local/share/locale"
+fi
 
 # Checking options in arch-update.conf
 if grep -Eq '^[[:space:]]*NoColor[[:space:]]*$' "${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf" 2> /dev/null; then
@@ -120,7 +124,7 @@ ${name} v${version}
 
 "$(eval_gettext "An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.")"
 
-"$(eval_gettext "Run arch-update to perform the main 'update' function:")"
+"$(eval_gettext "Run \${name} to perform the main 'update' function:")"
 "$(eval_gettext "Print the list of packages available for update, then ask for the user's confirmation to proceed with the installation.")"
 "$(eval_gettext "Before performing the update, offer to print the latest Arch Linux news.")"
 "$(eval_gettext "Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files and pending kernel update and, if there are, offers to process them.")"
@@ -146,24 +150,28 @@ invalid_option() {
 	exit 1
 }
 
+# Definition of the icon directory
+icon_dir="/usr/share/icons/${name}"
+[ -d "/usr/local/share/icons/${name}" ] && icon_dir="/usr/local/share/icons/${name}"
+
 # Definition of the icon_checking function: Change icon to "checking"
 icon_checking() {
-	cp -f /usr/share/icons/arch-update/arch-update_checking.svg /usr/share/icons/arch-update/arch-update.svg || exit 3
+	cp -f "${icon_dir}/${name}_checking.svg" "${icon_dir}/${name}.svg" || exit 3
 }
 
 # Definition of the icon_updates_available function: Change icon to "updates-available"
 icon_updates_available() {
-	cp -f /usr/share/icons/arch-update/arch-update_updates-available.svg /usr/share/icons/arch-update/arch-update.svg || exit 3
+	cp -f "${icon_dir}/${name}_updates-available.svg" "${icon_dir}/${name}.svg" || exit 3
 }
 
 # Definition of the icon_installing function: Change icon to "installing"
 icon_installing() {
-	cp -f /usr/share/icons/arch-update/arch-update_installing.svg /usr/share/icons/arch-update/arch-update.svg || exit 3
+	cp -f "${icon_dir}/${name}_installing.svg" "${icon_dir}/${name}.svg" || exit 3
 }
 
 # Definition of the icon_up_to_date function: Change icon to "up to date"
 icon_up_to_date() {
-	cp -f /usr/share/icons/arch-update/arch-update_up-to-date.svg /usr/share/icons/arch-update/arch-update.svg || exit 3
+	cp -f "${icon_dir}/${name}_up-to-date.svg" "${icon_dir}/${name}.svg" || exit 3
 }
 
 # Definition of the check function: Check for available updates, change the icon accordingly and send a desktop notification containing the number of available updates
@@ -194,9 +202,9 @@ check() {
 			if ! diff "${statedir}/current_check" "${statedir}/last_check" &> /dev/null; then
 				update_number=$(wc -l "${statedir}/current_check" | awk '{print $1}')
 				if [ "${update_number}" -eq 1 ]; then
-					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch-Update" "$(eval_gettext "\${update_number} update available")"
+					notify-send -i "${icon_dir}/${name}_updates-available.svg" "${_name}" "$(eval_gettext "\${update_number} update available")"
 				else
-					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch-Update" "$(eval_gettext "\${update_number} updates available")"
+					notify-send -i "${icon_dir}/${name}_updates-available.svg" "${_name}" "$(eval_gettext "\${update_number} updates available")"
 				fi
 			fi
 		fi

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -9,6 +9,9 @@ name="arch-update"
 version="1.10.1"
 option="${1}"
 
+# Export TEXTDOMAIN env var for translations
+export TEXTDOMAIN="${name}"
+
 # Checking options in arch-update.conf
 if grep -Eq '^[[:space:]]*NoColor[[:space:]]*$' "${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf" 2> /dev/null; then
 	no_color="y"
@@ -76,12 +79,14 @@ error_msg() {
 
 # Definition of the continue_msg function: Print the continue message
 continue_msg() {
-	read -n 1 -r -s -p $"$(info_msg "Press \"enter\" to continue ")" && echo
+	msg="$(eval_gettext "Press \"enter\" to continue ")"
+	read -n 1 -r -s -p $"$(info_msg "${msg}")" && echo
 }
 
 # Definition of the quit_msg function: Print the quit message
 quit_msg() {
-	read -n 1 -r -s -p $"$(info_msg "Press \"enter\" to quit ")" && echo
+	msg="$(eval_gettext "Press \"enter\" to quit ")"
+	read -n 1 -r -s -p $"$(info_msg "${msg}")" && echo
 }
 
 # Definition of the evelation method to use (depending on which one is installed on the system)
@@ -90,7 +95,7 @@ if command -v sudo > /dev/null; then
 elif command -v doas > /dev/null; then
 	su_cmd="doas"
 else
-	error_msg "A privilege elevation method is required\nPlease, install sudo or doas\n" && quit_msg
+	error_msg "$(eval_gettext "A privilege elevation method is required\nPlease, install sudo or doas\n")" && quit_msg
 	exit 2
 fi
 
@@ -112,20 +117,20 @@ help() {
 	cat <<EOF
 ${name} v${version}
 
-An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.
+"$(eval_gettext "An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.")"
 
-Run arch-update to perform the main "update" function:
-Print the list of packages available for update, then ask for the user's confirmation to proceed with the installation.
-Before performing the update, offer to print the latest Arch Linux news.
-Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files and pending kernel update and, if there are, offers to process them.
+"$(eval_gettext "Run arch-update to perform the main 'update' function:")"
+"$(eval_gettext "Print the list of packages available for update, then ask for the user's confirmation to proceed with the installation.")"
+"$(eval_gettext "Before performing the update, offer to print the latest Arch Linux news.")"
+"$(eval_gettext "Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files and pending kernel update and, if there are, offers to process them.")"
 
-Options:
-  -c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)
-  -h, --help     Display this message and exit
-  -V, --version  Display version information and exit
+"$(eval_gettext "Options:")"
+"$(eval_gettext "  -c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)")"
+"$(eval_gettext "  -h, --help     Display this message and exit")"
+"$(eval_gettext "  -V, --version  Display version information and exit")"
 
-For more information, see the ${name}(1) man page.
-Certain options can be enabled/disabled or modified via the ${name}.conf configuration file, see the ${name}.conf(5) man page.
+"$(eval_gettext "For more information, see the \${name}(1) man page.")"
+"$(eval_gettext "Certain options can be enabled/disabled or modified via the \${name}.conf configuration file, see the \${name}.conf(5) man page.")"
 EOF
 }
 
@@ -136,7 +141,7 @@ version() {
 
 # Definition of the invalid_option function: Print an error message, ask the user to check the help and exit
 invalid_option() {
-	echo -e >&2 "${name}: invalid option -- '${option}'\nTry '${name} --help' for more information."
+	echo -e >&2 "$(eval_gettext "\${name}: invalid option -- '\${option}'\nTry '\${name} --help' for more information.")"
 	exit 1
 }
 
@@ -188,9 +193,9 @@ check() {
 			if ! diff "${statedir}/current_check" "${statedir}/last_check" &> /dev/null; then
 				update_number=$(wc -l "${statedir}/current_check" | awk '{print $1}')
 				if [ "${update_number}" -eq 1 ]; then
-					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch-Update" "${update_number} update available"
+					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch-Update" "$(eval_gettext "\${update_number} update available")"
 				else
-					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch-Update" "${update_number} updates available"
+					notify-send -i /usr/share/icons/arch-update/arch-update_updates-available.svg "Arch-Update" "$(eval_gettext "\${update_number} updates available")"
 				fi
 			fi
 		fi
@@ -226,33 +231,33 @@ list_packages() {
 	fi
 
 	if [ -n "${packages}" ]; then
-		main_msg "Packages:"
+		main_msg "$(eval_gettext "Packages:")"
 		echo -e "${packages}\n"
 	fi
 
 	if [ -n "${aur_packages}" ]; then
-		main_msg "AUR Packages:"
+		main_msg "$(eval_gettext "AUR Packages:")"
 		echo -e "${aur_packages}\n"
 	fi
 
 	if [ -n "${flatpak_packages}" ]; then
-		main_msg "Flatpak Packages:"
+		main_msg "$(eval_gettext "Flatpak Packages:")"
 		echo -e "${flatpak_packages}\n"
 	fi
 
 	if [ -z "${packages}" ] && [ -z "${aur_packages}" ] && [ -z "${flatpak_packages}" ]; then
 		icon_up_to_date
-		info_msg "No update available\n"
+		info_msg "$(eval_gettext "No update available\n")"
 	else
 		icon_updates_available
-		ask_msg "Proceed with update? [Y/n]"
+		ask_msg "$(eval_gettext "Proceed with update? [Y/n]")"
 
 		case "${answer}" in
-			[Yy]|"")
+			"$(eval_gettext "[Yy]")"|"")
 				proceed_with_update="y"
 			;;
 			*)
-				error_msg "The update has been aborted\n" && quit_msg
+				error_msg "$(eval_gettext "The update has been aborted\n")" && quit_msg
 				exit 4
 			;;
 		esac
@@ -274,7 +279,8 @@ list_news() {
 		i=1
 		while IFS= read -r line; do
 			if [ "${news_dates["${i}-1"]}" -ge "$(date -d "$(date "+%Y-%m-%d" -d "15 days ago")" "+%s")" ]; then
-				echo -e "${i} - ${line} ${green}[NEW]${color_off}"
+				new_tag="$(eval_gettext "[NEW]")"
+				echo -e "${i} - ${line} ${green}${new_tag}${color_off}"
 			else
 				echo "${i} - ${line}"
 			fi
@@ -282,7 +288,7 @@ list_news() {
 		done < <(printf '%s\n' "${news_titles}")
 
 		echo
-		ask_msg "Select the news to read (or just press \"enter\" to proceed with update):"
+		ask_msg "$(eval_gettext "Select the news to read (or just press \"enter\" to proceed with update):")"
 
 		case "${answer}" in
 			1|2|3|4|5)
@@ -293,7 +299,10 @@ list_news() {
 				news_author=$(echo "${news_content}" | htmlq -t .article-info | cut -f3- -d " ")
 				news_date=$(echo "${news_content}" | htmlq -t .article-info | cut -f1 -d " ")
 				news_article=$(echo "${news_content}" | htmlq -t .article-content)
-				echo -e "\n${blue}---${color_off}\n${bold}Title:${color_off} ${news_selected}\n${bold}Author:${color_off} ${news_author}\n${bold}Publication date:${color_off} ${news_date}\n${bold}URL:${color_off} ${news_url}\n${blue}---${color_off}\n\n${news_article}\n" && continue_msg
+				title_tag="$(eval_gettext "Title:")"
+				author_tag="$(eval_gettext "Author:")"
+				publication_date_tag="$(eval_gettext "Publication date:")"
+				echo -e "\n${blue}---${color_off}\n${bold}${title_tag}${color_off} ${news_selected}\n${bold}${author_tag}${color_off} ${news_author}\n${bold}${publication_date_tag}${color_off} ${news_date}\n${bold}URL:${color_off} ${news_url}\n${blue}---${color_off}\n\n${news_article}\n" && continue_msg
 			;;
 			*)
 				redo="n"
@@ -308,42 +317,42 @@ update() {
 
 	if [ -n "${packages}" ]; then
 		echo
-		main_msg "Updating Packages...\n"
+		main_msg "$(eval_gettext "Updating Packages...\n")"
 
 		if ! "${su_cmd}" pacman -Syu; then
 			icon_updates_available
 			echo
-			error_msg "An error has occurred during the update process\nThe update has been aborted\n" && quit_msg
+			error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
 			exit 5
 		fi
 	fi
 					
 	if [ -n "${aur_packages}" ]; then
 		echo
-		main_msg "Updating AUR Packages...\n"
+		main_msg "$(eval_gettext "Updating AUR Packages...\n")"
 
 		if ! "${aur_helper}" -Syu; then
 			icon_updates_available
 			echo
-			error_msg "An error has occurred during the update process\nThe update has been aborted\n" && quit_msg
+			error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
 			exit 5
 		fi
 	fi
 
 	if [ -n "${flatpak_packages}" ]; then
 		echo
-		main_msg "Updating Flatpak Packages...\n"
+		main_msg "$(eval_gettext "Updating Flatpak Packages...\n")"
 
 		if ! flatpak update; then
 			icon_updates_available
-			error_msg "An error has occurred during the update process\nThe update has been aborted\n" && quit_msg
+			error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
 			exit 5
 		fi
 	fi
 
 	icon_up_to_date
 	echo
-	info_msg "The update has been applied\n"
+	info_msg "$(eval_gettext "The update has been applied\n")"
 }
 
 # Definition of the orphan_packages function: Print orphan packages and offer to remove them if there are
@@ -355,67 +364,67 @@ orphan_packages() {
 	fi
 
 	if [ -n "${orphan_packages}" ]; then
-		main_msg "Orphan Packages:"
+		main_msg "$(eval_gettext "Orphan Packages:")"
 		echo -e "${orphan_packages}\n"
 
 		if [ "$(echo "${orphan_packages}" | wc -l)" -eq 1 ]; then
-			ask_msg "Would you like to remove this orphan package (and its potential dependencies) now? [y/N]"
+			ask_msg "$(eval_gettext "Would you like to remove this orphan package (and its potential dependencies) now? [y/N]")"
 		else
-			ask_msg "Would you like to remove these orphan packages (and their potential dependencies) now? [y/N]"
+			ask_msg "$(eval_gettext "Would you like to remove these orphan packages (and their potential dependencies) now? [y/N]")"
 		fi
 
 		case "${answer}" in
-			[Yy])
+			"$(eval_gettext "[Yy]")")
 				echo
-				main_msg "Removing Orphan Packages...\n"
+				main_msg "$(eval_gettext "Removing Orphan Packages...\n")"
 				
 				if ! pacman -Qtdq | "${su_cmd}" pacman -Rns -; then
 					echo
-					error_msg "An error has occurred during the removal process\nThe removal has been aborted\n"
+					error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 				else
 					echo
-					info_msg "The removal has been applied\n"
+					info_msg "$(eval_gettext "The removal has been applied\n")"
 				fi
 			;;
 			*)
 				echo
-				info_msg "The removal hasn't been applied\n"
+				info_msg "$(eval_gettext "The removal hasn't been applied\n")"
 			;;
 		esac
 	else
-		info_msg "No orphan package found\n"
+		info_msg "$(eval_gettext "No orphan package found\n")"
 	fi
 
 	if [ -n "${flatpak}" ]; then
 		if [ -n "${flatpak_unused}" ]; then
-			main_msg "Flatpak Unused Packages:"
+			main_msg "$(eval_gettext "Flatpak Unused Packages:")"
 			echo -e "${flatpak_unused}\n"
 
 			if [ "$(echo "${flatpak_unused}" | wc -l)" -eq 1 ]; then
-				ask_msg "Would you like to remove this Flatpak unused package now? [y/N]"
+				ask_msg "$(eval_gettext "Would you like to remove this Flatpak unused package now? [y/N]")"
 			else
-				ask_msg "Would you like to remove these Flatpak unused packages now? [y/N]"
+				ask_msg "$(eval_gettext "Would you like to remove these Flatpak unused packages now? [y/N]")"
 			fi
 
 			case "${answer}" in
-				[Yy])
+				"$(eval_gettext "[Yy]")")
 					echo
-					main_msg "Removing Flatpak Unused Packages..."
+					main_msg "$(eval_gettext "Removing Flatpak Unused Packages...")"
 
 					if ! flatpak remove --unused; then
 						echo
-						error_msg "An error has occurred the removal process\nThe removal has been aborted\n"
+						error_msg "$(eval_gettext "An error has occurred the removal process\nThe removal has been aborted\n")"
 					else
 						echo
-						info_msg "The removal has been applied\n"
+						info_msg "$(eval_gettext "The removal has been applied\n")"
 					fi
 				;;
 				*)
-					info_msg "The removal hasn't been applied\n"
+					info_msg "$(eval_gettext "The removal hasn't been applied\n")"
 				;;
 			esac
 		else
-			info_msg "No Flatpak unused package found\n"
+			info_msg "$(eval_gettext "No Flatpak unused package found\n")"
 		fi
 	fi
 }
@@ -432,51 +441,51 @@ packages_cache() {
 	if [ "${pacman_cache_total}" -gt 0 ]; then
 
 		if [ "${pacman_cache_total}" -eq 1 ]; then
-			main_msg "Cached Packages:\nThere's an old or uninstalled cached package\n"
-			ask_msg "Would you like to remove it from the cache now? [Y/n]"
+			main_msg "$(eval_gettext "Cached Packages:\nThere's an old or uninstalled cached package\n")"
+			ask_msg "$(eval_gettext "Would you like to remove it from the cache now? [Y/n]")"
 		else
-			main_msg "Cached Packages:\nThere are old and/or uninstalled cached packages\n"
-			ask_msg "Would you like to remove them from the cache now? [Y/n]"
+			main_msg "$(eval_gettext "Cached Packages:\nThere are old and/or uninstalled cached packages\n")"
+			ask_msg "$(eval_gettext "Would you like to remove them from the cache now? [Y/n]")"
 		fi
 			
 		case "${answer}" in
-			[Yy]|"")
+			"$(eval_gettext "[Yy]")"|"")
 				if [ "${pacman_cache_old}" -gt 0 ] && [ "${pacman_cache_uninstalled}" -eq 0 ]; then
 					echo
-					main_msg "Removing old cached packages..."
+					main_msg "$(eval_gettext "Removing old cached packages...")"
 
 					if ! "${su_cmd}" paccache -rk"${old_packages_num}"; then
 						echo
-						error_msg "An error has occurred during the removal process\nThe removal has been aborted\n"
+						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
 						echo
 					fi
 				elif [ "${pacman_cache_old}" -eq 0 ] && [ "${pacman_cache_uninstalled}" -gt 0 ]; then
 					echo
-					main_msg "Removing uninstalled cached packages..."
+					main_msg "$(eval_gettext "Removing uninstalled cached packages...")"
 
 					if ! "${su_cmd}" paccache -ruk"${uninstalled_packages_num}"; then
 						echo
-						error_msg "An error has occurred during the removal process\nThe removal has been aborted\n"
+						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
 						echo
 					fi
 				elif [ "${pacman_cache_old}" -gt 0 ] && [ "${pacman_cache_uninstalled}" -gt 0 ]; then
 					echo
-					main_msg "Removing old cached packages..."
+					main_msg "$(eval_gettext "Removing old cached packages...")"
 
 					if ! "${su_cmd}" paccache -rk"${old_packages_num}"; then
 						echo
-						error_msg "An error has occurred during the removal process\nThe removal has been aborted\n"
+						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
 						echo
 					fi
 
-					main_msg "Removing uninstalled cached packages..."
+					main_msg "$(eval_gettext "Removing uninstalled cached packages...")"
 
 					if ! "${su_cmd}" paccache -ruk"${uninstalled_packages_num}"; then
 						echo
-						error_msg "An error has occurred during the removal process\nThe removal has been aborted\n"
+						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
 						echo
 					fi
@@ -484,11 +493,11 @@ packages_cache() {
 			;;
 			*)
 				echo
-				info_msg "The removal hasn't been applied\n"
+				info_msg "$(eval_gettext "The removal hasn't been applied\n")"
 			;;
 		esac
 	else
-		info_msg "No old or uninstalled cached package found\n"
+		info_msg "$(eval_gettext "No old or uninstalled cached package found\n")"
 	fi
 }
 
@@ -497,30 +506,30 @@ pacnew_files() {
 	pacnew_files=$(pacdiff -o)
 		
 	if [ -n "${pacnew_files}" ]; then
-		main_msg "Pacnew Files:"
+		main_msg "$(eval_gettext "Pacnew Files:")"
 		echo -e "${pacnew_files}\n"
 
 		if [ "$(echo "${pacnew_files}" | wc -l)" -eq 1 ]; then
-			ask_msg "Would you like to process this file now? [Y/n]"
+			ask_msg "$(eval_gettext "Would you like to process this file now? [Y/n]")"
 		else
-			ask_msg "Would you like to process these files now? [Y/n]"
+			ask_msg "$(eval_gettext "Would you like to process these files now? [Y/n]")"
 		fi
 
 		case "${answer}" in
-			[Yy]|"")
+			"$(eval_gettext "[Yy]")"|"")
 				echo
-				main_msg "Processing Pacnew Files...\n"
+				main_msg "$(eval_gettext "Processing Pacnew Files...\n")"
 
 				"${su_cmd}" pacdiff
 				echo
-				info_msg "The pacnew file(s) processing has been applied\n"
+				info_msg "$(eval_gettext "The pacnew file(s) processing has been applied\n")"
 			;;
 			*)
-				info_msg "The pacnew file(s) processing hasn't been applied\n"
+				info_msg "$(eval_gettext "The pacnew file(s) processing hasn't been applied\n")"
 			;;
 		esac
 	else
-		info_msg "No pacnew file found\n"
+		info_msg "$(eval_gettext "No pacnew file found\n")"
 	fi
 }
 
@@ -533,17 +542,17 @@ kernel_reboot() {
 	fi
 
 	if [ -z "${kernel_compare}" ]; then
-		main_msg "Reboot required:\nThere's a pending kernel update on your system requiring a reboot to be applied\n"
-		ask_msg "Would you like to reboot now? [y/N]"
+		main_msg "$(eval_gettext "Reboot required:\nThere's a pending kernel update on your system requiring a reboot to be applied\n")"
+		ask_msg "$(eval_gettext "Would you like to reboot now? [y/N]")"
 
 		case "${answer}" in
-			[Yy])
+			"$(eval_gettext "[Yy]")")
 				echo
-				main_msg "Rebooting in 5 seconds...\nPress ctrl+c to abort"
+				main_msg "$(eval_gettext "Rebooting in 5 seconds...\nPress ctrl+c to abort")"
 				sleep 5
 				if ! reboot; then
 					echo
-					error_msg "An error has occurred during the reboot process\nThe reboot has been aborted\n" && quit_msg
+					error_msg "$(eval_gettext "An error has occurred during the reboot process\nThe reboot has been aborted\n")" && quit_msg
 					exit 6
 				else
 					exit 0
@@ -551,11 +560,11 @@ kernel_reboot() {
 			;;
 			*)
 				echo
-				warning_msg "The reboot hasn't been performed\nPlease, consider rebooting to finalize the pending kernel update\n"
+				warning_msg "$(eval_gettext "The reboot hasn't been performed\nPlease, consider rebooting to finalize the pending kernel update\n")"
 			;;
 		esac
 	else
-		info_msg "No pending kernel update found\n"
+		info_msg "$(eval_gettext "No pending kernel update found\n")"
 	fi
 }
 
@@ -568,7 +577,7 @@ case "${option}" in
 				list_news
 			else
 				echo
-				warning_msg "NoNews option detected\nPlease, keep in mind that users are expected to check the latest Arch news before updating their system, to be aware of eventual required manual interventions"
+				warning_msg "$(eval_gettext "NoNews option detected\nPlease, keep in mind that users are expected to check the latest Arch news before updating their system, to be aware of eventual required manual interventions")"
 			fi
 			update
 		fi

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -312,7 +312,8 @@ list_news() {
 				title_tag="$(eval_gettext "Title:")"
 				author_tag="$(eval_gettext "Author:")"
 				publication_date_tag="$(eval_gettext "Publication date:")"
-				echo -e "\n${blue}---${color_off}\n${bold}${title_tag}${color_off} ${news_selected}\n${bold}${author_tag}${color_off} ${news_author}\n${bold}${publication_date_tag}${color_off} ${news_date}\n${bold}URL:${color_off} ${news_url}\n${blue}---${color_off}\n\n${news_article}\n" && continue_msg
+				url_tag="$(eval_gettext "URL:")"
+				echo -e "\n${blue}---${color_off}\n${bold}${title_tag}${color_off} ${news_selected}\n${bold}${author_tag}${color_off} ${news_author}\n${bold}${publication_date_tag}${color_off} ${news_date}\n${bold}${url_tag}${color_off} ${news_url}\n${blue}---${color_off}\n\n${news_article}\n" && continue_msg
 			;;
 			*)
 				redo="n"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -123,20 +123,20 @@ help() {
 	cat <<EOF
 ${name} v${version}
 
-"$(eval_gettext "An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.")"
+$(eval_gettext "An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.")
 
-"$(eval_gettext "Run \${name} to perform the main 'update' function:")"
-"$(eval_gettext "Print the list of packages available for update, then ask for the user's confirmation to proceed with the installation.")"
-"$(eval_gettext "Before performing the update, offer to print the latest Arch Linux news.")"
-"$(eval_gettext "Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files and pending kernel update and, if there are, offers to process them.")"
+$(eval_gettext "Run \${name} to perform the main 'update' function:")
+$(eval_gettext "Print the list of packages available for update, then ask for the user's confirmation to proceed with the installation.")
+$(eval_gettext "Before performing the update, offer to print the latest Arch Linux news.")
+$(eval_gettext "Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files and pending kernel update and, if there are, offers to process them.")
 
-"$(eval_gettext "Options:")"
-"$(eval_gettext "  -c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)")"
-"$(eval_gettext "  -h, --help     Display this message and exit")"
-"$(eval_gettext "  -V, --version  Display version information and exit")"
+$(eval_gettext "Options:")
+$(eval_gettext "  -c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)")
+$(eval_gettext "  -h, --help     Display this message and exit")
+$(eval_gettext "  -V, --version  Display version information and exit")
 
-"$(eval_gettext "For more information, see the \${name}(1) man page.")"
-"$(eval_gettext "Certain options can be enabled/disabled or modified via the \${name}.conf configuration file, see the \${name}.conf(5) man page.")"
+$(eval_gettext "For more information, see the \${name}(1) man page.")
+$(eval_gettext "Certain options can be enabled/disabled or modified via the \${name}.conf configuration file, see the \${name}.conf(5) man page.")
 EOF
 }
 

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -11,7 +11,7 @@ option="${1}"
 
 # Declare necessary paramaters for translations
 . gettext.sh
-export TEXTDOMAIN="${name}"
+export TEXTDOMAIN="${name^^}" # Using "ARCH-UPDATE" as TEXTDOMAIN to avoid conflicting with the "arch-update" TEXTDOMAIN used by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
 
 # Checking options in arch-update.conf
 if grep -Eq '^[[:space:]]*NoColor[[:space:]]*$' "${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf" 2> /dev/null; then

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -11,7 +11,7 @@ version="1.10.1"
 option="${1}"
 
 # Declare necessary parameters for translations
-. gettext.sh
+. gettext.sh # shellcheck disable=SC1091
 export TEXTDOMAIN="${_name}" # Using "Arch-Update" as TEXTDOMAIN to avoid conflicting with the "arch-update" TEXTDOMAIN used by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
 if find /usr/local/share/locale/*/LC_MESSAGES/"${_name}".mo &> /dev/null; then
 	export TEXTDOMAINDIR="/usr/local/share/locale"


### PR DESCRIPTION
This PR aims to bring a french translation for the `Arch-Update` script.
A template `arch-update.pot` file is available in the `po` folder for eventual future translations.

This PR also brings several improvements to the `Makefile` and the overall packaging method.

Closes #93 