### PR TITLE
Improve documentation wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Features:
 
 - Includes a (.desktop) clickeable icon that automatically changes to act as an update notifier/applier. Easy to integrate with any DE/WM, dock, status/launch bar, app menu, etc...
 - Automatic check and listing of every packages available for update (through [checkupdates](https://archlinux.org/packages/extra/x86_64/pacman-contrib/ "pacman-contrib package")).
-- Offers to print the latest Arch Linux news before applying updates (through [curl](https://archlinux.org/packages/core/x86_64/curl/ "curl package") and [htmlq](https://archlinux.org/packages/extra/x86_64/htmlq/ "htmlq package")).
+- Offers to display the latest Arch Linux news before applying updates (through [curl](https://archlinux.org/packages/core/x86_64/curl/ "curl package") and [htmlq](https://archlinux.org/packages/extra/x86_64/htmlq/ "htmlq package")).
 - Automatic check and listing of orphan packages and offering you to remove them.
 - Automatic check for old and/or uninstalled cached packages in `pacman`'s cache and offering you to remove them (through [paccache](https://archlinux.org/packages/extra/x86_64/pacman-contrib/ "pacman-contrib package")).
 - Helps you processing pacnew/pacsave files (through [pacdiff](https://archlinux.org/packages/extra/x86_64/pacman-contrib/ "pacman-contrib package"), optionally requires [vim](https://archlinux.org/packages/extra/x86_64/vim/ "vim package") as the default [merge program](https://wiki.archlinux.org/title/Pacman/Pacnew_and_Pacsave#pacdiff "pacdiff merge program")).
@@ -99,7 +99,7 @@ If there are new available updates, the icon will show a bell sign and a desktop
 ![icon-update-available](https://github.com/Antiz96/arch-update/assets/53110319/c1526ce7-5f94-41b8-a8fa-3587b9d00a9d)
 ![notification](https://github.com/Antiz96/arch-update/assets/53110319/631b8e67-487a-441a-84b4-6cce95223729)
 
-When the icon is clicked, it launches the relevant series of functions to perform a complete and proper update starting by refreshing the list of packages available for updates, print it inside a terminal window and asks for the user's confirmation to proceed with the installation (it can also be launched by running the `arch-update` command, requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR packages update support and [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak/) for Flatpak packages update support):
+When the icon is clicked, it launches the relevant series of functions to perform a complete and proper update starting by refreshing the list of packages available for updates, display it inside a terminal window and asks for the user's confirmation to proceed with the installation (it can also be launched by running the `arch-update` command, requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR packages update support and [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak/) for Flatpak packages update support):
 
 *The colored output can be disabled with the `NoColor` option in the `arch-update.conf` configuration file.*  
 *The versions changes in the packages listing can be hidden with the `NoVersion` option in the `arch-update.conf` configuration file.*  
@@ -107,13 +107,13 @@ When the icon is clicked, it launches the relevant series of functions to perfor
 
 ![listing-packages](https://github.com/Antiz96/arch-update/assets/53110319/43a990c8-ed93-420f-8c46-d50d60bff03f)
 
-Once you gave the confirmation to proceed, `arch-update` offers to print latest Arch Linux news.  
+Once you gave the confirmation to proceed, `arch-update` offers to display latest Arch Linux news.  
 Arch news that have been published within the last 15 days are tagged as `[NEW]`.  
 Select which news to read by typing its associated number.  
-After your read a news, `arch-update` will once again offers to print latest Arch Linux news, so you can read multiple news at once.  
+After your read a news, `arch-update` will once again offers to display latest Arch Linux news, so you can read multiple news at once.  
 Simply press "enter" without typing any number to proceed with update:
 
-*The Arch news listing/printing can be skipped with the `NoNews`  option in the `arch-update.conf` configuration file.*  
+*The Arch news listing/displaying can be skipped with the `NoNews`  option in the `arch-update.conf` configuration file.*  
 *Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.*  
 *See the [arch-update.conf documentation chapter](#arch-update-configuration-file) for more details.*
 
@@ -158,9 +158,9 @@ An update notifier/applier for Arch Linux that assists you with
 important pre/post update tasks.
 
 Run arch-update to perform the main "update" function:
-Print the list of packages available for update, then ask for the user's confirmation
+Display the list of packages available for update, then ask for the user's confirmation
 to proceed with the installation.
-Before performing the update, offer to print the latest Arch Linux news.
+Before performing the update, offer to display the latest Arch Linux news.
 Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files
 and pending kernel update and, if there are, offers to process them.
 
@@ -195,7 +195,7 @@ The supported options are:
 
 - NoColor # Do not colorize output.
 - NoVersion # Do not show versions changes for packages when listing pending updates.
-- NoNews # Do not print Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
+- NoNews # Do not display Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
 - KeepOldPackages=Num # Number of old packages' versions to keep in pacman's cache. Defaults to 3.
 - KeepUninstalledPackages=Num # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -14,11 +14,11 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 
 .SH OPTIONS
 .PP
-.RB "If no option is passed, launch the relevant series of functions to perform a complete and proper update starting by printing the list of packages available for update, then ask for the user's confirmation to proceed with the installation."
+.RB "If no option is passed, launch the relevant series of functions to perform a complete and proper update starting by displaying the list of packages available for update, then ask for the user's confirmation to proceed with the installation."
 .br
 .RB "It also supports AUR packages update (if " "yay " "or " "paru " "is installed) and Flatpak packages update (if " "flatpak " "is installed)."
 .br
-.RB "Before performing the update, it offers to print the latest Arch Linux news to the user. Arch news that have been published within the last 15 days are tagged as '[NEW]'."
+.RB "Before performing the update, it offers to display the latest Arch Linux news to the user. Arch news that have been published within the last 15 days are tagged as '[NEW]'."
 .br
 .RB "It also checks for orphan packages, unused Flatpak packages, old and/or uninstalled cached packages in pacman's cache, pacnew/pacsave files and pending kernel update requiring a reboot to be applied and, if there are, offers to process them."
 .br
@@ -40,11 +40,11 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 
 .TP
 .B \-v, \-\-version
-Print the current version.
+Display version information.
 
 .TP
 .B \-h, \-\-help
-Print the help message.
+Display the help message.
 
 .TP
 .RB "Certain options can be enabled/disabled or modified via the " "arch-update.conf " "configuration file, see the " "arch-update.conf(5) " "man page."

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -27,7 +27,7 @@ Do not show versions changes for packages when listing pending updates.
 
 .TP
 .B NoNews
-Do not print Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
+Do not display Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
 
 .TP
 .B KeepOldPackages=Num

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -40,7 +40,7 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 
 .TP
 .B \-v, \-\-version
-Afficher les informations de version et quitter.
+Afficher les informations de version.
 
 .TP
 .B \-h, \-\-help

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -47,14 +47,14 @@ msgstr ""
 #: src/script/arch-update.sh:129
 #, sh-format
 msgid ""
-"Print the list of packages available for update, then ask for the user's "
+"Display the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
 #: src/script/arch-update.sh:130
 #, sh-format
 msgid ""
-"Before performing the update, offer to print the latest Arch Linux news."
+"Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 
 #: src/script/arch-update.sh:131

--- a/po/fr.po
+++ b/po/fr.po
@@ -50,7 +50,7 @@ msgstr "Lancez ${name} pour exécuter la fonction principale 'update' :"
 #: src/script/arch-update.sh:129
 #, sh-format
 msgid ""
-"Print the list of packages available for update, then ask for the user's "
+"Display the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 "Afficher la liste des paquets disponibles pour mise à jour, puis demander la confirmation de l'utilisateur "
@@ -59,7 +59,7 @@ msgstr ""
 #: src/script/arch-update.sh:130
 #, sh-format
 msgid ""
-"Before performing the update, offer to print the latest Arch Linux news."
+"Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 "Avant d'effectuer la mise à jour, propose d'afficher les dernières news d'Arch Linux."
 

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -53,43 +53,43 @@ if [ -z "${no_color}" ]; then
 	color_off="\e[0m"
 fi
 
-# Definition of the main_msg function: Print a message as a main message
+# Definition of the main_msg function: Display a message as a main message
 main_msg() {
 	msg="${1}"
 	echo -e "${blue}==>${color_off}${bold} ${msg}${color_off}"
 }
 
-# Definition of the info_msg function: Print a message as an information message
+# Definition of the info_msg function: Display a message as an information message
 info_msg() {
 	msg="${1}"
 	echo -e "${green}==>${color_off}${bold} ${msg}${color_off}"
 }
 
-# Definition of the ask_msg function: Print a message as an interactive question
+# Definition of the ask_msg function: Display a message as an interactive question
 ask_msg() {
 	msg="${1}"
 	read -rp $"$(echo -e "${blue}->${color_off}${bold} ${msg}${color_off} ")" answer
 }
 
-# Definition of the warning_msg function: Print a message as a warning message
+# Definition of the warning_msg function: Display a message as a warning message
 warning_msg() {
 	msg="${1}"
 	echo -e "${yellow}==> WARNING:${color_off}${bold} ${msg}${color_off}"
 }
 
-# Definition of the error_msg function: Print a message as an error message
+# Definition of the error_msg function: Display a message as an error message
 error_msg() {
 	msg="${1}"
 	echo -e >&2 "${red}==> ERROR:${color_off}${bold} ${msg}${color_off}"
 }
 
-# Definition of the continue_msg function: Print the continue message
+# Definition of the continue_msg function: Display the continue message
 continue_msg() {
 	msg="$(eval_gettext "Press \"enter\" to continue ")"
 	read -n 1 -r -s -p $"$(info_msg "${msg}")" && echo
 }
 
-# Definition of the quit_msg function: Print the quit message
+# Definition of the quit_msg function: Display the quit message
 quit_msg() {
 	msg="$(eval_gettext "Press \"enter\" to quit ")"
 	read -n 1 -r -s -p $"$(info_msg "${msg}")" && echo
@@ -118,7 +118,7 @@ flatpak=$(command -v flatpak)
 # Check if notify-send is installed for the optional desktop notification support
 notif=$(command -v notify-send)
 
-# Definition of the help function: Print the help message
+# Definition of the help function: Display the help message
 help() {
 	cat <<EOF
 ${name} v${version}
@@ -126,8 +126,8 @@ ${name} v${version}
 $(eval_gettext "An update notifier/applier for Arch Linux that assists you with important pre/post update tasks.")
 
 $(eval_gettext "Run \${name} to perform the main 'update' function:")
-$(eval_gettext "Print the list of packages available for update, then ask for the user's confirmation to proceed with the installation.")
-$(eval_gettext "Before performing the update, offer to print the latest Arch Linux news.")
+$(eval_gettext "Display the list of packages available for update, then ask for the user's confirmation to proceed with the installation.")
+$(eval_gettext "Before performing the update, offer to display the latest Arch Linux news.")
 $(eval_gettext "Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files and pending kernel update and, if there are, offers to process them.")
 
 $(eval_gettext "Options:")
@@ -140,12 +140,12 @@ $(eval_gettext "Certain options can be enabled/disabled or modified via the \${n
 EOF
 }
 
-# Definition of the version function: Print the current version
+# Definition of the version function: Display the version information
 version() {
 	echo "${name} ${version}"
 }
 
-# Definition of the invalid_option function: Print an error message, ask the user to check the help and exit
+# Definition of the invalid_option function: Display an error message, ask the user to check the help and exit
 invalid_option() {
 	echo -e >&2 "$(eval_gettext "\${name}: invalid option -- '\${option}'\nTry '\${name} --help' for more information.")"
 	exit 1
@@ -218,7 +218,7 @@ check() {
 	fi
 }
 
-# Definition of the list_packages function: Print packages that are available for update and offer to apply them if there are
+# Definition of the list_packages function: Display packages that are available for update and offer to apply them if there are
 list_packages() {
 	icon_checking
 	
@@ -274,7 +274,7 @@ list_packages() {
 	fi
 }
 
-# Definition of the list_news function: Print the latest Arch news and offers to read them
+# Definition of the list_news function: Display the latest Arch news and offers to read them
 list_news() {
 	redo="y"
 
@@ -366,7 +366,7 @@ update() {
 	info_msg "$(eval_gettext "The update has been applied\n")"
 }
 
-# Definition of the orphan_packages function: Print orphan packages and offer to remove them if there are
+# Definition of the orphan_packages function: Display orphan packages and offer to remove them if there are
 orphan_packages() {
 	orphan_packages=$(pacman -Qtdq)
 
@@ -512,7 +512,7 @@ packages_cache() {
 	fi
 }
 
-# Definition of the pacnew_files function: Print pacnew files and offer to process them if there are
+# Definition of the pacnew_files function: Display pacnew files and offer to process them if there are
 pacnew_files() {
 	pacnew_files=$(pacdiff -o)
 		


### PR DESCRIPTION
Basically replace 'print' by 'display' everywhere. It sounds more accurate.