### PR TITLE
Explictely set color option of wrapped tool in the main script

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,48 +16,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:115
+#: src/script/arch-update.sh:119
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/script/arch-update.sh:121
+#: src/script/arch-update.sh:125
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/script/arch-update.sh:131
+#: src/script/arch-update.sh:135
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:153
+#: src/script/arch-update.sh:157
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:155
+#: src/script/arch-update.sh:159
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:156
+#: src/script/arch-update.sh:160
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:157
+#: src/script/arch-update.sh:161
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:158
+#: src/script/arch-update.sh:162
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -65,368 +65,368 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:160
+#: src/script/arch-update.sh:164
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:161
+#: src/script/arch-update.sh:165
 #, sh-format
 msgid ""
 "  -c, --check       Check for available updates, send a desktop notification "
 "containing the number of available updates (if libnotify is installed)"
 msgstr ""
 
-#: src/script/arch-update.sh:162
+#: src/script/arch-update.sh:166
 #, sh-format
 msgid "  -l, --list        Display the list of pending updates"
 msgstr ""
 
-#: src/script/arch-update.sh:163
+#: src/script/arch-update.sh:167
 #, sh-format
 msgid "  -d, --devel       Include AUR development packages updates"
 msgstr ""
 
-#: src/script/arch-update.sh:164
+#: src/script/arch-update.sh:168
 #, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
 "number of Arch news to display with '--news [Num]' (e.g. '--news 10')"
 msgstr ""
 
-#: src/script/arch-update.sh:165
+#: src/script/arch-update.sh:169
 #, sh-format
 msgid "  -D, --debug       Display debug traces"
 msgstr ""
 
-#: src/script/arch-update.sh:166
+#: src/script/arch-update.sh:170
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:167
+#: src/script/arch-update.sh:171
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:169
+#: src/script/arch-update.sh:173
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:170
+#: src/script/arch-update.sh:174
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:181
+#: src/script/arch-update.sh:185
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:237 src/script/arch-update.sh:239
+#: src/script/arch-update.sh:241 src/script/arch-update.sh:243
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:244 src/script/arch-update.sh:246
+#: src/script/arch-update.sh:248 src/script/arch-update.sh:250
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:283
+#: src/script/arch-update.sh:287
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:288
+#: src/script/arch-update.sh:292
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:293
+#: src/script/arch-update.sh:297
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:300
+#: src/script/arch-update.sh:304
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:307
+#: src/script/arch-update.sh:311
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:310 src/script/arch-update.sh:449
-#: src/script/arch-update.sh:482 src/script/arch-update.sh:524
-#: src/script/arch-update.sh:591 src/script/arch-update.sh:617
+#: src/script/arch-update.sh:314 src/script/arch-update.sh:453
+#: src/script/arch-update.sh:486 src/script/arch-update.sh:528
+#: src/script/arch-update.sh:595 src/script/arch-update.sh:621
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/script/arch-update.sh:310 src/script/arch-update.sh:449
-#: src/script/arch-update.sh:482 src/script/arch-update.sh:524
-#: src/script/arch-update.sh:591 src/script/arch-update.sh:617
+#: src/script/arch-update.sh:314 src/script/arch-update.sh:453
+#: src/script/arch-update.sh:486 src/script/arch-update.sh:528
+#: src/script/arch-update.sh:595 src/script/arch-update.sh:621
 #, sh-format
 msgid "y"
 msgstr ""
 
-#: src/script/arch-update.sh:314
+#: src/script/arch-update.sh:318
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:345
+#: src/script/arch-update.sh:349
 #, sh-format
 msgid "Arch News:"
 msgstr ""
 
-#: src/script/arch-update.sh:350
+#: src/script/arch-update.sh:354
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:361
+#: src/script/arch-update.sh:365
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr ""
 
-#: src/script/arch-update.sh:363
+#: src/script/arch-update.sh:367
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:378
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:375
+#: src/script/arch-update.sh:379
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:376
+#: src/script/arch-update.sh:380
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:377
+#: src/script/arch-update.sh:381
 #, sh-format
 msgid "URL:"
 msgstr ""
 
