### PR TITLE
Add the new `-l/--list` option to simply get the list of pending updates

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -104,6 +104,7 @@ Si de nouvelles mises à jour sont disponibles, l'icône affichera une cloche et
 Lorsque l'on clique sur l'icône, cela lance la série de fonctions adéquates pour effectuer une mise à jour complète et correcte, en commençant par actualiser la liste des paquets disponibles pour la mise à jour, en l'affichant dans un terminal et en demandant la confirmation de l'utilisateur pour procéder à l'installation (elle peut également être lancée en exécutant la commande `arch-update`, nécessite [yay](https://aur.archlinux.org/packages/yay "yay") ou [paru](https://aur.archlinux.org/packages/paru "paru") pour la prise en charge de la mise à jour des paquets AUR et [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak/) pour la prise en charge de la mise à jour des paquets Flatpak) :
 
 *La sortie colorée peut être désactivée avec l'option `NoColor` dans le fichier de configuration `arch-update.conf`.*  
+*La liste des mises à jour en attente peut être affichées à tout moment en exécutant `arch-update -l` ou `arch-update --list`.*  
 *Les changements de versions dans la listing des paquets peuvent être masqués avec l'option `NoVersion` dans le fichier de configuration `arch-update.conf`.*  
 *Voir le [chapitre de documentation arch-update.conf](#Fichier-de-configuration-arch-update) pour plus de détails.*
 
@@ -170,6 +171,7 @@ de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en 
 
 Options :
 -c, --check       Vérifier les mises à jour disponibles, envoyer une notification de bureau contenant le nombre de mises à jour disponibles (si libnotify est installé)
+-l, --list        Afficher la liste des mises à jour en attente (incluant les paquets AUR si yay ou paru est installé et les paquets flatpak si flatpak est installé)
 -n, --news [Num]  Afficher les dernieres Arch News, vous pouvez optionellement spécifier le nombre de Arch news à afficher avec `--news [Num]` (e.g. `--news 10`)
 -h, --help        Afficher ce message d'aide et quitter
 -V, --version     Afficher les informations de version et quitter
@@ -182,6 +184,7 @@ Codes de sortie :
 4  L'utilisateur n'a pas donné la confirmation de procéder
 5  Erreur lors de la mise à jour des paquets
 6  Erreur lors de l'appel de la commande reboot pour appliquer une mise à jour du noyau en attente
+7  Aucune mise à jour en attente durant l'utilisation de l'option "-l/--list"
 ```
 
 Pour plus d'informations, consultez la page de manuel arch-update(1).  
@@ -199,7 +202,7 @@ ou "${HOME}/.config/arch-update/arch-update.conf".
 Les options prises en charge sont :
 
 - NoColor # Ne pas coloriser la sortie.
-- NoVersion # Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente.
+- NoVersion # Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente (y compris lors de l'utilisation de l'option "-l/--list").
 - AlwaysShowNews # Toujours afficher les Arch news avant de mettre à jour, peu importe s'il y en a une nouvelle depuis la dernière exécution ou non.
 - NewsNum=[Num] # Nombre de Arch news à affcher avant la mise à jour et avec l'option `-n/--news` (voir la page de manuel arch-update(1) pour plus de details). La valeur par défaut est 5.
 - KeepOldPackages=[Num] # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.

--- a/README-fr.md
+++ b/README-fr.md
@@ -171,7 +171,7 @@ de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en 
 
 Options :
 -c, --check       Vérifier les mises à jour disponibles, envoyer une notification de bureau contenant le nombre de mises à jour disponibles (si libnotify est installé)
--l, --list        Afficher la liste des mises à jour en attente (incluant les paquets AUR si yay ou paru est installé et les paquets flatpak si flatpak est installé)
+-l, --list        Afficher la liste des mises à jour en attente
 -n, --news [Num]  Afficher les dernieres Arch News, vous pouvez optionellement spécifier le nombre de Arch news à afficher avec `--news [Num]` (e.g. `--news 10`)
 -h, --help        Afficher ce message d'aide et quitter
 -V, --version     Afficher les informations de version et quitter

--- a/README-fr.md
+++ b/README-fr.md
@@ -184,7 +184,7 @@ Codes de sortie :
 4  L'utilisateur n'a pas donné la confirmation de procéder
 5  Erreur lors de la mise à jour des paquets
 6  Erreur lors de l'appel de la commande reboot pour appliquer une mise à jour du noyau en attente
-7  Aucune mise à jour en attente durant l'utilisation de l'option "-l/--list"
+7  Aucune mise à jour en attente durant l'utilisation de l'option `-l/--list`
 ```
 
 Pour plus d'informations, consultez la page de manuel arch-update(1).  
@@ -202,7 +202,7 @@ ou "${HOME}/.config/arch-update/arch-update.conf".
 Les options prises en charge sont :
 
 - NoColor # Ne pas coloriser la sortie.
-- NoVersion # Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente (y compris lors de l'utilisation de l'option "-l/--list").
+- NoVersion # Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente (y compris lors de l'utilisation de l'option `-l/--list`).
 - AlwaysShowNews # Toujours afficher les Arch news avant de mettre à jour, peu importe s'il y en a une nouvelle depuis la dernière exécution ou non.
 - NewsNum=[Num] # Nombre de Arch news à affcher avant la mise à jour et avec l'option `-n/--news` (voir la page de manuel arch-update(1) pour plus de details). La valeur par défaut est 5.
 - KeepOldPackages=[Num] # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Exit Codes:
 4  User didn't gave the confirmation to proceed
 5  Error when updating the packages
 6  Error when calling the reboot command to apply a pending kernel update
-7  No pending update when using the "-l/--list" option
+7  No pending update when using the `-l/--list` option
 ```
 
 For more information, see the arch-update(1) man page.  
@@ -199,7 +199,7 @@ or "${HOME}/.config/arch-update/arch-update.conf".
 The supported options are:
 
 - NoColor # Do not colorize output.
-- NoVersion # Do not show versions changes for packages when listing pending updates (including when using the "-l/--list" option).
+- NoVersion # Do not show versions changes for packages when listing pending updates (including when using the `-l/--list` option).
 - AlwaysShowNews # Always display Arch news before updating, regardless of whether there's a new one since the last run or not.
 - NewsNum=[Num] # Number of Arch news to display before updating and with the `-n/--news` option (see the arch-update(1) man page for more details). Defaults to 5.
 - KeepOldPackages=[Num] # Number of old packages' versions to keep in pacman's cache. Defaults to 3.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If there are new available updates, the icon will show a bell sign and a desktop
 When the icon is clicked, it launches the relevant series of functions to perform a complete and proper update starting by refreshing the list of packages available for updates, display it inside a terminal window and asks for the user's confirmation to proceed with the installation (it can also be launched by running the `arch-update` command, requires [yay](https://aur.archlinux.org/packages/yay "yay") or [paru](https://aur.archlinux.org/packages/paru "paru") for AUR packages update support and [flatpak](https://archlinux.org/packages/extra/x86_64/flatpak/) for Flatpak packages update support):
 
 *The colored output can be disabled with the `NoColor` option in the `arch-update.conf` configuration file.*  
+*The list of pending updates can be displayed at anytime by running `arch-update -l` or `arch-update --list`.*  
 *The versions changes in the packages listing can be hidden with the `NoVersion` option in the `arch-update.conf` configuration file.*  
 *See the [arch-update.conf documentation chapter](#arch-update-configuration-file) for more details.*
 
@@ -167,6 +168,7 @@ and pending kernel update and, if there are, offers to process them.
 
 Options:
 -c, --check       Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)
+-l, --list        Display the list of pending updates (including AUR packages if yay or paru is installed and flatpak packages if flatpak is installed)
 -n, --news [Num]  Display latest Arch News, you can optionally specify the number of Arch news to display with `--news [Num]` (e.g. `--news 10`)
 -h, --help        Display this help message and exit
 -V, --version     Display version information and exit
@@ -179,6 +181,7 @@ Exit Codes:
 4  User didn't gave the confirmation to proceed
 5  Error when updating the packages
 6  Error when calling the reboot command to apply a pending kernel update
+7  No pending update when using the "-l/--list" option
 ```
 
 For more information, see the arch-update(1) man page.  
@@ -196,7 +199,7 @@ or "${HOME}/.config/arch-update/arch-update.conf".
 The supported options are:
 
 - NoColor # Do not colorize output.
-- NoVersion # Do not show versions changes for packages when listing pending updates.
+- NoVersion # Do not show versions changes for packages when listing pending updates (including when using the "-l/--list" option).
 - AlwaysShowNews # Always display Arch news before updating, regardless of whether there's a new one since the last run or not.
 - NewsNum=[Num] # Number of Arch news to display before updating and with the `-n/--news` option (see the arch-update(1) man page for more details). Defaults to 5.
 - KeepOldPackages=[Num] # Number of old packages' versions to keep in pacman's cache. Defaults to 3.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ and pending kernel update and, if there are, offers to process them.
 
 Options:
 -c, --check       Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)
