### PR TITLE
Add an explicit message that the script is looking for updates

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Arch-Update 1.14.3\n"
 "Report-Msgid-Bugs-To: https://github.com/Antiz96/arch-update/issues\n"
-"POT-Creation-Date: 2024-03-17 16:22-0400\n"
+"POT-Creation-Date: 2024-03-17 16:22+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: \n"
@@ -138,295 +138,300 @@ msgstr ""
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:287
+#: src/script/arch-update.sh:267
+#, sh-format
+msgid "Looking for updates...\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:288
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:292
+#: src/script/arch-update.sh:293
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:297
+#: src/script/arch-update.sh:298
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:304
+#: src/script/arch-update.sh:305
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:311
+#: src/script/arch-update.sh:312
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:314 src/script/arch-update.sh:453
-#: src/script/arch-update.sh:486 src/script/arch-update.sh:528
-#: src/script/arch-update.sh:595 src/script/arch-update.sh:621
+#: src/script/arch-update.sh:315 src/script/arch-update.sh:454
+#: src/script/arch-update.sh:487 src/script/arch-update.sh:529
+#: src/script/arch-update.sh:596 src/script/arch-update.sh:622
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/script/arch-update.sh:314 src/script/arch-update.sh:453
-#: src/script/arch-update.sh:486 src/script/arch-update.sh:528
-#: src/script/arch-update.sh:595 src/script/arch-update.sh:621
+#: src/script/arch-update.sh:315 src/script/arch-update.sh:454
+#: src/script/arch-update.sh:487 src/script/arch-update.sh:529
+#: src/script/arch-update.sh:596 src/script/arch-update.sh:622
 #, sh-format
 msgid "y"
 msgstr ""
 
-#: src/script/arch-update.sh:318
+#: src/script/arch-update.sh:319
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:349
+#: src/script/arch-update.sh:350
 #, sh-format
 msgid "Arch News:"
 msgstr ""
 
-#: src/script/arch-update.sh:354
+#: src/script/arch-update.sh:355
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:365
+#: src/script/arch-update.sh:366
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr ""
 
-#: src/script/arch-update.sh:367
+#: src/script/arch-update.sh:368
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:378
+#: src/script/arch-update.sh:379
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:379
+#: src/script/arch-update.sh:380
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:380
+#: src/script/arch-update.sh:381
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:381
+#: src/script/arch-update.sh:382
 #, sh-format
 msgid "URL:"
 msgstr ""
 
-#: src/script/arch-update.sh:396
+#: src/script/arch-update.sh:397
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:401 src/script/arch-update.sh:413
-#: src/script/arch-update.sh:424
+#: src/script/arch-update.sh:402 src/script/arch-update.sh:414
+#: src/script/arch-update.sh:425
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:408
+#: src/script/arch-update.sh:409
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:420
+#: src/script/arch-update.sh:421
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:431
+#: src/script/arch-update.sh:432
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:443
+#: src/script/arch-update.sh:444
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:447
+#: src/script/arch-update.sh:448
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:449
+#: src/script/arch-update.sh:450
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:455
+#: src/script/arch-update.sh:456
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:459 src/script/arch-update.sh:492
-#: src/script/arch-update.sh:535 src/script/arch-update.sh:545
-#: src/script/arch-update.sh:555 src/script/arch-update.sh:564
+#: src/script/arch-update.sh:460 src/script/arch-update.sh:493
+#: src/script/arch-update.sh:536 src/script/arch-update.sh:546
+#: src/script/arch-update.sh:556 src/script/arch-update.sh:565
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:462 src/script/arch-update.sh:495
+#: src/script/arch-update.sh:463 src/script/arch-update.sh:496
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:467 src/script/arch-update.sh:499
-#: src/script/arch-update.sh:572
+#: src/script/arch-update.sh:468 src/script/arch-update.sh:500
+#: src/script/arch-update.sh:573
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:471
+#: src/script/arch-update.sh:472
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:476
+#: src/script/arch-update.sh:477
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:480
+#: src/script/arch-update.sh:481
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:482
+#: src/script/arch-update.sh:483
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:488
+#: src/script/arch-update.sh:489
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:503
+#: src/script/arch-update.sh:504
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:520
+#: src/script/arch-update.sh:521
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:521
+#: src/script/arch-update.sh:522
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:523
+#: src/script/arch-update.sh:524
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:524
+#: src/script/arch-update.sh:525
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:531 src/script/arch-update.sh:551
+#: src/script/arch-update.sh:532 src/script/arch-update.sh:552
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:541 src/script/arch-update.sh:560
+#: src/script/arch-update.sh:542 src/script/arch-update.sh:561
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:576
+#: src/script/arch-update.sh:577
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:585
+#: src/script/arch-update.sh:586
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:589
+#: src/script/arch-update.sh:590
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:591
+#: src/script/arch-update.sh:592
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:597
+#: src/script/arch-update.sh:598
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:601
+#: src/script/arch-update.sh:602
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:604
+#: src/script/arch-update.sh:605
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:608
+#: src/script/arch-update.sh:609
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:617
+#: src/script/arch-update.sh:618
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:618
+#: src/script/arch-update.sh:619
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:623
+#: src/script/arch-update.sh:624
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr ""
 
