### PR TITLE
Add shell completions for bash, zsh and fish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,11 @@ uninstall:
 	# Delete .mo files
 	rm -f "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${_pkgname}.mo"
 
+	# Delete shell completions
+	rm -f "${DESTDIR}${PREFIX}/share/bash-completion/completions/${pkgname}"
+	rm -f "${DESTDIR}${PREFIX}/share/zsh/site-functions/_${pkgname}"
+	rm -f "${DESTDIR}${PREFIX}/share/fish/vendor_completions.d/${pkgname}.fish"
+
 	# Delete man pages
 	rm -f "${DESTDIR}${PREFIX}/share/man/man1/${pkgname}.1.gz"
 	rm -f "${DESTDIR}${PREFIX}/share/man/man5/${pkgname}.conf.5.gz"

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ install:
 	install -Dm 644 po/fr.mo "${DESTDIR}${PREFIX}/share/locale/fr/LC_MESSAGES/${_pkgname}.mo"
 	rm -f po/fr.mo
 
+	# Install shell completions
+	install -Dm 644 "res/completions/${pkgname}.bash" "${DESTDIR}${PREFIX}/share/bash-completion/completions/${pkgname}"
+	install -Dm 644 "res/completions/${pkgname}.zsh" "${DESTDIR}${PREFIX}/share/zsh/site-functions/_${pkgname}"
+	install -Dm 644 "res/completions/${pkgname}.fish" "${DESTDIR}${PREFIX}/share/fish/vendor_completions.d/${pkgname}.fish"
+
 	# Archive and install man pages
 	gzip -c "doc/man/${pkgname}.1" > "doc/man/${pkgname}.1.gz"
 	gzip -c "doc/man/${pkgname}.conf.5" > "doc/man/${pkgname}.conf.5.gz"

--- a/res/completions/arch-update.bash
+++ b/res/completions/arch-update.bash
@@ -1,0 +1,12 @@
+_arch-update() {
+	local arg="${2}"
+	local -a opts 
+	opts=('-c --check 
+	       -n --news 
+	       -h --help 
+	       -V --version')
+
+	COMPREPLY=( $(compgen -W "${opts[*]}" -- "${arg}") )
+}
+
+complete -F _arch-update arch-update

--- a/res/completions/arch-update.fish
+++ b/res/completions/arch-update.fish
@@ -1,0 +1,6 @@
+complete -c arch-update -f
+
+complete -c arch-update -s c -l check -d 'Check for available updates'
+complete -c arch-update -s n -l news -d 'Display latest Arch news'
+complete -c arch-update -s h -l help -d 'Display the help message'
+complete -c arch-update -s V -l version -d 'Display version information'

--- a/res/completions/arch-update.zsh
+++ b/res/completions/arch-update.zsh
@@ -1,0 +1,11 @@
+#compdef arch-update
+
+local -a opts
+opts=(
+    {-c,--check}'[Check for available updates]'
+    {-n,--news}'[Display latest Arch news]'
+    {-h,--help}'[Display the help message]'
+    {-V,--version}'[Display version information]'
+)
+
+_arguments $opts


### PR DESCRIPTION
This PR aims to introduce basic shell completions for `bash`, `zsh` and `fish` for the `arch-update` command.