-#: src/script/arch-update.sh:392
+#: src/script/arch-update.sh:396
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:397 src/script/arch-update.sh:409
-#: src/script/arch-update.sh:420
+#: src/script/arch-update.sh:401 src/script/arch-update.sh:413
+#: src/script/arch-update.sh:424
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:404
+#: src/script/arch-update.sh:408
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:416
+#: src/script/arch-update.sh:420
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:427
+#: src/script/arch-update.sh:431
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:439
+#: src/script/arch-update.sh:443
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:443
+#: src/script/arch-update.sh:447
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:445
+#: src/script/arch-update.sh:449
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:451
+#: src/script/arch-update.sh:455
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:455 src/script/arch-update.sh:488
-#: src/script/arch-update.sh:531 src/script/arch-update.sh:541
-#: src/script/arch-update.sh:551 src/script/arch-update.sh:560
+#: src/script/arch-update.sh:459 src/script/arch-update.sh:492
+#: src/script/arch-update.sh:535 src/script/arch-update.sh:545
+#: src/script/arch-update.sh:555 src/script/arch-update.sh:564
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:458 src/script/arch-update.sh:491
+#: src/script/arch-update.sh:462 src/script/arch-update.sh:495
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:463 src/script/arch-update.sh:495
-#: src/script/arch-update.sh:568
+#: src/script/arch-update.sh:467 src/script/arch-update.sh:499
+#: src/script/arch-update.sh:572
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:467
+#: src/script/arch-update.sh:471
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:472
+#: src/script/arch-update.sh:476
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:476
+#: src/script/arch-update.sh:480
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:478
+#: src/script/arch-update.sh:482
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:484
+#: src/script/arch-update.sh:488
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:499
+#: src/script/arch-update.sh:503
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:516
+#: src/script/arch-update.sh:520
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:517
+#: src/script/arch-update.sh:521
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:519
+#: src/script/arch-update.sh:523
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:520
+#: src/script/arch-update.sh:524
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:527 src/script/arch-update.sh:547
+#: src/script/arch-update.sh:531 src/script/arch-update.sh:551
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:537 src/script/arch-update.sh:556
+#: src/script/arch-update.sh:541 src/script/arch-update.sh:560
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:572
+#: src/script/arch-update.sh:576
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:581
+#: src/script/arch-update.sh:585
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:585
+#: src/script/arch-update.sh:589
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:587
+#: src/script/arch-update.sh:591
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:593
+#: src/script/arch-update.sh:597
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:597
+#: src/script/arch-update.sh:601
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:600
+#: src/script/arch-update.sh:604
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:604
+#: src/script/arch-update.sh:608
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:613
+#: src/script/arch-update.sh:617
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:614
+#: src/script/arch-update.sh:618
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:619
+#: src/script/arch-update.sh:623
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:623
+#: src/script/arch-update.sh:627
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:631
+#: src/script/arch-update.sh:635
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:635
+#: src/script/arch-update.sh:639
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,24 +16,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:115
+#: src/script/arch-update.sh:119
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/script/arch-update.sh:121
+#: src/script/arch-update.sh:125
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Appuyez sur \"entrée\" pour quitter "
 
-#: src/script/arch-update.sh:131
+#: src/script/arch-update.sh:135
 #, sh-format
 msgid ""
 "A privilege elevation method is required\\nPlease, install sudo or doas\\n"
 msgstr ""
 "Une méthode d'élévation de privilège est requise\\nVeuillez installer sudo ou doas\\n"
 
-#: src/script/arch-update.sh:153
+#: src/script/arch-update.sh:157
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
@@ -42,12 +42,12 @@ msgstr ""
 "Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les "
 "tâches importantes d'avant/après mise à jour."
 
-#: src/script/arch-update.sh:155
+#: src/script/arch-update.sh:159
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr "Lancez ${name} pour exécuter la fonction principale 'update' :"
 
