### PR TITLE
Allow to customise the number of Arch news to display before updating and with the `-n/--news` option

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -115,7 +115,7 @@ Sélectionnez la news à lire en tapant le numéro associé.
 Après avoir lu une news, `arch-update` vous proposera à nouveau d'afficher les dernières Arch news, afin que vous puissiez lire plusieurs news à la fois.  
 Appuyez simplement sur « Entrée » sans saisir de chiffre pour procéder à la mise à jour :
 
-*Les Arch news peuvent être affichées à tout moment en exécutant la commande `arch-update --news`*  
+*Les Arch news peuvent être affichées à tout moment en exécutant la commande `arch-update --news`.*  
 *Le nombre par défaut de Arch news à afficher avant la mise à jour et avec l'option `-n/--news` est de 5 mais il peut être modifié avec l'option `NewsNum=[Num]` dans le fichier de configuration `arch-update.conf`.*  
 *Le listing/affichage des Arch news peut être ignoré avec l'option `NoNews` dans le fichier de configuration `arch-update.conf`.*  
 *Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.*  
@@ -201,7 +201,7 @@ Les options prises en charge sont :
 - NoColor # Ne pas coloriser la sortie.
 - NoVersion # Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente.
 - NoNews # Ne pas afficher les Arch news. Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.
-- NewsNum=[Num] # Nombre de Arch news à affcher avant la mise à jour et avec l'option `-n/--news` (voir la page de man `arch-update(1)` pour plus de details). La valeur par défaut est 5.
+- NewsNum=[Num] # Nombre de Arch news à affcher avant la mise à jour et avec l'option `-n/--news` (voir la page de manuel arch-update(1) pour plus de details). La valeur par défaut est 5.
 - KeepOldPackages=[Num] # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
 - KeepUninstalledPackages=[Num] # Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -116,9 +116,10 @@ Après avoir lu une news, `arch-update` vous proposera à nouveau d'afficher les
 Appuyez simplement sur « Entrée » sans saisir de chiffre pour procéder à la mise à jour :
 
 *Les Arch news peuvent être affichées à tout moment en exécutant la commande `arch-update --news`*  
+*Le nombre par défaut de Arch news à afficher avant la mise à jour et avec l'option `-n/--news` est de 5 mais il peut être modifié avec l'option `NewsNum=[Num]` dans le fichier de configuration `arch-update.conf`.*  
 *Le listing/affichage des Arch news peut être ignoré avec l'option `NoNews` dans le fichier de configuration `arch-update.conf`.*  
 *Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.*  