--l, --list        Display the list of pending updates (including AUR packages if yay or paru is installed and flatpak packages if flatpak is installed)
+-l, --list        Display the list of pending updates
 -n, --news [Num]  Display latest Arch News, you can optionally specify the number of Arch news to display with `--news [Num]` (e.g. `--news 10`)
 -h, --help        Display this help message and exit
 -V, --version     Display version information and exit

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "February 2024" "Arch-Update 1.12.1" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "March 2024" "Arch-Update 1.12.1" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
@@ -37,6 +37,10 @@ Check for available updates and change the (.desktop) icon accordingly if there 
 .RB "The " "\-\-check " "option is automatically launched at boot and then every hour if you enabled the " "systemd.timer " "with the following command:" 
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
+
+.TP
+.B \-l, \-\-list
+Display the list of pending updates.
 
 .TP
 .B \-n, \-\-news
@@ -135,6 +139,10 @@ Error when updating the packages
 .TP
 .B 6
 Error when calling the reboot command to apply a pending kernel update
+
+.TP
+.B 7
+.RB "No pending update when using the " "-l/--list " "option"
 
 .SH SEE ALSO
 .BR checkupdates (8),

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE.CONF" "5" "February 2024" "Arch-Update 1.12.1" "Arch-Update Manual"
+.TH "ARCH-UPDATE.CONF" "5" "March 2024" "Arch-Update 1.12.1" "Arch-Update Manual"
 
 .SH NAME
 arch-update.conf \- arch-update configuration file.
