### PR TITLE
Introduce the `-n/--news` option that allows to display latest Arch News

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -115,6 +115,7 @@ Sélectionnez la news à lire en tapant le numéro associé.
 Après avoir lu une news, `arch-update` vous proposera à nouveau d'afficher les dernières Arch news, afin que vous puissiez lire plusieurs news à la fois.  
 Appuyez simplement sur « Entrée » sans saisir de chiffre pour procéder à la mise à jour :
 
+*Les Arch news peuvent être affichées à tout moment en exécutant la commande `arch-update --news`*  
 *Le listing/affichage des Arch news peut être ignoré avec l'option `NoNews` dans le fichier de configuration `arch-update.conf`.*  
 *Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.*  
 *Voir le [chapitre de documentation arch-update.conf](#Fichier-de-configuration-arch-update) pour plus de détails.*
@@ -168,7 +169,8 @@ de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en 
 
 Options :
 -c, --check    Vérifier les mises à jour disponibles, envoyer une notification de bureau contenant le nombre de mises à jour disponibles (si libnotify est installé)
--h, --help     Afficher ce message et quitter
+-n, --news     Afficher les dernières Arch News
+-h, --help     Afficher ce message d'aide et quitter
 -V, --version  Afficher les informations de version et quitter
 
 Codes de sortie :

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Select which news to read by typing its associated number.
 After your read a news, `arch-update` will once again offers to display latest Arch Linux news, so you can read multiple news at once.  
 Simply press "enter" without typing any number to proceed with update:
 
+*Arch news can be displayed at any time by running the `arch-update --news` command.*  
 *The Arch news listing/displaying can be skipped with the `NoNews`  option in the `arch-update.conf` configuration file.*  
 *Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.*  
 *See the [arch-update.conf documentation chapter](#arch-update-configuration-file) for more details.*
@@ -166,7 +167,8 @@ and pending kernel update and, if there are, offers to process them.
 
 Options:
 -c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)
--h, --help     Display this message and exit
+-n, --news     Display latest Arch News
+-h, --help     Display this help message and exit
 -V, --version  Display version information and exit
 
 Exit Codes:

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "January 2024" "Arch-Update 1.11.0" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "February 2024" "Arch-Update 1.11.0" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
@@ -37,6 +37,10 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .RB "The " "\-\-check " "option is automatically launched at boot and then every hour if you enabled the " "systemd.timer " "with the following command:" 
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
+
+.TP
+.B \-n, \-\-news
+Display latest Arch news.
 
 .TP
 .B \-v, \-\-version

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "Janvier 2024" "Arch-Update 1.11.0" "Manuel de Arch-Update"
+.TH "ARCH-UPDATE" "1" "Février 2024" "Arch-Update 1.11.0" "Manuel de Arch-Update"
 
 .SH NAME
 arch-update \- Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour.
@@ -37,6 +37,10 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 .RB "L'option " "\-\-check " "est automatiquement lancée au démarrage du système puis une fois chaque heure si vous avez activé le " "systemd.timer " "avec la commande suivante :"
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
+
+.TP
+.B \-n, \-\-news
+Afficher les dernières Arch news.
 
 .TP
 .B \-v, \-\-version

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -79,7 +79,7 @@ msgstr ""
 
 #: src/script/arch-update.sh:135
 #, sh-format
-msgid "  -h, --help     Display this message and exit"
+msgid "  -h, --help     Display this help message and exit"
 msgstr ""
 
 #: src/script/arch-update.sh:136

--- a/po/fr.po
+++ b/po/fr.po
@@ -90,8 +90,8 @@ msgstr ""
 
 #: src/script/arch-update.sh:135
 #, sh-format
-msgid "  -h, --help     Display this message and exit"
-msgstr " -h, --help     Afficher ce message et quitter"
+msgid "  -h, --help     Display this help message and exit"
+msgstr " -h, --help     Afficher ce message d'aide et quitter"
 
 #: src/script/arch-update.sh:136
 #, sh-format

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -132,7 +132,7 @@ $(eval_gettext "Post update, check for orphan/unused packages, old cached packag
 
 $(eval_gettext "Options:")
 $(eval_gettext "  -c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)")
-$(eval_gettext "  -h, --help     Display this message and exit")
+$(eval_gettext "  -h, --help     Display this help message and exit")
 $(eval_gettext "  -V, --version  Display version information and exit")
 
 $(eval_gettext "For more information, see the \${name}(1) man page.")


### PR DESCRIPTION
This PR aims to introduce the `-n/--news` option to `arch-update` that displays the latest Arch News.

This new option is meant to allow users to print latest Arch News at any time outside of the main "update" function of the script (and thus without requiring to have at least one pending update to be able to check latest Arch news).