-*Voir le [chapitre de documentation arch-update.conf](#Fichier-de-configuration-arch-update) pour plus de détails.*
+*Voir le [chapitre de documentation](#Documentation) pour plus de détails.*
 
 ![list-news](https://github.com/Antiz96/arch-update/assets/53110319/b6883ec4-8c44-4b97-86d9-4d0a304b748b)
 
@@ -139,7 +140,7 @@ Une fois la mise à jour terminée, l'icône change en conséquence :
 `arch-update` recherchera également les anciens paquets et/ou paquets désinstallés mis en cache et proposera de les supprimer (s'il y en a) :
 
 *Le comportement par défaut consiste à conserver les 3 dernières versions en cache des paquets installés et à supprimer toutes les versions en cache des paquets désinstallés.*  
-*Vous pouvez modifier le nombre d'anciennes versions de paquets et de versions de paquets désinstallés à conserver respectivement dans le cache de pacman avec les options `KeepOldPackages=Num` et `KeepUninstalledPackages=Num` dans le fichier de configuration `arch-update.conf`.*  
+*Vous pouvez modifier le nombre d'anciennes versions de paquets et de versions de paquets désinstallés à conserver respectivement dans le cache de pacman avec les options `KeepOldPackages=[Num]` et `KeepUninstalledPackages=[Num]` dans le fichier de configuration `arch-update.conf`.*  
 *Voir le [chapitre de documentation arch-update.conf](#Fichier-de-configuration-arch-update) pour plus de détails.*
 
 ![cached-packages](https://github.com/Antiz96/arch-update/assets/53110319/7199bbf1-acd8-49a1-80eb-e9874b94fba6)
@@ -168,10 +169,10 @@ Après la mise à jour, vérification de la présence de paquets orphelins/inuti
 de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, propose de les traiter.
 
 Options :
--c, --check    Vérifier les mises à jour disponibles, envoyer une notification de bureau contenant le nombre de mises à jour disponibles (si libnotify est installé)
--n, --news     Afficher les dernières Arch News
--h, --help     Afficher ce message d'aide et quitter
--V, --version  Afficher les informations de version et quitter
+-c, --check       Vérifier les mises à jour disponibles, envoyer une notification de bureau contenant le nombre de mises à jour disponibles (si libnotify est installé)
+-n, --news [Num]  Afficher les dernieres Arch News, vous pouvez optionellement spécifier le nombre de Arch news à afficher avec `--news [Num]` (e.g. `--news 10`)
+-h, --help        Afficher ce message d'aide et quitter
+-V, --version     Afficher les informations de version et quitter
 
 Codes de sortie :
 0  OK
@@ -200,8 +201,9 @@ Les options prises en charge sont :
 - NoColor # Ne pas coloriser la sortie.
 - NoVersion # Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente.
 - NoNews # Ne pas afficher les Arch news. Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.
-- KeepOldPackages=Num # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
-- KeepUninstalledPackages=Num # Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
+- NewsNum=[Num] # Nombre de Arch news à affcher avant la mise à jour et avec l'option `-n/--news` (voir la page de man `arch-update(1)` pour plus de details). La valeur par défaut est 5.
+- KeepOldPackages=[Num] # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
+- KeepUninstalledPackages=[Num] # Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
 
 Les options sont sensibles à la casse, les majuscules doivent donc être respectées.
 ```

--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ After your read a news, `arch-update` will once again offers to display latest A
 Simply press "enter" without typing any number to proceed with update:
 
 *Arch news can be displayed at any time by running the `arch-update --news` command.*  
+*The number of Arch news to display before updating and with the `-n/--news` option defaults to 5 but can be customised with the `NewsNum=[Num]` option in the `arch-update.conf` configuration file.*   
 *The Arch news listing/displaying can be skipped with the `NoNews`  option in the `arch-update.conf` configuration file.*  
 *Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.*  
-*See the [arch-update.conf documentation chapter](#arch-update-configuration-file) for more details.*
+*See the [documentation chapter](#Documentation) for more details.*
 
 ![list-news](https://github.com/Antiz96/arch-update/assets/53110319/b6883ec4-8c44-4b97-86d9-4d0a304b748b)
 
@@ -137,7 +138,7 @@ When the update is over, the icon changes accordingly:
 `arch-update` will also search for old and/or uninstalled cached packages and offers to remove them (if there are):
 
 *The default behavior is to keep the last 3 cached versions of installed packages and remove every cached versions of uninstalled packages.*  
-*You can modify the number of old packages' versions and uninstalled packages' versions to keep in pacman's cache respectively with the `KeepOldPackages=Num` and `KeepUninstalledPackages=Num` options in the `arch-update.conf` configuration file.*  
+*You can modify the number of old packages' versions and uninstalled packages' versions to keep in pacman's cache respectively with the `KeepOldPackages=[Num]` and `KeepUninstalledPackages=[Num]` options in the `arch-update.conf` configuration file.*  
 *See the [arch-update.conf documentation chapter](#arch-update-configuration-file) for more details.*
 
 ![cached-packages](https://github.com/Antiz96/arch-update/assets/53110319/7199bbf1-acd8-49a1-80eb-e9874b94fba6)
@@ -166,10 +167,10 @@ Post update, check for orphan/unused packages, old cached packages, pacnew/pacsa
 and pending kernel update and, if there are, offers to process them.
 
 Options:
--c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)
--n, --news     Display latest Arch News
--h, --help     Display this help message and exit
--V, --version  Display version information and exit
+-c, --check       Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)
+-n, --news [Num]  Display latest Arch News, you can optionally specify the number of Arch news to display with `--news [Num]` (e.g. `--news 10`)
+-h, --help        Display this help message and exit
+-V, --version     Display version information and exit
 
 Exit Codes:
 0  OK
@@ -198,8 +199,9 @@ The supported options are:
 - NoColor # Do not colorize output.
 - NoVersion # Do not show versions changes for packages when listing pending updates.
 - NoNews # Do not display Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
-- KeepOldPackages=Num # Number of old packages' versions to keep in pacman's cache. Defaults to 3.
-- KeepUninstalledPackages=Num # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
+- NewsNum=[Num] # Number of Arch news to display before updating and with the `-n/--news` option (see the `arch-update(1)` man page for more details). Defaults to 5.
+- KeepOldPackages=[Num] # Number of old packages' versions to keep in pacman's cache. Defaults to 3.
+- KeepUninstalledPackages=[Num] # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
 
 Options are case sensitive, so capital letters have to be respected.
 ```

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The supported options are:
 - NoColor # Do not colorize output.
 - NoVersion # Do not show versions changes for packages when listing pending updates.
 - NoNews # Do not display Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
-- NewsNum=[Num] # Number of Arch news to display before updating and with the `-n/--news` option (see the `arch-update(1)` man page for more details). Defaults to 5.
+- NewsNum=[Num] # Number of Arch news to display before updating and with the `-n/--news` option (see the arch-update(1) man page for more details). Defaults to 5.
 - KeepOldPackages=[Num] # Number of old packages' versions to keep in pacman's cache. Defaults to 3.
 - KeepUninstalledPackages=[Num] # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ After your read a news, `arch-update` will once again offers to display latest A
 Simply press "enter" without typing any number to proceed with update:
 
 *Arch news can be displayed at any time by running the `arch-update --news` command.*  
-*The number of Arch news to display before updating and with the `-n/--news` option defaults to 5 but can be customised with the `NewsNum=[Num]` option in the `arch-update.conf` configuration file.*   
+*The number of Arch news to display before updating and with the `-n/--news` option defaults to 5 but can be customised with the `NewsNum=[Num]` option in the `arch-update.conf` configuration file.*  
 *The Arch news listing/displaying can be skipped with the `NoNews`  option in the `arch-update.conf` configuration file.*  
 *Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.*  
 *See the [documentation chapter](#Documentation) for more details.*

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -42,9 +42,7 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .B \-n, \-\-news
 Display latest Arch news.
 .br
-The default number of Arch news displayed is 5.
-.br
-.RB "To modify the number of Arch news displayed, either specify the number as an argument (like so: " "arch-update --news 10" ") or set the " "NewsNum=[Num] " "option in " "arch-update.conf " "to modify it permanently (see the " "arch-update.conf(5) " "man page for more details)."
+.RB "The default number of Arch news displayed is 5 but you can specify another one as an argument, like so: " "arch-update --news 10" "."
 
 .TP
 .B \-v, \-\-version

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -42,11 +42,9 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .B \-n, \-\-news
 Display latest Arch news.
 .br
-.RB "The default number of Arch news displayed is " "5""."
+The default number of Arch news displayed is 5.
 .br
-.RB "To modify the number of Arch news displayed, either specify the number as an argument (like so: " "arch-update --news 10"")..."
-.br
-.RB "...or set the " "NewsNum=[Num] " "option in " "arch-update.conf " "to modify it permanently (see the " "arch-update.conf(5) " "man page for more details)."
+.RB "To modify the number of Arch news displayed, either specify the number as an argument (like so: " "arch-update --news 10" ") or set the " "NewsNum=[Num] " "option in " "arch-update.conf " "to modify it permanently (see the " "arch-update.conf(5) " "man page for more details)."
 
 .TP
 .B \-v, \-\-version

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -41,6 +41,12 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .TP
 .B \-n, \-\-news
 Display latest Arch news.
+.br
+.RB "The default number of Arch news displayed is " "5""."
+.br
+.RB "To modify the number of Arch news displayed, either specificy the number as an argument (like so: " "arch-update --news 10"")..."
+.br
+.RB "...or set the " "NewsNum=[Num] " "option in " "arch-update.conf " "to modify it permanently (see the " "arch-update.conf(5) " "man page for more details)."
 
 .TP
 .B \-v, \-\-version

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -44,7 +44,7 @@ Display latest Arch news.
 .br
 .RB "The default number of Arch news displayed is " "5""."
 .br
-.RB "To modify the number of Arch news displayed, either specificy the number as an argument (like so: " "arch-update --news 10"")..."
+.RB "To modify the number of Arch news displayed, either specify the number as an argument (like so: " "arch-update --news 10"")..."
 .br
 .RB "...or set the " "NewsNum=[Num] " "option in " "arch-update.conf " "to modify it permanently (see the " "arch-update.conf(5) " "man page for more details)."
 

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -30,11 +30,15 @@ Do not show versions changes for packages when listing pending updates.
 Do not display Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
 
 .TP
-.B KeepOldPackages=Num
+.B NewsNum=[Num]
+.RB "Number of Arch news to display before updating and with the " "-n/--news " "option (see the " "arch-update(1) " "man page for more details). Defaults to 5."
+
+.TP
+.B KeepOldPackages=[Num]
 Number of old packages' versions to keep in pacman's cache. Defaults to 3.
 
 .TP
-.B KeepUninstalledPackages=Num
+.B KeepUninstalledPackages=[Num]
 Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
 
 .SH SEE ALSO

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -42,9 +42,7 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 .B \-n, \-\-news
 Afficher les dernières Arch news.
 .br
-Le nombre par défaut de Arch news affichées est 5.
-.br
-.RB "Pour modifier le nombre de Arch news affichées, vous pouvez spécifier le nombre en tant qu'argument (comme ceci: " "arch-update --news 10" ") ou paramétrer l'option " "NewsNum=[Num] " "dans " "arch-update.conf " "pour le modifier de façon permanente (voir la page de man " "arch-update.conf(5) " "pour plus de détails)."
+.RB "Le nombre par défaut de Arch news affichées est 5 mais vous pouvez en spécifier un autre en tant qu'argument, comme ceci : " "arch-update --news 10" "."
 
 .TP
 .B \-v, \-\-version

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -41,6 +41,13 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 .TP
 .B \-n, \-\-news
 Afficher les dernières Arch news.
+.br
+.RB "Le nombre par défaut de Arch news affichées est " "5""."
+.br
+.RB "Pour modifier le nombre de Arch news affichées, vous pouvez spécifier le nombre en tant qu'argument (comme ceci: " "arch-update --news 10"")..."
+.br
+.RB "...or set the " "NewsNum=[Num] " "option in " "arch-update.conf " "to modify it permanently (see the " "arch-update.conf(5) " "man page for more details)."
+.RB "...ou paramétrer l'option " "NewsNum=[Num] " "dans " "arch-update.conf " "pour le modifier de façon permanente (voir la page de man " "arch-update.conf(5) " "pour plus de détails)."
 
 .TP
 .B \-v, \-\-version

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -42,12 +42,9 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 .B \-n, \-\-news
 Afficher les dernières Arch news.
 .br
-.RB "Le nombre par défaut de Arch news affichées est " "5""."
+Le nombre par défaut de Arch news affichées est 5.
 .br
-.RB "Pour modifier le nombre de Arch news affichées, vous pouvez spécifier le nombre en tant qu'argument (comme ceci: " "arch-update --news 10"")..."
-.br
-.RB "...or set the " "NewsNum=[Num] " "option in " "arch-update.conf " "to modify it permanently (see the " "arch-update.conf(5) " "man page for more details)."
-.RB "...ou paramétrer l'option " "NewsNum=[Num] " "dans " "arch-update.conf " "pour le modifier de façon permanente (voir la page de man " "arch-update.conf(5) " "pour plus de détails)."
+.RB "Pour modifier le nombre de Arch news affichées, vous pouvez spécifier le nombre en tant qu'argument (comme ceci: " "arch-update --news 10" ") ou paramétrer l'option " "NewsNum=[Num] " "dans " "arch-update.conf " "pour le modifier de façon permanente (voir la page de man " "arch-update.conf(5) " "pour plus de détails)."
 
 .TP
 .B \-v, \-\-version

--- a/doc/man/fr/arch-update.conf.5
+++ b/doc/man/fr/arch-update.conf.5
@@ -30,11 +30,15 @@ Ne pas afficher les modifications de versions des paquets lors du listing des mi
 Ne pas afficher les Arch news. Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.
 
 .TP
-.B KeepOldPackages=Num
+.B NewsNum=[Num]
+.RB "Nombre de Arch news à afficher avant la mise à jour et avec l'option " "-n/--news " "(voir la page de man " "arch-update(1) " "pour plus de détails). La valeur par défaut est 5."
+
+.TP
+.B KeepOldPackages=[Num]
 Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
 
 .TP
-.B KeepUninstalledPackages=Num
+.B KeepUninstalledPackages=[Num]
 Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
 
 .SH VOIR AUSSI

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,48 +16,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:88
+#: src/script/arch-update.sh:94
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/script/arch-update.sh:94
+#: src/script/arch-update.sh:100
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/script/arch-update.sh:104
+#: src/script/arch-update.sh:110
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:126
+#: src/script/arch-update.sh:132
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:128
+#: src/script/arch-update.sh:134
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:129
+#: src/script/arch-update.sh:135
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:130
+#: src/script/arch-update.sh:136
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:131
+#: src/script/arch-update.sh:137
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -65,351 +65,358 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:133
+#: src/script/arch-update.sh:139
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:134
+#: src/script/arch-update.sh:140
 #, sh-format
 msgid ""
-"  -c, --check    Check for available updates, send a desktop notification "
+"  -c, --check       Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
 
-#: src/script/arch-update.sh:135
+#: src/script/arch-update.sh:141
 #, sh-format
-msgid "  -h, --help     Display this help message and exit"
+msgid ""
+"  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
+"number of Arch news to display with '--news [Num]' (e.g. '--news 10')"
 msgstr ""
 
-#: src/script/arch-update.sh:136
+#: src/script/arch-update.sh:142
 #, sh-format
-msgid "  -V, --version  Display version information and exit"
+msgid "  -h, --help        Display this help message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:138
+#: src/script/arch-update.sh:143
+#, sh-format
+msgid "  -V, --version     Display version information and exit"
+msgstr ""
+
+#: src/script/arch-update.sh:145
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:139
+#: src/script/arch-update.sh:146
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:150
+#: src/script/arch-update.sh:157
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:206
+#: src/script/arch-update.sh:213
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:208
+#: src/script/arch-update.sh:215
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:244
+#: src/script/arch-update.sh:251
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:249
+#: src/script/arch-update.sh:256
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:254
+#: src/script/arch-update.sh:261
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:260
+#: src/script/arch-update.sh:267
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:263
+#: src/script/arch-update.sh:270
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:266 src/script/arch-update.sh:396
-#: src/script/arch-update.sh:429 src/script/arch-update.sh:471
-#: src/script/arch-update.sh:538 src/script/arch-update.sh:568
+#: src/script/arch-update.sh:273 src/script/arch-update.sh:400
+#: src/script/arch-update.sh:433 src/script/arch-update.sh:475
+#: src/script/arch-update.sh:542 src/script/arch-update.sh:572
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/script/arch-update.sh:266 src/script/arch-update.sh:396
-#: src/script/arch-update.sh:429 src/script/arch-update.sh:471
-#: src/script/arch-update.sh:538 src/script/arch-update.sh:568
+#: src/script/arch-update.sh:273 src/script/arch-update.sh:400
+#: src/script/arch-update.sh:433 src/script/arch-update.sh:475
+#: src/script/arch-update.sh:542 src/script/arch-update.sh:572
 #, sh-format
 msgid "y"
 msgstr ""
 
-#: src/script/arch-update.sh:270
+#: src/script/arch-update.sh:277
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:287
+#: src/script/arch-update.sh:294
 #, sh-format
 msgid "Arch News:"
 msgstr ""
 
-#: src/script/arch-update.sh:292
+#: src/script/arch-update.sh:299
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:304
+#: src/script/arch-update.sh:311
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr ""
 
-#: src/script/arch-update.sh:307
+#: src/script/arch-update.sh:314
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:320
+#: src/script/arch-update.sh:326
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:321
+#: src/script/arch-update.sh:327
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:322
+#: src/script/arch-update.sh:328
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:323
+#: src/script/arch-update.sh:329
 #, sh-format
 msgid "URL:"
 msgstr ""
 
-#: src/script/arch-update.sh:339
+#: src/script/arch-update.sh:343
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:344 src/script/arch-update.sh:356
-#: src/script/arch-update.sh:367
+#: src/script/arch-update.sh:348 src/script/arch-update.sh:360
+#: src/script/arch-update.sh:371
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:351
+#: src/script/arch-update.sh:355
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:363
+#: src/script/arch-update.sh:367
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:378
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:386
+#: src/script/arch-update.sh:390
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:390
+#: src/script/arch-update.sh:394
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:392
+#: src/script/arch-update.sh:396
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:398
+#: src/script/arch-update.sh:402
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:402 src/script/arch-update.sh:435
-#: src/script/arch-update.sh:478 src/script/arch-update.sh:488
-#: src/script/arch-update.sh:498 src/script/arch-update.sh:507
+#: src/script/arch-update.sh:406 src/script/arch-update.sh:439
+#: src/script/arch-update.sh:482 src/script/arch-update.sh:492
+#: src/script/arch-update.sh:502 src/script/arch-update.sh:511
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:405 src/script/arch-update.sh:438
+#: src/script/arch-update.sh:409 src/script/arch-update.sh:442
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:410 src/script/arch-update.sh:442
-#: src/script/arch-update.sh:515
+#: src/script/arch-update.sh:414 src/script/arch-update.sh:446
+#: src/script/arch-update.sh:519
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:414
+#: src/script/arch-update.sh:418
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:419
+#: src/script/arch-update.sh:423
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:423
+#: src/script/arch-update.sh:427
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:425
+#: src/script/arch-update.sh:429
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:431
+#: src/script/arch-update.sh:435
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:446
+#: src/script/arch-update.sh:450
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:463
+#: src/script/arch-update.sh:467
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:464
+#: src/script/arch-update.sh:468
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:466
+#: src/script/arch-update.sh:470
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:467
+#: src/script/arch-update.sh:471
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:474 src/script/arch-update.sh:494
+#: src/script/arch-update.sh:478 src/script/arch-update.sh:498
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:484 src/script/arch-update.sh:503
+#: src/script/arch-update.sh:488 src/script/arch-update.sh:507
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:519
+#: src/script/arch-update.sh:523
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:528
+#: src/script/arch-update.sh:532
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:532
+#: src/script/arch-update.sh:536
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:534
+#: src/script/arch-update.sh:538
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:540
+#: src/script/arch-update.sh:544
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:544
+#: src/script/arch-update.sh:548
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:547
+#: src/script/arch-update.sh:551
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:551
+#: src/script/arch-update.sh:555
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:564
+#: src/script/arch-update.sh:568
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:565
+#: src/script/arch-update.sh:569
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:570
+#: src/script/arch-update.sh:574
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:574
+#: src/script/arch-update.sh:578
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:582
+#: src/script/arch-update.sh:586
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:586
+#: src/script/arch-update.sh:590
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:599
+#: src/script/arch-update.sh:603
 #, sh-format
 msgid ""
 "NoNews option detected\\nPlease, keep in mind that users are expected to "

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,24 +16,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:88
+#: src/script/arch-update.sh:94
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/script/arch-update.sh:94
+#: src/script/arch-update.sh:100
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Appuyez sur \"entrée\" pour quitter "
 
-#: src/script/arch-update.sh:104
+#: src/script/arch-update.sh:110
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 "Une méthode d'élévation de privilège est requise\\nVeuillez installer sudo ou doas\\n"
 
-#: src/script/arch-update.sh:126
+#: src/script/arch-update.sh:132
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
@@ -42,12 +42,12 @@ msgstr ""
 "Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les "
 "tâches importantes d'avant/après mise à jour."
 
-#: src/script/arch-update.sh:128
+#: src/script/arch-update.sh:134
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr "Lancez ${name} pour exécuter la fonction principale 'update' :"
 
-#: src/script/arch-update.sh:129
+#: src/script/arch-update.sh:135
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
@@ -56,14 +56,14 @@ msgstr ""
 "Afficher la liste des paquets disponibles pour mise à jour, puis demander la confirmation de l'utilisateur "
 "pour procéder à l'installation."
 
-#: src/script/arch-update.sh:130
+#: src/script/arch-update.sh:136
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 "Avant d'effectuer la mise à jour, propose d'afficher les dernières news d'Arch Linux."
 
-#: src/script/arch-update.sh:131
+#: src/script/arch-update.sh:137
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -74,36 +74,45 @@ msgstr ""
 "pacsave et de mise à jour du noyau en attente et, s'il y en a, "
 "propose de les traiter."
 
-#: src/script/arch-update.sh:133
+#: src/script/arch-update.sh:139
 #, sh-format
 msgid "Options:"
 msgstr "Options :"
 
-#: src/script/arch-update.sh:134
+#: src/script/arch-update.sh:140
 #, sh-format
 msgid ""
-"  -c, --check    Check for available updates, send a desktop notification "
+"  -c, --check       Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
-" -c, --check    Vérifier les mises à jour disponibles, envoyer une notification de bureau "
+" -c, --check       Vérifier les mises à jour disponibles, envoyer une notification de bureau "
 "contenant le nombre de mises à jour disponibles (si libnotify est installé)"
 
-#: src/script/arch-update.sh:135
+#: src/script/arch-update.sh:141
 #, sh-format
-msgid "  -h, --help     Display this help message and exit"
-msgstr " -h, --help     Afficher ce message d'aide et quitter"
+msgid ""
+"  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
+"number of Arch news to display with '--news [Num]' (e.g. '--news 10')"
+msgstr ""
+"  -n, --news [Num]  Afficher les dernières Arch news, vous pouvez optionellement spécifier le "
+"nombre de Arch news à afficher avec '--news [Num]' (e.g. '--news 10')"
 
-#: src/script/arch-update.sh:136
+#: src/script/arch-update.sh:142
+#, sh-format
+msgid "  -h, --help        Display this help message and exit"
+msgstr " -h, --help        Afficher ce message d'aide et quitter"
+
+#: src/script/arch-update.sh:143
 #, sh-format
 msgid "  -V, --version  Display version information and exit"
 msgstr " -V, --version  Afficher les informations de version et quitter"
 
-#: src/script/arch-update.sh:138
+#: src/script/arch-update.sh:145
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr "Pour plus d'informations, consultez la page de manuel ${name}(1)."
 
-#: src/script/arch-update.sh:139
+#: src/script/arch-update.sh:146
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
@@ -112,7 +121,7 @@ msgstr ""
 "Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration ${name}.conf, "
 "voir la page de manuel ${name}.conf(5)."
 
-#: src/script/arch-update.sh:150
+#: src/script/arch-update.sh:157
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
@@ -121,109 +130,109 @@ msgstr ""
 "${name}: option invalide -- '${option}'\\nEssayez '${name} --help' pour plus "
 "d'informations."
 
-#: src/script/arch-update.sh:206
+#: src/script/arch-update.sh:213
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} mise à jour disponible"
 
-#: src/script/arch-update.sh:208
+#: src/script/arch-update.sh:215
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/script/arch-update.sh:244
+#: src/script/arch-update.sh:251
 #, sh-format
 msgid "Packages:"
 msgstr "Paquets :"
 
-#: src/script/arch-update.sh:249
+#: src/script/arch-update.sh:256
 #, sh-format
 msgid "AUR Packages:"
 msgstr "Paquets AUR :"
 
-#: src/script/arch-update.sh:254
+#: src/script/arch-update.sh:261
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/script/arch-update.sh:260
+#: src/script/arch-update.sh:267
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
 
-#: src/script/arch-update.sh:263
+#: src/script/arch-update.sh:270
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:266 src/script/arch-update.sh:396
-#: src/script/arch-update.sh:429 src/script/arch-update.sh:471
-#: src/script/arch-update.sh:538 src/script/arch-update.sh:568
+#: src/script/arch-update.sh:273 src/script/arch-update.sh:400
+#: src/script/arch-update.sh:433 src/script/arch-update.sh:475
+#: src/script/arch-update.sh:542 src/script/arch-update.sh:572
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/script/arch-update.sh:266 src/script/arch-update.sh:396
-#: src/script/arch-update.sh:429 src/script/arch-update.sh:471
-#: src/script/arch-update.sh:538 src/script/arch-update.sh:568
+#: src/script/arch-update.sh:273 src/script/arch-update.sh:400
+#: src/script/arch-update.sh:433 src/script/arch-update.sh:475
+#: src/script/arch-update.sh:542 src/script/arch-update.sh:572
 #, sh-format
 msgid "y"
 msgstr "o"
 
-#: src/script/arch-update.sh:270
+#: src/script/arch-update.sh:277
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
 
-#: src/script/arch-update.sh:287
+#: src/script/arch-update.sh:294
 #, sh-format
 msgid "Arch News:"
 msgstr "Arch News :"
 
-#: src/script/arch-update.sh:292
+#: src/script/arch-update.sh:299
 #, sh-format
 msgid "[NEW]"
 msgstr "[NOUVEAU]"
 
-#: src/script/arch-update.sh:304
+#: src/script/arch-update.sh:311
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour quitter) :"
 
-#: src/script/arch-update.sh:307
+#: src/script/arch-update.sh:314
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour procéder à la mise à jour) :"
 
-#: src/script/arch-update.sh:320
+#: src/script/arch-update.sh:326
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/script/arch-update.sh:321
+#: src/script/arch-update.sh:327
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/script/arch-update.sh:322
+#: src/script/arch-update.sh:328
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:323
+#: src/script/arch-update.sh:329
 #, sh-format
 msgid "URL:"
 msgstr "URL :"
 
-#: src/script/arch-update.sh:339
+#: src/script/arch-update.sh:343
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:344 src/script/arch-update.sh:356
-#: src/script/arch-update.sh:367
+#: src/script/arch-update.sh:348 src/script/arch-update.sh:360
+#: src/script/arch-update.sh:371
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -232,27 +241,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:351
+#: src/script/arch-update.sh:355
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:363
+#: src/script/arch-update.sh:367
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:378
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:386
+#: src/script/arch-update.sh:390
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:390
+#: src/script/arch-update.sh:394
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -261,7 +270,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:392
+#: src/script/arch-update.sh:396
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -270,14 +279,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:398
+#: src/script/arch-update.sh:402
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:402 src/script/arch-update.sh:435
-#: src/script/arch-update.sh:478 src/script/arch-update.sh:488
-#: src/script/arch-update.sh:498 src/script/arch-update.sh:507
+#: src/script/arch-update.sh:406 src/script/arch-update.sh:439
+#: src/script/arch-update.sh:482 src/script/arch-update.sh:492
+#: src/script/arch-update.sh:502 src/script/arch-update.sh:511
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -286,118 +295,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:405 src/script/arch-update.sh:438
+#: src/script/arch-update.sh:409 src/script/arch-update.sh:442
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:410 src/script/arch-update.sh:442
-#: src/script/arch-update.sh:515
+#: src/script/arch-update.sh:414 src/script/arch-update.sh:446
+#: src/script/arch-update.sh:519
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:414
+#: src/script/arch-update.sh:418
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:419
+#: src/script/arch-update.sh:423
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:423
+#: src/script/arch-update.sh:427
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:425
+#: src/script/arch-update.sh:429
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:431
+#: src/script/arch-update.sh:435
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:446
+#: src/script/arch-update.sh:450
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:463
+#: src/script/arch-update.sh:467
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:464
+#: src/script/arch-update.sh:468
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:466
+#: src/script/arch-update.sh:470
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:467
+#: src/script/arch-update.sh:471
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:474 src/script/arch-update.sh:494
+#: src/script/arch-update.sh:478 src/script/arch-update.sh:498
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:484 src/script/arch-update.sh:503
+#: src/script/arch-update.sh:488 src/script/arch-update.sh:507
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:519
+#: src/script/arch-update.sh:523
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:528
+#: src/script/arch-update.sh:532
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:532
+#: src/script/arch-update.sh:536
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:534
+#: src/script/arch-update.sh:538
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:540
+#: src/script/arch-update.sh:544
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:544
+#: src/script/arch-update.sh:548
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:547
+#: src/script/arch-update.sh:551
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:551
+#: src/script/arch-update.sh:555
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:564
+#: src/script/arch-update.sh:568
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -406,17 +415,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:565
+#: src/script/arch-update.sh:569
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:570
+#: src/script/arch-update.sh:574
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr "Redémarrage dans 5 secondes...\\nAppuyez sur ctrl+c pour annuler"
 
-#: src/script/arch-update.sh:574
+#: src/script/arch-update.sh:578
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -425,7 +434,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:582
+#: src/script/arch-update.sh:586
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -434,12 +443,12 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:586
+#: src/script/arch-update.sh:590
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"
 
-#: src/script/arch-update.sh:599
+#: src/script/arch-update.sh:603
 #, sh-format
 msgid ""
 "NoNews option detected\\nPlease, keep in mind that users are expected to "

--- a/po/fr.po
+++ b/po/fr.po
@@ -85,7 +85,7 @@ msgid ""
 "  -c, --check       Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
-" -c, --check       Vérifier les mises à jour disponibles, envoyer une notification de bureau "
+"  -c, --check       Vérifier les mises à jour disponibles, envoyer une notification de bureau "
 "contenant le nombre de mises à jour disponibles (si libnotify est installé)"
 
 #: src/script/arch-update.sh:141
@@ -100,7 +100,7 @@ msgstr ""
 #: src/script/arch-update.sh:142
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
-msgstr " -h, --help        Afficher ce message d'aide et quitter"
+msgstr "  -h, --help        Afficher ce message d'aide et quitter"
 
 #: src/script/arch-update.sh:143
 #, sh-format

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -31,6 +31,12 @@ if grep -Eq '^[[:space:]]*NoNews[[:space:]]*$' "${XDG_CONFIG_HOME:-${HOME}/.conf
 	no_news="y"
 fi
 
+if grep -Eq '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf" 2> /dev/null; then
+	news_num=$(grep -E '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
+else
+	news_num="5"
+fi
+
 if grep -Eq '^[[:space:]]*KeepOldPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf" 2> /dev/null; then
 	old_packages_num=$(grep -E '^[[:space:]]*KeepOldPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 else
@@ -281,8 +287,8 @@ list_news() {
 
 	while [ "${redo}" = "y" ]; do
 		news=$(curl -Ls https://www.archlinux.org/news)
-		news_titles=$(echo "${news}" | htmlq -a title a | grep ^"View:" | sed s/View:\ //g | head -5)
-		mapfile -t news_dates < <(echo "${news}" | htmlq td | grep -v "class" | grep "[0-9]" | sed "s/<[^>]*>//g" | head -5 | xargs -I{} date -d "{}" "+%s")
+		news_titles=$(echo "${news}" | htmlq -a title a | grep ^"View:" | sed "s/View:\ //g" | head -"${news_num}")
+		mapfile -t news_dates < <(echo "${news}" | htmlq td | grep -v "class" | grep "[0-9]" | sed "s/<[^>]*>//g" | head -"${news_num}" | xargs -I{} date -d "{}" "+%s")
 
 		echo
 		main_msg "$(eval_gettext "Arch News:")"
@@ -309,25 +315,22 @@ list_news() {
 			;;
 		esac
 
-		case "${answer}" in
-			1|2|3|4|5)
-				news_selected=$(sed -n "${answer}"p <<< "${news_titles}")
-				news_path=$(echo "${news_selected}" | sed s/\ -//g | sed s/\ /-/g | sed s/[.]//g | sed s/=//g | sed s/\>//g | sed s/\<//g | sed s/\`//g | sed s/://g | sed s/+//g | sed s/[[]//g | sed s/]//g | sed s/,//g | sed s/\(//g | sed s/\)//g | sed s/[/]//g | sed s/@//g | sed s/\'//g | sed s/--/-/g | awk '{print tolower($0)}')
-				news_url="https://www.archlinux.org/news/${news_path}"
-				news_content=$(curl -Ls "${news_url}")
-				news_author=$(echo "${news_content}" | htmlq -t .article-info | cut -f3- -d " ")
-				news_date=$(echo "${news_content}" | htmlq -t .article-info | cut -f1 -d " ")
-				news_article=$(echo "${news_content}" | htmlq -t .article-content)
-				title_tag="$(eval_gettext "Title:")"
-				author_tag="$(eval_gettext "Author:")"
-				publication_date_tag="$(eval_gettext "Publication date:")"
-				url_tag="$(eval_gettext "URL:")"
-				echo -e "\n${blue}---${color_off}\n${bold}${title_tag}${color_off} ${news_selected}\n${bold}${author_tag}${color_off} ${news_author}\n${bold}${publication_date_tag}${color_off} ${news_date}\n${bold}${url_tag}${color_off} ${news_url}\n${blue}---${color_off}\n\n${news_article}\n" && continue_msg
-			;;
-			*)
-				redo="n"
-			;;
-		esac
+		if [ "${answer}" -le "${news_num}" ] 2> /dev/null && [ "${answer}" -gt "0" ]; then
+			news_selected=$(sed -n "${answer}"p <<< "${news_titles}")
+			news_path=$(echo "${news_selected}" | sed s/\ -//g | sed s/\ /-/g | sed s/[.]//g | sed s/=//g | sed s/\>//g | sed s/\<//g | sed s/\`//g | sed s/://g | sed s/+//g | sed s/[[]//g | sed s/]//g | sed s/,//g | sed s/\(//g | sed s/\)//g | sed s/[/]//g | sed s/@//g | sed s/\'//g | sed s/--/-/g | awk '{print tolower($0)}')
+			news_url="https://www.archlinux.org/news/${news_path}"
+			news_content=$(curl -Ls "${news_url}")
+			news_author=$(echo "${news_content}" | htmlq -t .article-info | cut -f3- -d " ")
+			news_date=$(echo "${news_content}" | htmlq -t .article-info | cut -f1 -d " ")
+			news_article=$(echo "${news_content}" | htmlq -t .article-content)
+			title_tag="$(eval_gettext "Title:")"
+			author_tag="$(eval_gettext "Author:")"
+			publication_date_tag="$(eval_gettext "Publication date:")"
+			url_tag="$(eval_gettext "URL:")"
+			echo -e "\n${blue}---${color_off}\n${bold}${title_tag}${color_off} ${news_selected}\n${bold}${author_tag}${color_off} ${news_author}\n${bold}${publication_date_tag}${color_off} ${news_date}\n${bold}${url_tag}${color_off} ${news_url}\n${blue}---${color_off}\n\n${news_article}\n" && continue_msg
+		else
+			redo="n"
+		fi
 	done
 }
 
@@ -611,6 +614,9 @@ case "${option}" in
 		check
 	;;
 	-n|--news)
+		if [ "${2}" -gt 0 ] 2> /dev/null; then
+			news_num="${2}"
+		fi
 		list_news
 	;;
 	-h|--help)

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -131,9 +131,10 @@ $(eval_gettext "Before performing the update, offer to display the latest Arch L
 $(eval_gettext "Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files and pending kernel update and, if there are, offers to process them.")
 
 $(eval_gettext "Options:")
-$(eval_gettext "  -c, --check    Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)")
-$(eval_gettext "  -h, --help     Display this help message and exit")
-$(eval_gettext "  -V, --version  Display version information and exit")
+$(eval_gettext "  -c, --check       Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)")
+$(eval_gettext "  -n, --news [Num]  Display latest Arch News, you can optionally specify the number of Arch news to display with '--news [Num]' (e.g. '--news 10')")
+$(eval_gettext "  -h, --help        Display this help message and exit")
+$(eval_gettext "  -V, --version     Display version information and exit")
 
 $(eval_gettext "For more information, see the \${name}(1) man page.")
 $(eval_gettext "Certain options can be enabled/disabled or modified via the \${name}.conf configuration file, see the \${name}.conf(5) man page.")

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -138,7 +138,7 @@ $(eval_gettext "Post update, check for orphan/unused packages, old cached packag
 
 $(eval_gettext "Options:")
 $(eval_gettext "  -c, --check       Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)")
-$(eval_gettext "  -n, --news [Num]  Display latest Arch News, you can optionally specify the number of Arch news to display with '--news [Num]' (e.g. '--news 10')")
+$(eval_gettext "  -n, --news [Num]  Display latest Arch news, you can optionally specify the number of Arch news to display with '--news [Num]' (e.g. '--news 10')")
 $(eval_gettext "  -h, --help        Display this help message and exit")
 $(eval_gettext "  -V, --version     Display version information and exit")
 


### PR DESCRIPTION
This PR aims to bring options allowing to customise the number of Arch news to display before updating and with the `-n/--news` option.

Users can now optionally specify the number of Arch news to display for the current execution when using the `-n/--news` option, like so: `arch-update --news 10`.
Users can permanently set the number of Arch news to display before updating and with the `-n/--news` option by setting the `NewsNum=[Num]` option in `arch-update.conf`, like so: `NewsNum=10`

The default value is 5.

Closes #111