@@ -23,7 +23,7 @@ Do not colorize output.
 
 .TP
 .B NoVersion
-Do not show versions changes for packages when listing pending updates.
+.RB "Do not show versions changes for packages when listing pending updates (including when using the " "-l/--list " "option, see the " "arch-update(1) " "man page for more details)."
 
 .TP
 .B AlwaysShowNews

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "Février 2024" "Arch-Update 1.12.1" "Manuel de Arch-Update"
+.TH "ARCH-UPDATE" "1" "Mars 2024" "Arch-Update 1.12.1" "Manuel de Arch-Update"
 
 .SH NAME
 arch-update \- Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour.
@@ -37,6 +37,10 @@ Vérifier les mises à jour disponibles and changer l'icône (.desktop) en cons�
 .RB "L'option " "\-\-check " "est automatiquement lancée au démarrage du système puis une fois chaque heure si vous avez activé le " "systemd.timer " "avec la commande suivante :"
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
+
+.TP
+.B \-l, \-\-list
+Afficher la liste des mises à jour en attente.
 
 .TP
 .B \-n, \-\-news
@@ -135,6 +139,10 @@ Erreur lors de la mise à jour des paquets
 .TP
 .B 6
 Erreur lors de l'appel de la commande reboot pour appliquer une mise à jour du noyau en attente
+
+.TP
+.B 7
+.RB "Aucune mise à jour en attente durant l'utilisation de l'option " "-l/--list"
 
 .SH VOIR AUSSI
 .BR checkupdates (8),

--- a/doc/man/fr/arch-update.conf.5
+++ b/doc/man/fr/arch-update.conf.5
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE.CONF" "5" "Février 2024" "Arch-Update 1.12.1" "Manuel de Arch-Update"
+.TH "ARCH-UPDATE.CONF" "5" "Mars 2024" "Arch-Update 1.12.1" "Manuel de Arch-Update"
 
 .SH NAME
 arch-update.conf \- fichier de configuration pour arch-update.