-#: src/script/arch-update.sh:156
+#: src/script/arch-update.sh:160
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
@@ -56,14 +56,14 @@ msgstr ""
 "Afficher la liste des paquets disponibles pour mise à jour, puis demander la confirmation de l'utilisateur "
 "pour procéder à l'installation."
 
-#: src/script/arch-update.sh:157
+#: src/script/arch-update.sh:161
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 "Avant d'effectuer la mise à jour, propose d'afficher les dernières news d'Arch Linux."
 
-#: src/script/arch-update.sh:158
+#: src/script/arch-update.sh:162
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -74,12 +74,12 @@ msgstr ""
 "pacsave et de mise à jour du noyau en attente et, s'il y en a, "
 "propose de les traiter."
 
-#: src/script/arch-update.sh:160
+#: src/script/arch-update.sh:164
 #, sh-format
 msgid "Options:"
 msgstr "Options :"
 
-#: src/script/arch-update.sh:161
+#: src/script/arch-update.sh:165
 #, sh-format
 msgid ""
 "  -c, --check       Check for available updates, send a desktop notification "
@@ -88,17 +88,17 @@ msgstr ""
 "  -c, --check       Vérifier les mises à jour disponibles, envoyer une notification de bureau "
 "contenant le nombre de mises à jour disponibles (si libnotify est installé)"
 
-#: src/script/arch-update.sh:162
+#: src/script/arch-update.sh:166
 #, sh-format
 msgid "  -l, --list        Display the list of pending updates"
 msgstr "  -l, --list        Afficher les mises à jours en attente"
 
-#: src/script/arch-update.sh:163
+#: src/script/arch-update.sh:167
 #, sh-format
 msgid "  -d, --devel       Include AUR development packages updates"
 msgstr "  -d, --devel       Inclure les mises à jour des paquets de développement AUR"
 
-#: src/script/arch-update.sh:164
+#: src/script/arch-update.sh:168
 #, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
@@ -107,27 +107,27 @@ msgstr ""
 "  -n, --news [Num]  Afficher les dernières Arch news, vous pouvez optionellement spécifier le "
 "nombre de Arch news à afficher avec '--news [Num]' (e.g. '--news 10')"
 
-#: src/script/arch-update.sh:165
+#: src/script/arch-update.sh:169
 #, sh-format
 msgid "  -D, --debug       Display debug traces"
 msgstr "  -D, --debug       Afficher les traces de débogage"
 
-#: src/script/arch-update.sh:166
+#: src/script/arch-update.sh:170
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr "  -h, --help        Afficher ce message d'aide et quitter"
 
-#: src/script/arch-update.sh:167
+#: src/script/arch-update.sh:171
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr "  -V, --version     Afficher les informations de version et quitter"
 
-#: src/script/arch-update.sh:169
+#: src/script/arch-update.sh:173
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr "Pour plus d'informations, consultez la page de manuel ${name}(1)."
 
-#: src/script/arch-update.sh:170
+#: src/script/arch-update.sh:174
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
@@ -136,7 +136,7 @@ msgstr ""
 "Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration ${name}.conf, "
 "voir la page de manuel ${name}.conf(5)."
 
-#: src/script/arch-update.sh:181
+#: src/script/arch-update.sh:185
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
@@ -145,109 +145,109 @@ msgstr ""
 "${name}: option invalide -- '${option}'\\nEssayez '${name} --help' pour plus "
 "d'informations."
 
-#: src/script/arch-update.sh:237 src/script/arch-update.sh:239
+#: src/script/arch-update.sh:241 src/script/arch-update.sh:243
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} mise à jour disponible"
 
-#: src/script/arch-update.sh:244 src/script/arch-update.sh:246
+#: src/script/arch-update.sh:248 src/script/arch-update.sh:250
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/script/arch-update.sh:283
+#: src/script/arch-update.sh:287
 #, sh-format
 msgid "Packages:"
 msgstr "Paquets :"
 