-#: src/script/arch-update.sh:627
+#: src/script/arch-update.sh:628
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:635
+#: src/script/arch-update.sh:636
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:639
+#: src/script/arch-update.sh:640
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Arch-Update 1.14.3\n"
 "Report-Msgid-Bugs-To: https://github.com/Antiz96/arch-update/issues\n"
-"POT-Creation-Date: 2024-02-09 01:21+0100\n"
+"POT-Creation-Date: 2024-03-17 16:22+0100\n"
 "PO-Revision-Date: 2024-03-17 17:00+0100\n"
 "Last-Translator: Robin Candau <robincandau@protonmail.com>\n"
 "Language: fr\n"
@@ -155,99 +155,104 @@ msgstr "${update_number} mise à jour disponible"
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/script/arch-update.sh:287
+#: src/script/arch-update.sh:267
+#, sh-format
+msgid "Looking for updates...\\n"
+msgstr "Recherche de mises à jour...\\n"
+
+#: src/script/arch-update.sh:288
 #, sh-format
 msgid "Packages:"
 msgstr "Paquets :"
 
-#: src/script/arch-update.sh:292
+#: src/script/arch-update.sh:293
 #, sh-format
 msgid "AUR Packages:"
 msgstr "Paquets AUR :"
 
-#: src/script/arch-update.sh:297
+#: src/script/arch-update.sh:298
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/script/arch-update.sh:304
+#: src/script/arch-update.sh:305
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
 
-#: src/script/arch-update.sh:311
+#: src/script/arch-update.sh:312
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:314 src/script/arch-update.sh:453
-#: src/script/arch-update.sh:486 src/script/arch-update.sh:528
-#: src/script/arch-update.sh:595 src/script/arch-update.sh:621
+#: src/script/arch-update.sh:315 src/script/arch-update.sh:454
+#: src/script/arch-update.sh:487 src/script/arch-update.sh:529
+#: src/script/arch-update.sh:596 src/script/arch-update.sh:622
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/script/arch-update.sh:314 src/script/arch-update.sh:453
-#: src/script/arch-update.sh:486 src/script/arch-update.sh:528
-#: src/script/arch-update.sh:595 src/script/arch-update.sh:621
+#: src/script/arch-update.sh:315 src/script/arch-update.sh:454
+#: src/script/arch-update.sh:487 src/script/arch-update.sh:529
+#: src/script/arch-update.sh:596 src/script/arch-update.sh:622
 #, sh-format
 msgid "y"
 msgstr "o"
 
-#: src/script/arch-update.sh:318
+#: src/script/arch-update.sh:319
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
 
-#: src/script/arch-update.sh:349
+#: src/script/arch-update.sh:350
 #, sh-format
 msgid "Arch News:"
 msgstr "Arch News :"
 
-#: src/script/arch-update.sh:354
+#: src/script/arch-update.sh:355
 #, sh-format
 msgid "[NEW]"
 msgstr "[NOUVEAU]"
 
-#: src/script/arch-update.sh:365
+#: src/script/arch-update.sh:366
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour quitter) :"
 
-#: src/script/arch-update.sh:367
+#: src/script/arch-update.sh:368
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour procéder à la mise à jour) :"
 
-#: src/script/arch-update.sh:378
+#: src/script/arch-update.sh:379
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/script/arch-update.sh:379
+#: src/script/arch-update.sh:380
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/script/arch-update.sh:380
+#: src/script/arch-update.sh:381
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:381
+#: src/script/arch-update.sh:382
 #, sh-format
 msgid "URL:"
 msgstr "URL :"
 
