### PR TITLE
Only display Arch news if a new one has been published since the last run

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -110,7 +110,7 @@ Lorsque l'on clique sur l'icône, cela lance la série de fonctions adéquates p
 ![listing-packages](https://github.com/Antiz96/arch-update/assets/53110319/43a990c8-ed93-420f-8c46-d50d60bff03f)
 
 Une fois que vous avez donné la confirmation pour procéder, `arch-update` propose d'afficher les dernières Arch news.  
-Par défaut, les Arch news sont seulement affichées si au moins une nouvelle news a été publiée depuis la dernière exécution. Les Arch news publiées depuis la dernière exécution sont étiquetées comme `[NOUVEAU]`.  
+Par défaut, les Arch news sont seulement affichées si au moins une nouvelle news a été publiée depuis la dernière exécution. Les Arch news publiées depuis la dernière exécution ou à la même date sont étiquetées comme `[NOUVEAU]`.  
 Sélectionnez la news à lire en tapant le numéro associé.  
 Après avoir lu une news, `arch-update` vous proposera à nouveau d'afficher les dernières Arch news, afin que vous puissiez lire plusieurs news à la fois.  
 Appuyez simplement sur « Entrée » sans saisir de chiffre pour procéder à la mise à jour :

--- a/README-fr.md
+++ b/README-fr.md
@@ -110,14 +110,14 @@ Lorsque l'on clique sur l'icône, cela lance la série de fonctions adéquates p
 ![listing-packages](https://github.com/Antiz96/arch-update/assets/53110319/43a990c8-ed93-420f-8c46-d50d60bff03f)
 
 Une fois que vous avez donné la confirmation pour procéder, `arch-update` propose d'afficher les dernières Arch news.  
-Les Arch news publiées au cours des 15 derniers jours sont étiquetées comme « [NOUVEAU] ».  
+Par défaut, les Arch news sont seulement affichées si au moins une nouvelle news a été publiée depuis la dernière exécution. Les Arch news publiées depuis la dernière exécution sont étiquetées comme `[NOUVEAU]`.  
 Sélectionnez la news à lire en tapant le numéro associé.  
 Après avoir lu une news, `arch-update` vous proposera à nouveau d'afficher les dernières Arch news, afin que vous puissiez lire plusieurs news à la fois.  
 Appuyez simplement sur « Entrée » sans saisir de chiffre pour procéder à la mise à jour :
 
 *Les Arch news peuvent être affichées à tout moment en exécutant la commande `arch-update --news`.*  
 *Le nombre par défaut de Arch news à afficher avant la mise à jour et avec l'option `-n/--news` est de 5 mais il peut être modifié avec l'option `NewsNum=[Num]` dans le fichier de configuration `arch-update.conf`.*  
-*Le listing/affichage des Arch news peut être ignoré avec l'option `NoNews` dans le fichier de configuration `arch-update.conf`.*  
+*Les Arch news peuvent être systématiquement affichées avant la mise à jour, peu importe s'il y en a une nouvelle depuis la dernière exécution ou non, en paramétrant l'option `AlwaysShowNews` dans le fichier de configuration `arch-update.conf`*  
 *Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.*  
 *Voir le [chapitre de documentation](#Documentation) pour plus de détails.*
 
@@ -200,7 +200,7 @@ Les options prises en charge sont :
 
 - NoColor # Ne pas coloriser la sortie.
 - NoVersion # Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente.
-- NoNews # Ne pas afficher les Arch news. Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.
+- AlwaysShowNews # Toujours afficher les Arch news avant de mettre à jour, peu importe s'il y en a une nouvelle depuis la dernière exécution ou non.
 - NewsNum=[Num] # Nombre de Arch news à affcher avant la mise à jour et avec l'option `-n/--news` (voir la page de manuel arch-update(1) pour plus de details). La valeur par défaut est 5.
 - KeepOldPackages=[Num] # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
 - KeepUninstalledPackages=[Num] # Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.

--- a/README.md
+++ b/README.md
@@ -108,15 +108,14 @@ When the icon is clicked, it launches the relevant series of functions to perfor
 ![listing-packages](https://github.com/Antiz96/arch-update/assets/53110319/43a990c8-ed93-420f-8c46-d50d60bff03f)
 
 Once you gave the confirmation to proceed, `arch-update` offers to display latest Arch Linux news.  
-Arch news that have been published within the last 15 days are tagged as `[NEW]`.  
+By default, Arch news are only displayed if at least a new one has been published since the last run. Arch news published since the last run are tagged as `[NEW]`.  
 Select which news to read by typing its associated number.  
 After your read a news, `arch-update` will once again offers to display latest Arch Linux news, so you can read multiple news at once.  
 Simply press "enter" without typing any number to proceed with update:
 
 *Arch news can be displayed at any time by running the `arch-update --news` command.*  
 *The number of Arch news to display before updating and with the `-n/--news` option defaults to 5 but can be customised with the `NewsNum=[Num]` option in the `arch-update.conf` configuration file.*  
-*The Arch news listing/displaying can be skipped with the `NoNews`  option in the `arch-update.conf` configuration file.*  
-*Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.*  
+*Arch news can be displayed everytime before updating, regardless of whether there's a new one since the last run or not, by setting the `AlwaysShowNews` option in the `arch-update.conf` configuration file.*  
 *See the [documentation chapter](#Documentation) for more details.*
 
 ![list-news](https://github.com/Antiz96/arch-update/assets/53110319/b6883ec4-8c44-4b97-86d9-4d0a304b748b)
@@ -198,7 +197,7 @@ The supported options are:
 
 - NoColor # Do not colorize output.
 - NoVersion # Do not show versions changes for packages when listing pending updates.
-- NoNews # Do not display Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
+- AlwaysShowNews # Always display Arch news before updating, regardless of whether there's a new one since the last run or not.
 - NewsNum=[Num] # Number of Arch news to display before updating and with the `-n/--news` option (see the arch-update(1) man page for more details). Defaults to 5.
 - KeepOldPackages=[Num] # Number of old packages' versions to keep in pacman's cache. Defaults to 3.
 - KeepUninstalledPackages=[Num] # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Simply press "enter" without typing any number to proceed with update:
 
 *Arch news can be displayed at any time by running the `arch-update --news` command.*  
 *The number of Arch news to display before updating and with the `-n/--news` option defaults to 5 but can be customised with the `NewsNum=[Num]` option in the `arch-update.conf` configuration file.*  
-*Arch news can be displayed everytime before updating, regardless of whether there's a new one since the last run or not, by setting the `AlwaysShowNews` option in the `arch-update.conf` configuration file.*  
+*Arch news can be displayed every time before updating, regardless of whether there's a new one since the last run or not, by setting the `AlwaysShowNews` option in the `arch-update.conf` configuration file.*  
 *See the [documentation chapter](#Documentation) for more details.*
 
 ![list-news](https://github.com/Antiz96/arch-update/assets/53110319/b6883ec4-8c44-4b97-86d9-4d0a304b748b)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ When the icon is clicked, it launches the relevant series of functions to perfor
 ![listing-packages](https://github.com/Antiz96/arch-update/assets/53110319/43a990c8-ed93-420f-8c46-d50d60bff03f)
 
 Once you gave the confirmation to proceed, `arch-update` offers to display latest Arch Linux news.  
-By default, Arch news are only displayed if at least a new one has been published since the last run. Arch news published since the last run are tagged as `[NEW]`.  
+By default, Arch news are only displayed if at least a new one has been published since the last run. Arch news published since the last run or at the same date are tagged as `[NEW]`.  
 Select which news to read by typing its associated number.  
 After your read a news, `arch-update` will once again offers to display latest Arch Linux news, so you can read multiple news at once.  
 Simply press "enter" without typing any number to proceed with update:

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -18,7 +18,7 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .br
 .RB "It also supports AUR packages update (if " "yay " "or " "paru " "is installed) and Flatpak packages update (if " "flatpak " "is installed)."
 .br
-.RB "Before performing the update, it offers to display the latest Arch Linux news to the user. By default, Arch news are only displayed if at least a new one has been published since the last run. Arch news published since the last run are tagged as '[NEW]'."
+.RB "Before performing the update, it offers to display the latest Arch Linux news to the user. By default, Arch news are only displayed if at least a new one has been published since the last run. Arch news published since the last run or at the same date are tagged as '[NEW]'."
 .br
 .RB "It also checks for orphan packages, unused Flatpak packages, old and/or uninstalled cached packages in pacman's cache, pacnew/pacsave files and pending kernel update requiring a reboot to be applied and, if there are, offers to process them."
 .br

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -18,7 +18,7 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .br
 .RB "It also supports AUR packages update (if " "yay " "or " "paru " "is installed) and Flatpak packages update (if " "flatpak " "is installed)."
 .br
-.RB "Before performing the update, it offers to display the latest Arch Linux news to the user. Arch news that have been published within the last 15 days are tagged as '[NEW]'."
+.RB "Before performing the update, it offers to display the latest Arch Linux news to the user. By default, Arch news are only displayed if at least a new one has been published since the last run. Arch news published since the last run are tagged as '[NEW]'."
 .br
 .RB "It also checks for orphan packages, unused Flatpak packages, old and/or uninstalled cached packages in pacman's cache, pacnew/pacsave files and pending kernel update requiring a reboot to be applied and, if there are, offers to process them."
 .br
@@ -42,7 +42,7 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .B \-n, \-\-news
 Display latest Arch news.
 .br
-.RB "The default number of Arch news displayed is 5 but you can specify another one as an argument, like so: " "arch-update --news 10" "."
+.RB "You can optionally specify how much Arch news to display as an argument, like so: " "arch-update --news 10" ". Defaults to 5."
 
 .TP
 .B \-v, \-\-version

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE.CONF" "5" "January 2024" "Arch-Update 1.11.0" "Arch-Update Manual"
+.TH "ARCH-UPDATE.CONF" "5" "February 2024" "Arch-Update 1.11.0" "Arch-Update Manual"
 
 .SH NAME
 arch-update.conf \- arch-update configuration file.
@@ -26,8 +26,8 @@ Do not colorize output.
 Do not show versions changes for packages when listing pending updates.
 
 .TP
-.B NoNews
-Do not display Arch news. Note that using this option will generate a warning message as a reminder that users are expected to regularly check Arch news.
+.B AlwaysShowNews
+Always display Arch news before updating, regardless of whether there's a new one since the last run or not.
 
 .TP
 .B NewsNum=[Num]

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -18,7 +18,7 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 .br
 .RB "Supporte les mises à jour des paquets AUR (si " "yay " "ou " "paru " "est installé) et des paquets Flatpak (si " "flatpak " "est installé)."
 .br
-.RB "Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news à l'utilisateur. Par défaut, les Arch news sont seulement affichées si au moins une nouvelle news a été publiée depuis la dernière exécution. Les Arch news publiées depuis la dernière exécution sont étiquetées comme '[NOUVEAU]'."
+.RB "Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news à l'utilisateur. Par défaut, les Arch news sont seulement affichées si au moins une nouvelle news a été publiée depuis la dernière exécution. Les Arch news publiées depuis la dernière exécution ou à la même date sont étiquetées comme '[NOUVEAU]'."
 .br
 .RB "Arch-Update vérifie aussi la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache, de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, propose de les traiter."
 .br

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -18,7 +18,7 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 .br
 .RB "Supporte les mises à jour des paquets AUR (si " "yay " "ou " "paru " "est installé) et des paquets Flatpak (si " "flatpak " "est installé)."
 .br
-.RB "Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news à l'utilisateur. Les Arch news publiées au cours des 15 derniers jours sont étiquetées comme '[NEW]'."
+.RB "Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news à l'utilisateur. Par défaut, les Arch news sont seulement affichées si au moins une nouvelle news a été publiée depuis la dernière exécution. Les Arch news publiées depuis la dernière exécution sont étiquetées comme '[NOUVEAU]'."
 .br
 .RB "Arch-Update vérifie aussi la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache, de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, propose de les traiter."
 .br
@@ -42,7 +42,7 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 .B \-n, \-\-news
 Afficher les dernières Arch news.
 .br
-.RB "Le nombre par défaut de Arch news affichées est 5 mais vous pouvez en spécifier un autre en tant qu'argument, comme ceci : " "arch-update --news 10" "."
+.RB "Vous pouvez optionellement spécifier combien de Arch news afficher en tant qu'argument, comme ceci : " "arch-update --news 10" ". La valeur par défaut est 5."
 
 .TP
 .B \-v, \-\-version

--- a/doc/man/fr/arch-update.conf.5
+++ b/doc/man/fr/arch-update.conf.5
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE.CONF" "5" "Janvier 2024" "Arch-Update 1.11.0" "Manuel de Arch-Update"
+.TH "ARCH-UPDATE.CONF" "5" "Février 2024" "Arch-Update 1.11.0" "Manuel de Arch-Update"
 
 .SH NAME
 arch-update.conf \- fichier de configuration pour arch-update.
@@ -26,8 +26,8 @@ Ne pas coloriser la sortie.
 Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente.
 
 .TP
-.B NoNews
-Ne pas afficher les Arch news. Notez que l'utilisation de cette option générera un message d'avertissement pour rappeler que les utilisateurs sont censés consulter régulièrement les Arch news.
+.B AlwaysShowNews
+Toujours afficher les Arch news avant de mettre à jour, peu importe s'il y en a une nouvelle depuis la dernière exécution ou non.
 
 .TP
 .B NewsNum=[Num]

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,48 +16,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:94
+#: src/script/arch-update.sh:98
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/script/arch-update.sh:100
+#: src/script/arch-update.sh:104
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/script/arch-update.sh:110
+#: src/script/arch-update.sh:114
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:132
+#: src/script/arch-update.sh:136
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:134
+#: src/script/arch-update.sh:138
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:135
+#: src/script/arch-update.sh:139
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:136
+#: src/script/arch-update.sh:140
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:137
+#: src/script/arch-update.sh:141
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -65,361 +65,353 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:139
+#: src/script/arch-update.sh:143
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:140
+#: src/script/arch-update.sh:144
 #, sh-format
 msgid ""
 "  -c, --check       Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
 
-#: src/script/arch-update.sh:141
+#: src/script/arch-update.sh:145
 #, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
 "number of Arch news to display with '--news [Num]' (e.g. '--news 10')"
 msgstr ""
 
-#: src/script/arch-update.sh:142
+#: src/script/arch-update.sh:146
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:143
+#: src/script/arch-update.sh:147
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:145
+#: src/script/arch-update.sh:149
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:146
+#: src/script/arch-update.sh:150
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:157
+#: src/script/arch-update.sh:161
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:213
+#: src/script/arch-update.sh:215
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:215
+#: src/script/arch-update.sh:217
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:251
+#: src/script/arch-update.sh:253
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:256
+#: src/script/arch-update.sh:258
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:261
+#: src/script/arch-update.sh:263
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:267
+#: src/script/arch-update.sh:269
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:270
+#: src/script/arch-update.sh:272
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:273 src/script/arch-update.sh:400
-#: src/script/arch-update.sh:433 src/script/arch-update.sh:475
-#: src/script/arch-update.sh:542 src/script/arch-update.sh:572
+#: src/script/arch-update.sh:275 src/script/arch-update.sh:413
+#: src/script/arch-update.sh:446 src/script/arch-update.sh:488
+#: src/script/arch-update.sh:555 src/script/arch-update.sh:585
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/script/arch-update.sh:273 src/script/arch-update.sh:400
-#: src/script/arch-update.sh:433 src/script/arch-update.sh:475
-#: src/script/arch-update.sh:542 src/script/arch-update.sh:572
+#: src/script/arch-update.sh:275 src/script/arch-update.sh:413
+#: src/script/arch-update.sh:446 src/script/arch-update.sh:488
+#: src/script/arch-update.sh:555 src/script/arch-update.sh:585
 #, sh-format
 msgid "y"
 msgstr ""
 
-#: src/script/arch-update.sh:277
+#: src/script/arch-update.sh:279
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:294
+#: src/script/arch-update.sh:309
 #, sh-format
 msgid "Arch News:"
 msgstr ""
 
-#: src/script/arch-update.sh:299
+#: src/script/arch-update.sh:314
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:311
+#: src/script/arch-update.sh:325
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr ""
 
-#: src/script/arch-update.sh:314
+#: src/script/arch-update.sh:327
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:326
+#: src/script/arch-update.sh:338
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:327
+#: src/script/arch-update.sh:339
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:328
+#: src/script/arch-update.sh:340
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:329
+#: src/script/arch-update.sh:341
 #, sh-format
 msgid "URL:"
 msgstr ""
 
-#: src/script/arch-update.sh:343
+#: src/script/arch-update.sh:356
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:348 src/script/arch-update.sh:360
-#: src/script/arch-update.sh:371
+#: src/script/arch-update.sh:361 src/script/arch-update.sh:373
+#: src/script/arch-update.sh:384
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:355
+#: src/script/arch-update.sh:368
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:367
+#: src/script/arch-update.sh:380
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:378
+#: src/script/arch-update.sh:391
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:390
+#: src/script/arch-update.sh:403
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:394
+#: src/script/arch-update.sh:407
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:396
+#: src/script/arch-update.sh:409
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:402
+#: src/script/arch-update.sh:415
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:406 src/script/arch-update.sh:439
-#: src/script/arch-update.sh:482 src/script/arch-update.sh:492
-#: src/script/arch-update.sh:502 src/script/arch-update.sh:511
+#: src/script/arch-update.sh:419 src/script/arch-update.sh:452
+#: src/script/arch-update.sh:495 src/script/arch-update.sh:505
+#: src/script/arch-update.sh:515 src/script/arch-update.sh:524
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:409 src/script/arch-update.sh:442
+#: src/script/arch-update.sh:422 src/script/arch-update.sh:455
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:414 src/script/arch-update.sh:446
-#: src/script/arch-update.sh:519
+#: src/script/arch-update.sh:427 src/script/arch-update.sh:459
+#: src/script/arch-update.sh:532
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:418
+#: src/script/arch-update.sh:431
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:423
+#: src/script/arch-update.sh:436
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:427
+#: src/script/arch-update.sh:440
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:429
+#: src/script/arch-update.sh:442
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:435
+#: src/script/arch-update.sh:448
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:450
+#: src/script/arch-update.sh:463
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:467
+#: src/script/arch-update.sh:480
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:468
+#: src/script/arch-update.sh:481
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:470
+#: src/script/arch-update.sh:483
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:471
+#: src/script/arch-update.sh:484
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:478 src/script/arch-update.sh:498
+#: src/script/arch-update.sh:491 src/script/arch-update.sh:511
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:488 src/script/arch-update.sh:507
+#: src/script/arch-update.sh:501 src/script/arch-update.sh:520
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:523
+#: src/script/arch-update.sh:536
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:532
+#: src/script/arch-update.sh:545
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:536
+#: src/script/arch-update.sh:549
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:538
+#: src/script/arch-update.sh:551
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:544
+#: src/script/arch-update.sh:557
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:548
+#: src/script/arch-update.sh:561
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:551
+#: src/script/arch-update.sh:564
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:555
+#: src/script/arch-update.sh:568
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:568
+#: src/script/arch-update.sh:581
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:569
+#: src/script/arch-update.sh:582
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:574
+#: src/script/arch-update.sh:587
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:578
+#: src/script/arch-update.sh:591
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:586
+#: src/script/arch-update.sh:599
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:590
-#, sh-format
-msgid "No pending kernel update found\\n"
-msgstr ""
-
 #: src/script/arch-update.sh:603
 #, sh-format
-msgid ""
-"NoNews option detected\\nPlease, keep in mind that users are expected to "
-"check the latest Arch news before updating their system, to be aware of "
-"eventual required manual interventions"
+msgid "No pending kernel update found\\n"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -9,31 +9,31 @@ msgstr ""
 "Project-Id-Version: Arch-Update 1.11.0\n"
 "Report-Msgid-Bugs-To: https://github.com/Antiz96/arch-update/issues\n"
 "POT-Creation-Date: 2024-02-09 01:21+0100\n"
-"PO-Revision-Date: 2024-02-09 09:07+0100\n"
+"PO-Revision-Date: 2024-02-25 23:07+0100\n"
 "Last-Translator: Robin Candau <robincandau@protonmail.com>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:94
+#: src/script/arch-update.sh:98
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/script/arch-update.sh:100
+#: src/script/arch-update.sh:104
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Appuyez sur \"entrée\" pour quitter "
 
-#: src/script/arch-update.sh:110
+#: src/script/arch-update.sh:114
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 "Une méthode d'élévation de privilège est requise\\nVeuillez installer sudo ou doas\\n"
 
-#: src/script/arch-update.sh:132
+#: src/script/arch-update.sh:136
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
@@ -42,12 +42,12 @@ msgstr ""
 "Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les "
 "tâches importantes d'avant/après mise à jour."
 
-#: src/script/arch-update.sh:134
+#: src/script/arch-update.sh:138
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr "Lancez ${name} pour exécuter la fonction principale 'update' :"
 
-#: src/script/arch-update.sh:135
+#: src/script/arch-update.sh:139
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
@@ -56,14 +56,14 @@ msgstr ""
 "Afficher la liste des paquets disponibles pour mise à jour, puis demander la confirmation de l'utilisateur "
 "pour procéder à l'installation."
 
-#: src/script/arch-update.sh:136
+#: src/script/arch-update.sh:140
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 "Avant d'effectuer la mise à jour, propose d'afficher les dernières news d'Arch Linux."
 
-#: src/script/arch-update.sh:137
+#: src/script/arch-update.sh:141
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -74,12 +74,12 @@ msgstr ""
 "pacsave et de mise à jour du noyau en attente et, s'il y en a, "
 "propose de les traiter."
 
-#: src/script/arch-update.sh:139
+#: src/script/arch-update.sh:143
 #, sh-format
 msgid "Options:"
 msgstr "Options :"
 
-#: src/script/arch-update.sh:140
+#: src/script/arch-update.sh:144
 #, sh-format
 msgid ""
 "  -c, --check       Check for available updates, send a desktop notification "
@@ -88,7 +88,7 @@ msgstr ""
 "  -c, --check       Vérifier les mises à jour disponibles, envoyer une notification de bureau "
 "contenant le nombre de mises à jour disponibles (si libnotify est installé)"
 
-#: src/script/arch-update.sh:141
+#: src/script/arch-update.sh:145
 #, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
@@ -97,22 +97,22 @@ msgstr ""
 "  -n, --news [Num]  Afficher les dernières Arch news, vous pouvez optionellement spécifier le "
 "nombre de Arch news à afficher avec '--news [Num]' (e.g. '--news 10')"
 
-#: src/script/arch-update.sh:142
+#: src/script/arch-update.sh:146
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr "  -h, --help        Afficher ce message d'aide et quitter"
 
-#: src/script/arch-update.sh:143
+#: src/script/arch-update.sh:147
 #, sh-format
-msgid "  -V, --version  Display version information and exit"
-msgstr " -V, --version  Afficher les informations de version et quitter"
+msgid "  -V, --version     Display version information and exit"
+msgstr " -V, --version     Afficher les informations de version et quitter"
 
-#: src/script/arch-update.sh:145
+#: src/script/arch-update.sh:149
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr "Pour plus d'informations, consultez la page de manuel ${name}(1)."
 
-#: src/script/arch-update.sh:146
+#: src/script/arch-update.sh:150
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
@@ -121,7 +121,7 @@ msgstr ""
 "Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration ${name}.conf, "
 "voir la page de manuel ${name}.conf(5)."
 
-#: src/script/arch-update.sh:157
+#: src/script/arch-update.sh:161
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
@@ -130,109 +130,109 @@ msgstr ""
 "${name}: option invalide -- '${option}'\\nEssayez '${name} --help' pour plus "
 "d'informations."
 
-#: src/script/arch-update.sh:213
+#: src/script/arch-update.sh:215
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} mise à jour disponible"
 
-#: src/script/arch-update.sh:215
+#: src/script/arch-update.sh:217
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/script/arch-update.sh:251
+#: src/script/arch-update.sh:253
 #, sh-format
 msgid "Packages:"
 msgstr "Paquets :"
 
-#: src/script/arch-update.sh:256
+#: src/script/arch-update.sh:258
 #, sh-format
 msgid "AUR Packages:"
 msgstr "Paquets AUR :"
 
-#: src/script/arch-update.sh:261
+#: src/script/arch-update.sh:263
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/script/arch-update.sh:267
+#: src/script/arch-update.sh:269
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
 
-#: src/script/arch-update.sh:270
+#: src/script/arch-update.sh:272
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:273 src/script/arch-update.sh:400
-#: src/script/arch-update.sh:433 src/script/arch-update.sh:475
-#: src/script/arch-update.sh:542 src/script/arch-update.sh:572
+#: src/script/arch-update.sh:275 src/script/arch-update.sh:413
+#: src/script/arch-update.sh:446 src/script/arch-update.sh:488
+#: src/script/arch-update.sh:555 src/script/arch-update.sh:585
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/script/arch-update.sh:273 src/script/arch-update.sh:400
-#: src/script/arch-update.sh:433 src/script/arch-update.sh:475
-#: src/script/arch-update.sh:542 src/script/arch-update.sh:572
+#: src/script/arch-update.sh:275 src/script/arch-update.sh:413
+#: src/script/arch-update.sh:446 src/script/arch-update.sh:488
+#: src/script/arch-update.sh:555 src/script/arch-update.sh:585
 #, sh-format
 msgid "y"
 msgstr "o"
 
-#: src/script/arch-update.sh:277
+#: src/script/arch-update.sh:279
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
 
-#: src/script/arch-update.sh:294
+#: src/script/arch-update.sh:309
 #, sh-format
 msgid "Arch News:"
 msgstr "Arch News :"
 
-#: src/script/arch-update.sh:299
+#: src/script/arch-update.sh:314
 #, sh-format
 msgid "[NEW]"
 msgstr "[NOUVEAU]"
 
-#: src/script/arch-update.sh:311
+#: src/script/arch-update.sh:325
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour quitter) :"
 
-#: src/script/arch-update.sh:314
+#: src/script/arch-update.sh:327
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour procéder à la mise à jour) :"
 
-#: src/script/arch-update.sh:326
+#: src/script/arch-update.sh:338
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/script/arch-update.sh:327
+#: src/script/arch-update.sh:339
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/script/arch-update.sh:328
+#: src/script/arch-update.sh:340
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:329
+#: src/script/arch-update.sh:341
 #, sh-format
 msgid "URL:"
 msgstr "URL :"
 
-#: src/script/arch-update.sh:343
+#: src/script/arch-update.sh:356
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:348 src/script/arch-update.sh:360
-#: src/script/arch-update.sh:371
+#: src/script/arch-update.sh:361 src/script/arch-update.sh:373
+#: src/script/arch-update.sh:384
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -241,27 +241,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:355
+#: src/script/arch-update.sh:368
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:367
+#: src/script/arch-update.sh:380
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:378
+#: src/script/arch-update.sh:391
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:390
+#: src/script/arch-update.sh:403
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:394
+#: src/script/arch-update.sh:407
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -270,7 +270,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:396
+#: src/script/arch-update.sh:409
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -279,14 +279,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:402
+#: src/script/arch-update.sh:415
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:406 src/script/arch-update.sh:439
-#: src/script/arch-update.sh:482 src/script/arch-update.sh:492
-#: src/script/arch-update.sh:502 src/script/arch-update.sh:511
+#: src/script/arch-update.sh:419 src/script/arch-update.sh:452
+#: src/script/arch-update.sh:495 src/script/arch-update.sh:505
+#: src/script/arch-update.sh:515 src/script/arch-update.sh:524
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -295,118 +295,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:409 src/script/arch-update.sh:442
+#: src/script/arch-update.sh:422 src/script/arch-update.sh:455
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:414 src/script/arch-update.sh:446
-#: src/script/arch-update.sh:519
+#: src/script/arch-update.sh:427 src/script/arch-update.sh:459
+#: src/script/arch-update.sh:532
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:418
+#: src/script/arch-update.sh:431
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:423
+#: src/script/arch-update.sh:436
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:427
+#: src/script/arch-update.sh:440
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:429
+#: src/script/arch-update.sh:442
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:435
+#: src/script/arch-update.sh:448
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:450
+#: src/script/arch-update.sh:463
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:467
+#: src/script/arch-update.sh:480
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:468
+#: src/script/arch-update.sh:481
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:470
+#: src/script/arch-update.sh:483
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:471
+#: src/script/arch-update.sh:484
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:478 src/script/arch-update.sh:498
+#: src/script/arch-update.sh:491 src/script/arch-update.sh:511
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:488 src/script/arch-update.sh:507
+#: src/script/arch-update.sh:501 src/script/arch-update.sh:520
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:523
+#: src/script/arch-update.sh:536
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:532
+#: src/script/arch-update.sh:545
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:536
+#: src/script/arch-update.sh:549
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:538
+#: src/script/arch-update.sh:551
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:544
+#: src/script/arch-update.sh:557
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:548
+#: src/script/arch-update.sh:561
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:551
+#: src/script/arch-update.sh:564
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:555
+#: src/script/arch-update.sh:568
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:568
+#: src/script/arch-update.sh:581
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -415,17 +415,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:569
+#: src/script/arch-update.sh:582
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:574
+#: src/script/arch-update.sh:587
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr "Redémarrage dans 5 secondes...\\nAppuyez sur ctrl+c pour annuler"
 
-#: src/script/arch-update.sh:578
+#: src/script/arch-update.sh:591
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -434,7 +434,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:586
+#: src/script/arch-update.sh:599
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -443,18 +443,7 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:590
+#: src/script/arch-update.sh:603
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"
-
-#: src/script/arch-update.sh:603
-#, sh-format
-msgid ""
-"NoNews option detected\\nPlease, keep in mind that users are expected to "
-"check the latest Arch news before updating their system, to be aware of "
-"eventual required manual interventions"
-msgstr ""
-"Option NoNews détectée\\nVeuillez garder à l'esprit que les utilisateurs sont sensés "
-"vérifier les dernières Arch news avant de mettre à jour leur système, afin d'être au courant des "
-"éventuelles interventions manuelles nécessaires"

--- a/po/fr.po
+++ b/po/fr.po
@@ -105,7 +105,7 @@ msgstr "  -h, --help        Afficher ce message d'aide et quitter"
 #: src/script/arch-update.sh:147
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
-msgstr " -V, --version     Afficher les informations de version et quitter"
+msgstr "  -V, --version     Afficher les informations de version et quitter"
 
 #: src/script/arch-update.sh:149
 #, sh-format

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -310,7 +310,7 @@ list_news() {
 
 			i=1
 			while IFS= read -r line; do
-				if [ -z "${no_new_tag}" ] && [ "${news_dates["${i}-1"]}" -ge "$(date -d "$(date "+%Y-%m-%d" -d "100 days ago")" "+%s")" ]; then
+				if [ -z "${news_option}" ] && [ "${news_dates["${i}-1"]}" -ge "$(date -d "$(cat "${statedir}/last_update_run" 2> /dev/null)" +%s)" ]; then
 					new_tag="$(eval_gettext "[NEW]")"
 					echo -e "${i} - ${line} ${green}${new_tag}${color_off}"
 				else
@@ -321,14 +321,11 @@ list_news() {
 
 			echo
 
-			case "${option}" in
-				-n|--news)
-					ask_msg "$(eval_gettext "Select the news to read (or just press \"enter\" to quit):")"
-				;;
-				*)
-					ask_msg "$(eval_gettext "Select the news to read (or just press \"enter\" to proceed with update):")"
-				;;
-			esac
+			if [ -n "${news_option}" ]; then
+				ask_msg "$(eval_gettext "Select the news to read (or just press \"enter\" to quit):")"
+			else
+				ask_msg "$(eval_gettext "Select the news to read (or just press \"enter\" to proceed with update):")"
+			fi
 
 			if [ "${answer}" -le "${news_num}" ] 2> /dev/null && [ "${answer}" -gt "0" ]; then
 				news_selected=$(sed -n "${answer}"p <<< "${news_titles}")
@@ -614,6 +611,7 @@ case "${option}" in
 		if [ -n "${proceed_with_update}" ]; then
 			list_news
 			update
+			date +%Y-%m-%d > "${statedir}/last_update_run"
 		fi
 		orphan_packages
 		packages_cache
@@ -626,7 +624,7 @@ case "${option}" in
 	;;
 	-n|--news)
 		show_news="y"
-		no_new_tag="y"
+		news_option="y"
 		if [ "${2}" -gt 0 ] 2> /dev/null; then
 			news_num="${2}"
 		fi


### PR DESCRIPTION
This PR aims to makes Arch news displaying more relevant by only displaying them if at least a new one had been published since the last `arch-update` run (instead of being displayed systematically, which is irrelevant/useless most of the time).

Arch news published since the last run are tagged as `[NEW]`.

One can still use the 'old' behavior (always display Arch news before updating, regardless of whether there's a new one since the last run or not), by setting the `AlwaysShowNews` option in `arch-update.conf`.

With this new behavior, the `NoNews` option (suggested in #85 and introduced in #89) is deprecated and completely removed since it's not relevant anymore.

Closes #110 