-#: src/script/arch-update.sh:288
+#: src/script/arch-update.sh:292
 #, sh-format
 msgid "AUR Packages:"
 msgstr "Paquets AUR :"
 
-#: src/script/arch-update.sh:293
+#: src/script/arch-update.sh:297
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/script/arch-update.sh:300
+#: src/script/arch-update.sh:304
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
 
-#: src/script/arch-update.sh:307
+#: src/script/arch-update.sh:311
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:310 src/script/arch-update.sh:449
-#: src/script/arch-update.sh:482 src/script/arch-update.sh:524
-#: src/script/arch-update.sh:591 src/script/arch-update.sh:617
+#: src/script/arch-update.sh:314 src/script/arch-update.sh:453
+#: src/script/arch-update.sh:486 src/script/arch-update.sh:528
+#: src/script/arch-update.sh:595 src/script/arch-update.sh:621
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/script/arch-update.sh:310 src/script/arch-update.sh:449
-#: src/script/arch-update.sh:482 src/script/arch-update.sh:524
-#: src/script/arch-update.sh:591 src/script/arch-update.sh:617
+#: src/script/arch-update.sh:314 src/script/arch-update.sh:453
+#: src/script/arch-update.sh:486 src/script/arch-update.sh:528
+#: src/script/arch-update.sh:595 src/script/arch-update.sh:621
 #, sh-format
 msgid "y"
 msgstr "o"
 
-#: src/script/arch-update.sh:314
+#: src/script/arch-update.sh:318
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
 
-#: src/script/arch-update.sh:345
+#: src/script/arch-update.sh:349
 #, sh-format
 msgid "Arch News:"
 msgstr "Arch News :"
 
-#: src/script/arch-update.sh:350
+#: src/script/arch-update.sh:354
 #, sh-format
 msgid "[NEW]"
 msgstr "[NOUVEAU]"
 
-#: src/script/arch-update.sh:361
+#: src/script/arch-update.sh:365
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour quitter) :"
 
-#: src/script/arch-update.sh:363
+#: src/script/arch-update.sh:367
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour procéder à la mise à jour) :"
 
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:378
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/script/arch-update.sh:375
+#: src/script/arch-update.sh:379
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/script/arch-update.sh:376
+#: src/script/arch-update.sh:380
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:377
+#: src/script/arch-update.sh:381
 #, sh-format
 msgid "URL:"
 msgstr "URL :"
 
-#: src/script/arch-update.sh:392
+#: src/script/arch-update.sh:396
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:397 src/script/arch-update.sh:409
-#: src/script/arch-update.sh:420
+#: src/script/arch-update.sh:401 src/script/arch-update.sh:413
+#: src/script/arch-update.sh:424
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -256,27 +256,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:404
+#: src/script/arch-update.sh:408
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:416
+#: src/script/arch-update.sh:420
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:427
+#: src/script/arch-update.sh:431
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:439
+#: src/script/arch-update.sh:443
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:443
+#: src/script/arch-update.sh:447
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -285,7 +285,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:445
+#: src/script/arch-update.sh:449
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -294,14 +294,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:451
+#: src/script/arch-update.sh:455
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:455 src/script/arch-update.sh:488
-#: src/script/arch-update.sh:531 src/script/arch-update.sh:541
-#: src/script/arch-update.sh:551 src/script/arch-update.sh:560
+#: src/script/arch-update.sh:459 src/script/arch-update.sh:492
+#: src/script/arch-update.sh:535 src/script/arch-update.sh:545
+#: src/script/arch-update.sh:555 src/script/arch-update.sh:564
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -310,118 +310,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:458 src/script/arch-update.sh:491
+#: src/script/arch-update.sh:462 src/script/arch-update.sh:495
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:463 src/script/arch-update.sh:495
-#: src/script/arch-update.sh:568
+#: src/script/arch-update.sh:467 src/script/arch-update.sh:499
+#: src/script/arch-update.sh:572
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:467
+#: src/script/arch-update.sh:471
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:472
+#: src/script/arch-update.sh:476
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:476
+#: src/script/arch-update.sh:480
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:478
+#: src/script/arch-update.sh:482
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:484
+#: src/script/arch-update.sh:488
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:499
+#: src/script/arch-update.sh:503
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:516
+#: src/script/arch-update.sh:520
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:517
+#: src/script/arch-update.sh:521
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:519
+#: src/script/arch-update.sh:523
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:520
+#: src/script/arch-update.sh:524
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:527 src/script/arch-update.sh:547
+#: src/script/arch-update.sh:531 src/script/arch-update.sh:551
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:537 src/script/arch-update.sh:556
+#: src/script/arch-update.sh:541 src/script/arch-update.sh:560
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:572
+#: src/script/arch-update.sh:576
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:581
+#: src/script/arch-update.sh:585
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:585
+#: src/script/arch-update.sh:589
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:587
+#: src/script/arch-update.sh:591
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:593
+#: src/script/arch-update.sh:597
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:597
+#: src/script/arch-update.sh:601
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:600
+#: src/script/arch-update.sh:604
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:604
+#: src/script/arch-update.sh:608
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:613
+#: src/script/arch-update.sh:617
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -430,17 +430,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:614
+#: src/script/arch-update.sh:618
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:619
+#: src/script/arch-update.sh:623
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr "Redémarrage dans 5 secondes...\\nAppuyez sur ctrl+c pour annuler"
 
