### PR TITLE
git commit -m "Make the pending kernel update detection more robust (for EndeavourOS)

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -578,11 +578,7 @@ pacnew_files() {
 
 # Definition of the kernel_reboot function: Verify if there's a kernel update waiting for a reboot to be applied
 kernel_reboot() {
-	if find /boot/vmlinuz* &> /dev/null; then
-		kernel_compare=$(file /boot/vmlinuz* | sed 's/^.*version\ //' | awk '{print $1}' | grep "$(uname -r)")
-	else
-		kernel_compare=$(file /usr/lib/modules/*/vmlinuz* | sed 's/^.*version\ //' | awk '{print $1}' | grep "$(uname -r)")
-	fi
+	kernel_compare=$(file /boot/vmlinuz* /usr/lib/modules/*/vmlinuz* | sed 's/^.*version\ //' | awk '{print $1}' | grep "$(uname -r)")
 
 	if [ -z "${kernel_compare}" ]; then
 		main_msg "$(eval_gettext "Reboot required:\nThere's a pending kernel update on your system requiring a reboot to be applied\n")"


### PR DESCRIPTION
The fix implemented for EndeavourOS in https://github.com/Antiz96/arch-update/pull/75 can create false positives in case some old-ish/outdated kernel related files are [laying in /boot](https://github.com/Antiz96/arch-update/issues/74#issuecomment-2013160918) *for some reasons... (?)* 
This commit aims to make the pending kernel update detection more robust to avoid such potential false positives by making Arch-Update looking for kernel related files in **both** /boot and in /usr/lib/modules/* (instead of falling-back to the latter only if kernel files are not found in the former).

Fixes https://github.com/Antiz96/arch-update/issues/74