@@ -23,7 +23,7 @@ Ne pas coloriser la sortie.
 
 .TP
 .B NoVersion
-Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente.
+.RB "Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente (y compris lors de l'utilisation de l'option " "-l/--list" ", voir la page de man " "arch-update(1) " "pour plus de détails)."
 
 .TP
 .B AlwaysShowNews

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -79,339 +79,344 @@ msgstr ""
 
 #: src/script/arch-update.sh:145
 #, sh-format
+msgid "  -l, --list        Display the list of pending updates"
+msgstr ""
+
+#: src/script/arch-update.sh:146
+#, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
 "number of Arch news to display with '--news [Num]' (e.g. '--news 10')"
 msgstr ""
 
-#: src/script/arch-update.sh:146
+#: src/script/arch-update.sh:147
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:147
+#: src/script/arch-update.sh:148
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:149
+#: src/script/arch-update.sh:150
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:150
+#: src/script/arch-update.sh:151
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:161
+#: src/script/arch-update.sh:162
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:215
+#: src/script/arch-update.sh:216
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:217
+#: src/script/arch-update.sh:218
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:253
+#: src/script/arch-update.sh:254
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:258
+#: src/script/arch-update.sh:259
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:263
+#: src/script/arch-update.sh:264
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:269
+#: src/script/arch-update.sh:271
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:272
+#: src/script/arch-update.sh:278
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:275 src/script/arch-update.sh:413
-#: src/script/arch-update.sh:446 src/script/arch-update.sh:488
-#: src/script/arch-update.sh:555 src/script/arch-update.sh:585
+#: src/script/arch-update.sh:281 src/script/arch-update.sh:420
+#: src/script/arch-update.sh:453 src/script/arch-update.sh:495
+#: src/script/arch-update.sh:562 src/script/arch-update.sh:592
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/script/arch-update.sh:275 src/script/arch-update.sh:413
-#: src/script/arch-update.sh:446 src/script/arch-update.sh:488
-#: src/script/arch-update.sh:555 src/script/arch-update.sh:585
+#: src/script/arch-update.sh:281 src/script/arch-update.sh:420
+#: src/script/arch-update.sh:453 src/script/arch-update.sh:495
+#: src/script/arch-update.sh:562 src/script/arch-update.sh:592
 #, sh-format
 msgid "y"
 msgstr ""
 
-#: src/script/arch-update.sh:279
+#: src/script/arch-update.sh:285
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:309
+#: src/script/arch-update.sh:316
 #, sh-format
 msgid "Arch News:"
 msgstr ""
 
-#: src/script/arch-update.sh:314
+#: src/script/arch-update.sh:321
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:325
+#: src/script/arch-update.sh:332
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr ""
 
-#: src/script/arch-update.sh:327
+#: src/script/arch-update.sh:334
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:338
+#: src/script/arch-update.sh:345
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:339
+#: src/script/arch-update.sh:346
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:340
+#: src/script/arch-update.sh:347
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:341
+#: src/script/arch-update.sh:348
 #, sh-format
 msgid "URL:"
 msgstr ""
 