-#: src/script/arch-update.sh:396
+#: src/script/arch-update.sh:397
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:401 src/script/arch-update.sh:413
-#: src/script/arch-update.sh:424
+#: src/script/arch-update.sh:402 src/script/arch-update.sh:414
+#: src/script/arch-update.sh:425
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -256,27 +261,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:408
+#: src/script/arch-update.sh:409
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:420
+#: src/script/arch-update.sh:421
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:431
+#: src/script/arch-update.sh:432
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:443
+#: src/script/arch-update.sh:444
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:447
+#: src/script/arch-update.sh:448
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -285,7 +290,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:449
+#: src/script/arch-update.sh:450
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -294,14 +299,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:455
+#: src/script/arch-update.sh:456
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:459 src/script/arch-update.sh:492
-#: src/script/arch-update.sh:535 src/script/arch-update.sh:545
-#: src/script/arch-update.sh:555 src/script/arch-update.sh:564
+#: src/script/arch-update.sh:460 src/script/arch-update.sh:493
+#: src/script/arch-update.sh:536 src/script/arch-update.sh:546
+#: src/script/arch-update.sh:556 src/script/arch-update.sh:565
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -310,118 +315,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:462 src/script/arch-update.sh:495
+#: src/script/arch-update.sh:463 src/script/arch-update.sh:496
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:467 src/script/arch-update.sh:499
-#: src/script/arch-update.sh:572
+#: src/script/arch-update.sh:468 src/script/arch-update.sh:500
+#: src/script/arch-update.sh:573
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:471
+#: src/script/arch-update.sh:472
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:476
+#: src/script/arch-update.sh:477
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:480
+#: src/script/arch-update.sh:481
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:482
+#: src/script/arch-update.sh:483
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:488
+#: src/script/arch-update.sh:489
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:503
+#: src/script/arch-update.sh:504
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:520
+#: src/script/arch-update.sh:521
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:521
+#: src/script/arch-update.sh:522
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:523
+#: src/script/arch-update.sh:524
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:524
+#: src/script/arch-update.sh:525
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:531 src/script/arch-update.sh:551
+#: src/script/arch-update.sh:532 src/script/arch-update.sh:552
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:541 src/script/arch-update.sh:560
+#: src/script/arch-update.sh:542 src/script/arch-update.sh:561
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:576
+#: src/script/arch-update.sh:577
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:585
+#: src/script/arch-update.sh:586
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:589
+#: src/script/arch-update.sh:590
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:591
+#: src/script/arch-update.sh:592
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:597
+#: src/script/arch-update.sh:598
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:601
+#: src/script/arch-update.sh:602
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:604
+#: src/script/arch-update.sh:605
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:608
+#: src/script/arch-update.sh:609
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:617
+#: src/script/arch-update.sh:618
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -430,17 +435,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:618
+#: src/script/arch-update.sh:619
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:623
+#: src/script/arch-update.sh:624
 #, sh-format
 msgid "Rebooting in 5 seconds...\\nPress ctrl+c to abort"
 msgstr "Redémarrage dans 5 secondes...\\nAppuyez sur ctrl+c pour annuler"
 
-#: src/script/arch-update.sh:627
+#: src/script/arch-update.sh:628
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -449,7 +454,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:635
+#: src/script/arch-update.sh:636
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -458,7 +463,7 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:639
+#: src/script/arch-update.sh:640
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -264,6 +264,7 @@ check() {
 # Definition of the list_packages function: Display packages that are available for update and offer to apply them if there are
 list_packages() {
 	icon_checking
+	info_msg "$(eval_gettext "Looking for updates...\n")"
 	
 	if [ -z "${no_version}" ]; then
 		packages=$(checkupdates "${contrib_color_opt[@]}")
@@ -689,4 +690,3 @@ case "${option}" in
 		invalid_option
 	;;
 esac
-


### PR DESCRIPTION
On a poor network connection and/or with a long list of pending updates, the script might take some time to look for and generate the list of packages available to update.

Without an explicit/clear indicator that the script is actually looking for updates, one could think that it is 'stuck'. This commit introduces an explicit message that the script is currently looking for updates to avoid people thinking it hanged up.