-#: src/script/arch-update.sh:623
+#: src/script/arch-update.sh:627
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -449,7 +449,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:631
+#: src/script/arch-update.sh:635
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -458,7 +458,7 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:635
+#: src/script/arch-update.sh:639
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -73,9 +73,9 @@ if [ -z "${no_color}" ]; then
 	yellow="${bold}\e[33m"
 	red="${bold}\e[31m"
 	color_off="\e[0m"
-	pacman_color_opt+=("--color always")
+	pacman_color_opt="always"
 else
-	pacman_color_opt+=("--color never")
+	pacman_color_opt="never"
 	contrib_color_opt="--nocolor"
 fi
 
@@ -273,9 +273,9 @@ list_packages() {
 
 	if [ -n "${aur_helper}" ]; then
 		if [ -z "${no_version}" ]; then
-			aur_packages=$("${aur_helper}" "${pacman_color_opt[@]}" "${devel_flag[@]}" -Qua)
+			aur_packages=$("${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Qua)
 		else
-			aur_packages=$("${aur_helper}" "${pacman_color_opt[@]}" "${devel_flag[@]}" -Qua | awk '{print $1}')
+			aur_packages=$("${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Qua | awk '{print $1}')
 		fi
 	fi
 
@@ -395,7 +395,7 @@ update() {
 		echo
 		main_msg "$(eval_gettext "Updating Packages...\n")"
 
-		if ! "${su_cmd}" pacman "${pacman_color_opt[@]}" -Syu; then
+		if ! "${su_cmd}" pacman --color "${pacman_color_opt}" -Syu; then
 			icon_updates_available
 			echo
 			error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
@@ -407,7 +407,7 @@ update() {
 		echo
 		main_msg "$(eval_gettext "Updating AUR Packages...\n")"
 
-		if ! "${aur_helper}" "${pacman_color_opt[@]}" "${devel_flag[@]}" -Syu; then
+		if ! "${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Syu; then
 			icon_updates_available
 			echo
 			error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
@@ -454,7 +454,7 @@ orphan_packages() {
 				echo
 				main_msg "$(eval_gettext "Removing Orphan Packages...\n")"
 				
-				if ! pacman -Qtdq | "${su_cmd}" pacman "${pacman_color_opt[@]}" -Rns -; then
+				if ! pacman -Qtdq | "${su_cmd}" pacman --color "${pacman_color_opt}" -Rns -; then
 					echo
 					error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 				else

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -73,9 +73,9 @@ if [ -z "${no_color}" ]; then
 	yellow="${bold}\e[33m"
 	red="${bold}\e[31m"
 	color_off="\e[0m"
-	pacman_color_opt="--color always"
+	pacman_color_opt+=("--color always")
 else
-	pacman_color_opt="--color never"
+	pacman_color_opt+=("--color never")
 	contrib_color_opt="--nocolor"
 fi
 
@@ -273,9 +273,9 @@ list_packages() {
 
 	if [ -n "${aur_helper}" ]; then
 		if [ -z "${no_version}" ]; then
-			aur_packages=$("${aur_helper}" "${pacman_color_opt}" "${devel_flag[@]}" -Qua)
+			aur_packages=$("${aur_helper}" "${pacman_color_opt[@]}" "${devel_flag[@]}" -Qua)
 		else
-			aur_packages=$("${aur_helper}" "${pacman_color_opt}" "${devel_flag[@]}" -Qua | awk '{print $1}')
+			aur_packages=$("${aur_helper}" "${pacman_color_opt[@]}" "${devel_flag[@]}" -Qua | awk '{print $1}')
 		fi
 	fi
 
@@ -395,7 +395,7 @@ update() {
 		echo
 		main_msg "$(eval_gettext "Updating Packages...\n")"
 
-		if ! "${su_cmd}" pacman "${pacman_color_opt}" -Syu; then
+		if ! "${su_cmd}" pacman "${pacman_color_opt[@]}" -Syu; then
 			icon_updates_available
 			echo
 			error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
@@ -407,7 +407,7 @@ update() {
 		echo
 		main_msg "$(eval_gettext "Updating AUR Packages...\n")"
 
-		if ! "${aur_helper}" "${pacman_color_opt}" "${devel_flag[@]}" -Syu; then
+		if ! "${aur_helper}" "${pacman_color_opt[@]}" "${devel_flag[@]}" -Syu; then
 			icon_updates_available
 			echo
 			error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
@@ -454,7 +454,7 @@ orphan_packages() {
 				echo
 				main_msg "$(eval_gettext "Removing Orphan Packages...\n")"
 				
-				if ! pacman -Qtdq | "${su_cmd}" pacman "${pacman_color_opt}" -Rns -; then
+				if ! pacman -Qtdq | "${su_cmd}" pacman "${pacman_color_opt[@]}" -Rns -; then
 					echo
 					error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 				else

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -76,7 +76,7 @@ if [ -z "${no_color}" ]; then
 	pacman_color_opt="always"
 else
 	pacman_color_opt="never"
-	contrib_color_opt="--nocolor"
+	contrib_color_opt+=("--nocolor")
 fi
 
 # Create state and tmp dirs if they don't exist
@@ -266,9 +266,9 @@ list_packages() {
 	icon_checking
 	
 	if [ -z "${no_version}" ]; then
-		packages=$(checkupdates "${contrib_color_opt}")
+		packages=$(checkupdates "${contrib_color_opt[@]}")
 	else
-		packages=$(checkupdates "${contrib_color_opt}" | awk '{print $1}')
+		packages=$(checkupdates "${contrib_color_opt[@]}" | awk '{print $1}')
 	fi
 
 	if [ -n "${aur_helper}" ]; then
@@ -530,7 +530,7 @@ packages_cache() {
 					echo
 					main_msg "$(eval_gettext "Removing old cached packages...")"
 
-					if ! "${su_cmd}" paccache "${contrib_color_opt}" -rk"${old_packages_num}"; then
+					if ! "${su_cmd}" paccache "${contrib_color_opt[@]}" -rk"${old_packages_num}"; then
 						echo
 						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
@@ -540,7 +540,7 @@ packages_cache() {
 					echo
 					main_msg "$(eval_gettext "Removing uninstalled cached packages...")"
 
-					if ! "${su_cmd}" paccache "${contrib_color_opt}" -ruk"${uninstalled_packages_num}"; then
+					if ! "${su_cmd}" paccache "${contrib_color_opt[@]}" -ruk"${uninstalled_packages_num}"; then
 						echo
 						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
@@ -550,7 +550,7 @@ packages_cache() {
 					echo
 					main_msg "$(eval_gettext "Removing old cached packages...")"
 
-					if ! "${su_cmd}" paccache "${contrib_color_opt}" -rk"${old_packages_num}"; then
+					if ! "${su_cmd}" paccache "${contrib_color_opt[@]}" -rk"${old_packages_num}"; then
 						echo
 						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
@@ -559,7 +559,7 @@ packages_cache() {
 
 					main_msg "$(eval_gettext "Removing uninstalled cached packages...")"
 
-					if ! "${su_cmd}" paccache "${contrib_color_opt}" -ruk"${uninstalled_packages_num}"; then
+					if ! "${su_cmd}" paccache "${contrib_color_opt[@]}" -ruk"${uninstalled_packages_num}"; then
 						echo
 						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
@@ -596,7 +596,7 @@ pacnew_files() {
 				echo
 				main_msg "$(eval_gettext "Processing Pacnew Files...\n")"
 
-				"${su_cmd}" pacdiff "${contrib_color_opt}"
+				"${su_cmd}" pacdiff "${contrib_color_opt[@]}"
 				echo
 				info_msg "$(eval_gettext "The pacnew file(s) processing has been applied\n")"
 			;;

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -507,8 +507,8 @@ orphan_packages() {
 
 # Definition of the packages_cache function: Search for old package archives in the pacman cache and offer to remove them if there are
 packages_cache() {
-	pacman_cache_old=$(paccache "${contrib_color_opt}" -dk"${old_packages_num}" | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
-	pacman_cache_uninstalled=$(paccache "${contrib_color_opt}" -duk"${uninstalled_packages_num}" | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
+	pacman_cache_old=$(paccache -dk"${old_packages_num}" | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
+	pacman_cache_uninstalled=$(paccache -duk"${uninstalled_packages_num}" | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
 
 	[ -z "${pacman_cache_old}" ] && pacman_cache_old="0"
 	[ -z "${pacman_cache_uninstalled}" ] && pacman_cache_uninstalled="0"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -73,6 +73,10 @@ if [ -z "${no_color}" ]; then
 	yellow="${bold}\e[33m"
 	red="${bold}\e[31m"
 	color_off="\e[0m"
+	pacman_color_opt="--color always"
+else
+	pacman_color_opt="--color never"
+	contrib_color_opt="--nocolor"
 fi
 
 # Create state and tmp dirs if they don't exist
@@ -262,16 +266,16 @@ list_packages() {
 	icon_checking
 	
 	if [ -z "${no_version}" ]; then
-		packages=$(checkupdates)
+		packages=$(checkupdates "${contrib_color_opt}")
 	else
-		packages=$(checkupdates | awk '{print $1}')
+		packages=$(checkupdates "${contrib_color_opt}" | awk '{print $1}')
 	fi
 
 	if [ -n "${aur_helper}" ]; then
 		if [ -z "${no_version}" ]; then
-			aur_packages=$("${aur_helper}" -Qua "${devel_flag[@]}")
+			aur_packages=$("${aur_helper}" "${pacman_color_opt}" "${devel_flag[@]}" -Qua)
 		else
-			aur_packages=$("${aur_helper}" -Qua "${devel_flag[@]}" | awk '{print $1}')
+			aur_packages=$("${aur_helper}" "${pacman_color_opt}" "${devel_flag[@]}" -Qua | awk '{print $1}')
 		fi
 	fi
 
@@ -391,7 +395,7 @@ update() {
 		echo
 		main_msg "$(eval_gettext "Updating Packages...\n")"
 
-		if ! "${su_cmd}" pacman -Syu; then
+		if ! "${su_cmd}" pacman "${pacman_color_opt}" -Syu; then
 			icon_updates_available
 			echo
 			error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
@@ -403,7 +407,7 @@ update() {
 		echo
 		main_msg "$(eval_gettext "Updating AUR Packages...\n")"
 
-		if ! "${aur_helper}" -Syu "${devel_flag[@]}"; then
+		if ! "${aur_helper}" "${pacman_color_opt}" "${devel_flag[@]}" -Syu; then
 			icon_updates_available
 			echo
 			error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
@@ -450,7 +454,7 @@ orphan_packages() {
 				echo
 				main_msg "$(eval_gettext "Removing Orphan Packages...\n")"
 				
-				if ! pacman -Qtdq | "${su_cmd}" pacman -Rns -; then
+				if ! pacman -Qtdq | "${su_cmd}" pacman "${pacman_color_opt}" -Rns -; then
 					echo
 					error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 				else
@@ -503,8 +507,8 @@ orphan_packages() {
 
 # Definition of the packages_cache function: Search for old package archives in the pacman cache and offer to remove them if there are
 packages_cache() {
-	pacman_cache_old=$(paccache -dk"${old_packages_num}" | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
-	pacman_cache_uninstalled=$(paccache -duk"${uninstalled_packages_num}" | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
+	pacman_cache_old=$(paccache "${contrib_color_opt}" -dk"${old_packages_num}" | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
+	pacman_cache_uninstalled=$(paccache "${contrib_color_opt}" -duk"${uninstalled_packages_num}" | sed -n 's/.*: \([0-9]*\) candidate.*/\1/p')
 
 	[ -z "${pacman_cache_old}" ] && pacman_cache_old="0"
 	[ -z "${pacman_cache_uninstalled}" ] && pacman_cache_uninstalled="0"
@@ -526,7 +530,7 @@ packages_cache() {
 					echo
 					main_msg "$(eval_gettext "Removing old cached packages...")"
 
-					if ! "${su_cmd}" paccache -rk"${old_packages_num}"; then
+					if ! "${su_cmd}" paccache "${contrib_color_opt}" -rk"${old_packages_num}"; then
 						echo
 						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
@@ -536,7 +540,7 @@ packages_cache() {
 					echo
 					main_msg "$(eval_gettext "Removing uninstalled cached packages...")"
 
-					if ! "${su_cmd}" paccache -ruk"${uninstalled_packages_num}"; then
+					if ! "${su_cmd}" paccache "${contrib_color_opt}" -ruk"${uninstalled_packages_num}"; then
 						echo
 						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
@@ -546,7 +550,7 @@ packages_cache() {
 					echo
 					main_msg "$(eval_gettext "Removing old cached packages...")"
 
-					if ! "${su_cmd}" paccache -rk"${old_packages_num}"; then
+					if ! "${su_cmd}" paccache "${contrib_color_opt}" -rk"${old_packages_num}"; then
 						echo
 						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
@@ -555,7 +559,7 @@ packages_cache() {
 
 					main_msg "$(eval_gettext "Removing uninstalled cached packages...")"
 
-					if ! "${su_cmd}" paccache -ruk"${uninstalled_packages_num}"; then
+					if ! "${su_cmd}" paccache "${contrib_color_opt}" -ruk"${uninstalled_packages_num}"; then
 						echo
 						error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 					else
@@ -592,7 +596,7 @@ pacnew_files() {
 				echo
 				main_msg "$(eval_gettext "Processing Pacnew Files...\n")"
 
-				"${su_cmd}" pacdiff
+				"${su_cmd}" pacdiff "${contrib_color_opt}"
 				echo
 				info_msg "$(eval_gettext "The pacnew file(s) processing has been applied\n")"
 			;;


### PR DESCRIPTION
Paru recently changed the way [the color output are automatically enabled](https://github.com/Morganamilo/paru/commit/b345771e91261b2eb19d33d8e3c192bd0be14051), resulting in a non-colored output when executing `arch-update`.

This PR aims to fix that by enforcing the color option depending on the presence of the `NoColor` option in `arch-update.conf` (`--color always|never`) for Paru but also for every wrapped tool in the main script (pacman, yay/paru, pacman-contrib tools, etc...) to avoid such issue in the future.