-#: src/script/arch-update.sh:356
+#: src/script/arch-update.sh:363
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:361 src/script/arch-update.sh:373
-#: src/script/arch-update.sh:384
+#: src/script/arch-update.sh:368 src/script/arch-update.sh:380
+#: src/script/arch-update.sh:391
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:368
+#: src/script/arch-update.sh:375
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:380
+#: src/script/arch-update.sh:387
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:391
+#: src/script/arch-update.sh:398
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:403
+#: src/script/arch-update.sh:410
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:407
+#: src/script/arch-update.sh:414
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:409
+#: src/script/arch-update.sh:416
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:415
+#: src/script/arch-update.sh:422
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:419 src/script/arch-update.sh:452
-#: src/script/arch-update.sh:495 src/script/arch-update.sh:505
-#: src/script/arch-update.sh:515 src/script/arch-update.sh:524
+#: src/script/arch-update.sh:426 src/script/arch-update.sh:459
+#: src/script/arch-update.sh:502 src/script/arch-update.sh:512
+#: src/script/arch-update.sh:522 src/script/arch-update.sh:531
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:422 src/script/arch-update.sh:455
+#: src/script/arch-update.sh:429 src/script/arch-update.sh:462
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:427 src/script/arch-update.sh:459
-#: src/script/arch-update.sh:532
+#: src/script/arch-update.sh:434 src/script/arch-update.sh:466
+#: src/script/arch-update.sh:539
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:431
+#: src/script/arch-update.sh:438
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:436
+#: src/script/arch-update.sh:443
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:440
+#: src/script/arch-update.sh:447
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:442
+#: src/script/arch-update.sh:449
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:448
+#: src/script/arch-update.sh:455
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:463
+#: src/script/arch-update.sh:470
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:480
+#: src/script/arch-update.sh:487
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:481
+#: src/script/arch-update.sh:488
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:483
+#: src/script/arch-update.sh:490
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:484
+#: src/script/arch-update.sh:491
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:491 src/script/arch-update.sh:511
+#: src/script/arch-update.sh:498 src/script/arch-update.sh:518
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:501 src/script/arch-update.sh:520
+#: src/script/arch-update.sh:508 src/script/arch-update.sh:527
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:536
+#: src/script/arch-update.sh:543
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:545
+#: src/script/arch-update.sh:552
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:549
+#: src/script/arch-update.sh:556
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:551
+#: src/script/arch-update.sh:558
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:557
+#: src/script/arch-update.sh:564
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:561
+#: src/script/arch-update.sh:568
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:564
+#: src/script/arch-update.sh:571
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:568
+#: src/script/arch-update.sh:575
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:581
+#: src/script/arch-update.sh:588
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:582
+#: src/script/arch-update.sh:589
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:587
+#: src/script/arch-update.sh:594
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:591
+#: src/script/arch-update.sh:598
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:599
+#: src/script/arch-update.sh:606
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:603
+#: src/script/arch-update.sh:610
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Arch-Update 1.12.1\n"
 "Report-Msgid-Bugs-To: https://github.com/Antiz96/arch-update/issues\n"
 "POT-Creation-Date: 2024-02-09 01:21+0100\n"
-"PO-Revision-Date: 2024-02-25 23:07+0100\n"
+"PO-Revision-Date: 2024-03-12 17:00+0100\n"
 "Last-Translator: Robin Candau <robincandau@protonmail.com>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -90,6 +90,11 @@ msgstr ""
 
 #: src/script/arch-update.sh:145
 #, sh-format
+msgid "  -l, --list        Display the list of pending updates"
+msgstr "  -l, --list        Afficher les mises à jours en attente"
+
+#: src/script/arch-update.sh:146
+#, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
 "number of Arch news to display with '--news [Num]' (e.g. '--news 10')"
@@ -97,22 +102,22 @@ msgstr ""
 "  -n, --news [Num]  Afficher les dernières Arch news, vous pouvez optionellement spécifier le "
 "nombre de Arch news à afficher avec '--news [Num]' (e.g. '--news 10')"
 
-#: src/script/arch-update.sh:146
+#: src/script/arch-update.sh:147
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr "  -h, --help        Afficher ce message d'aide et quitter"
 
-#: src/script/arch-update.sh:147
+#: src/script/arch-update.sh:148
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr "  -V, --version     Afficher les informations de version et quitter"
 
-#: src/script/arch-update.sh:149
+#: src/script/arch-update.sh:150
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr "Pour plus d'informations, consultez la page de manuel ${name}(1)."
 
-#: src/script/arch-update.sh:150
+#: src/script/arch-update.sh:151
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
@@ -121,7 +126,7 @@ msgstr ""
 "Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration ${name}.conf, "
 "voir la page de manuel ${name}.conf(5)."
 
-#: src/script/arch-update.sh:161
+#: src/script/arch-update.sh:162
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
@@ -130,109 +135,109 @@ msgstr ""
 "${name}: option invalide -- '${option}'\\nEssayez '${name} --help' pour plus "
 "d'informations."
 
-#: src/script/arch-update.sh:215
+#: src/script/arch-update.sh:216
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} mise à jour disponible"
 
-#: src/script/arch-update.sh:217
+#: src/script/arch-update.sh:218
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/script/arch-update.sh:253
+#: src/script/arch-update.sh:254
 #, sh-format
 msgid "Packages:"
 msgstr "Paquets :"
 
-#: src/script/arch-update.sh:258
+#: src/script/arch-update.sh:259
 #, sh-format
 msgid "AUR Packages:"
 msgstr "Paquets AUR :"
 
-#: src/script/arch-update.sh:263
+#: src/script/arch-update.sh:264
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/script/arch-update.sh:269
+#: src/script/arch-update.sh:271
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
 
-#: src/script/arch-update.sh:272
+#: src/script/arch-update.sh:278
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:275 src/script/arch-update.sh:413
-#: src/script/arch-update.sh:446 src/script/arch-update.sh:488
-#: src/script/arch-update.sh:555 src/script/arch-update.sh:585
+#: src/script/arch-update.sh:281 src/script/arch-update.sh:420
+#: src/script/arch-update.sh:453 src/script/arch-update.sh:495
+#: src/script/arch-update.sh:562 src/script/arch-update.sh:592
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/script/arch-update.sh:275 src/script/arch-update.sh:413
-#: src/script/arch-update.sh:446 src/script/arch-update.sh:488
-#: src/script/arch-update.sh:555 src/script/arch-update.sh:585
+#: src/script/arch-update.sh:281 src/script/arch-update.sh:420
+#: src/script/arch-update.sh:453 src/script/arch-update.sh:495
+#: src/script/arch-update.sh:562 src/script/arch-update.sh:592
 #, sh-format
 msgid "y"
 msgstr "o"
 
-#: src/script/arch-update.sh:279
+#: src/script/arch-update.sh:285
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
 
-#: src/script/arch-update.sh:309
+#: src/script/arch-update.sh:316
 #, sh-format
 msgid "Arch News:"
 msgstr "Arch News :"
 
-#: src/script/arch-update.sh:314
+#: src/script/arch-update.sh:321
 #, sh-format
 msgid "[NEW]"
 msgstr "[NOUVEAU]"
 
-#: src/script/arch-update.sh:325
+#: src/script/arch-update.sh:332
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour quitter) :"
 
-#: src/script/arch-update.sh:327
+#: src/script/arch-update.sh:334
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour procéder à la mise à jour) :"
 
-#: src/script/arch-update.sh:338
+#: src/script/arch-update.sh:345
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/script/arch-update.sh:339
+#: src/script/arch-update.sh:346
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/script/arch-update.sh:340
+#: src/script/arch-update.sh:347
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:341
+#: src/script/arch-update.sh:348
 #, sh-format
 msgid "URL:"
 msgstr "URL :"
 
-#: src/script/arch-update.sh:356
+#: src/script/arch-update.sh:363
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:361 src/script/arch-update.sh:373
-#: src/script/arch-update.sh:384
+#: src/script/arch-update.sh:368 src/script/arch-update.sh:380
+#: src/script/arch-update.sh:391
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -241,27 +246,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:368
+#: src/script/arch-update.sh:375
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:380
+#: src/script/arch-update.sh:387
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:391
+#: src/script/arch-update.sh:398
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:403
+#: src/script/arch-update.sh:410
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:407
+#: src/script/arch-update.sh:414
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -270,7 +275,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:409
+#: src/script/arch-update.sh:416
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -279,14 +284,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:415
+#: src/script/arch-update.sh:422
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:419 src/script/arch-update.sh:452
-#: src/script/arch-update.sh:495 src/script/arch-update.sh:505
-#: src/script/arch-update.sh:515 src/script/arch-update.sh:524
+#: src/script/arch-update.sh:426 src/script/arch-update.sh:459
+#: src/script/arch-update.sh:502 src/script/arch-update.sh:512
+#: src/script/arch-update.sh:522 src/script/arch-update.sh:531
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -295,118 +300,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:422 src/script/arch-update.sh:455
+#: src/script/arch-update.sh:429 src/script/arch-update.sh:462
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:427 src/script/arch-update.sh:459
-#: src/script/arch-update.sh:532
+#: src/script/arch-update.sh:434 src/script/arch-update.sh:466
+#: src/script/arch-update.sh:539
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:431
+#: src/script/arch-update.sh:438
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:436
+#: src/script/arch-update.sh:443
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:440
+#: src/script/arch-update.sh:447
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:442
+#: src/script/arch-update.sh:449
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:448
+#: src/script/arch-update.sh:455
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:463
+#: src/script/arch-update.sh:470
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:480
+#: src/script/arch-update.sh:487
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:481
+#: src/script/arch-update.sh:488
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:483
+#: src/script/arch-update.sh:490
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:484
+#: src/script/arch-update.sh:491
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:491 src/script/arch-update.sh:511
+#: src/script/arch-update.sh:498 src/script/arch-update.sh:518
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:501 src/script/arch-update.sh:520
+#: src/script/arch-update.sh:508 src/script/arch-update.sh:527
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:536
+#: src/script/arch-update.sh:543
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:545
+#: src/script/arch-update.sh:552
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:549
+#: src/script/arch-update.sh:556
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:551
+#: src/script/arch-update.sh:558
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:557
+#: src/script/arch-update.sh:564
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:561
+#: src/script/arch-update.sh:568
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:564
+#: src/script/arch-update.sh:571
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:568
+#: src/script/arch-update.sh:575
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:581
+#: src/script/arch-update.sh:588
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -415,17 +420,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:582
+#: src/script/arch-update.sh:589
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:587
+#: src/script/arch-update.sh:594
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr "Redémarrage dans 5 secondes...\\nAppuyez sur ctrl+c pour annuler"
 
-#: src/script/arch-update.sh:591
+#: src/script/arch-update.sh:598
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -434,7 +439,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:599
+#: src/script/arch-update.sh:606
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -443,7 +448,7 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:603
+#: src/script/arch-update.sh:610
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -267,20 +267,26 @@ list_packages() {
 
 	if [ -z "${packages}" ] && [ -z "${aur_packages}" ] && [ -z "${flatpak_packages}" ]; then
 		icon_up_to_date
-		info_msg "$(eval_gettext "No update available\n")"
+		if [ -z "${list_option}" ]; then
+			info_msg "$(eval_gettext "No update available\n")"
+		else
+			exit 7
+		fi
 	else
 		icon_updates_available
-		ask_msg "$(eval_gettext "Proceed with update? [Y/n]")"
-
-		case "${answer}" in
-			"$(eval_gettext "Y")"|"$(eval_gettext "y")"|"")
-				proceed_with_update="y"
-			;;
-			*)
-				error_msg "$(eval_gettext "The update has been aborted\n")" && quit_msg
-				exit 4
-			;;
-		esac
+		if [ -z "${list_option}" ]; then
+			ask_msg "$(eval_gettext "Proceed with update? [Y/n]")"
+	
+			case "${answer}" in
+				"$(eval_gettext "Y")"|"$(eval_gettext "y")"|"")
+					proceed_with_update="y"
+				;;
+				*)
+					error_msg "$(eval_gettext "The update has been aborted\n")" && quit_msg
+					exit 4
+				;;
+			esac
+		fi
 	fi
 }
 
@@ -622,6 +628,10 @@ case "${option}" in
 	;;
 	-c|--check)
 		check
+	;;
+	-l|--list)
+		list_option="y"
+		list_packages | sed '${/^$/d;}'
 	;;
 	-n|--news)
 		show_news="y"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -142,6 +142,7 @@ $(eval_gettext "Post update, check for orphan/unused packages, old cached packag
 
 $(eval_gettext "Options:")
 $(eval_gettext "  -c, --check       Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)")
+$(eval_gettext "  -l, --list        Display the list of pending updates")
 $(eval_gettext "  -n, --news [Num]  Display latest Arch news, you can optionally specify the number of Arch news to display with '--news [Num]' (e.g. '--news 10')")
 $(eval_gettext "  -h, --help        Display this help message and exit")
 $(eval_gettext "  -V, --version     Display version information and exit")


### PR DESCRIPTION
Introduce the new `arch-update -l`/`arch-update --list` option that simply displays the list of pending updates (including AUR packages if yay/paru is installed and flatpak packages if flatpak is installed).

This option allow users to get the list of pending updates in a non-interactive way, e.g. to have it scheduled in a cronjob to get the list of pending updates automatically and periodically. It basically acts like `checkupdates`, except it includes AUR and flatpak packages (if the related dependencies are installed).

Closes #122 