### PR TITLE
Make systray applet also searching in XDG_DATA_HOME & XDG_DATA_DIRS when looking for the .desktop file

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -84,7 +84,7 @@ Pour démarrer l'applet systray automatiquement au démarrage du système, ajout
 systemctl --user enable --now arch-update-tray.service
 ```
 
-L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance `arch-update` via le [fichier arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
+L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance `arch-update` via le fichier [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
 
 L'applet systray essaie de lire le fichier `arch-update.desktop` dans les chemins ci-dessous avec l'ordre suivant :
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -84,9 +84,17 @@ Pour démarrer l'applet systray automatiquement au démarrage du système, ajout
 systemctl --user enable --now arch-update-tray.service
 ```
 
-L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Il lancera la série de fonctions nécessaires pour effectuer une mise à jour complète et appropriée lorsque vous cliquez dessus.
+L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance `arch-update` via le [fichier arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
 
-Alternativement, si vous n'avez pas (ou ne voulez pas) le support du systray, il y a un fichier `.desktop` classique (sous `/usr/share/applications/arch-update.desktop` ou `/usr/local/share/applications/arch-update.desktop` si vous avez installé `Arch-Update` [depuis la source](#depuis-la-source)). Notez que, à l'inverse de l'applet systray, l'icône du fichier `.desktop` ne changera **pas** dynamiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles').
+L'applet systray essaie de lire le fichier `arch-update.desktop` dans les chemins ci-dessous avec l'ordre suivant :
+
+- `$XDG_DATA_HOME/applications/arch-update.desktop`
+- `$HOME/.local/share/applications/arch-update.desktop`
+- `$XDG_DATA_DIRS/applications/arch-update.desktop`
+- `/usr/local/share/applications/arch-update.desktop` <-- Chemin d'installation par défaut lorsque vous installez Arch-Update [depuis la source](#depuis-la-source)
+- `/usr/share/applications/arch-update.desktop` <-- Chemin d'installation par défaut lorsque vous installez Arch-Update [depuis le AUR](#AUR)
+
+Dans le cas où vous avez envie/besoin de personnaliser le fichier `arch-update.desktop`, copiez le dans un chemin qui a une priorité plus élevée que le chemin d'installation par défaut et modifier le ici (afin d'assurer que votre ficher `arch-update.desktop` personnalisé remplace celui par défaut et que vos modifications ne soient pas écrasées à chaque mise à jour).
 
 ### Le timer systemd
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The systray applet attempts to read the `arch-update.desktop` file at the below 
 - `/usr/local/share/applications/arch-update.desktop` <-- Default installation path when installing Arch-Update [from source](#from-source)
 - `/usr/share/applications/arch-update.desktop` <-- Default installation path when installing Arch-Update [from the AUR](#AUR)
 
-In case you wan't/need to customize the `arch-update.desktop` file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom `arch-update.desktop` file supersedes the default one and that your modifications are not being overwritten on updates).
+In case you want/need to customize the `arch-update.desktop` file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom `arch-update.desktop` file supersedes the default one and that your modifications are not being overwritten on updates).
 
 ### The systemd timer
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,17 @@ To start the systray applet automatically at boot, add the `arch-update --tray` 
 systemctl --user enable --now arch-update-tray.service
 ```
 
-The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). It will launch the relevant series of functions to perform a complete and proper update when clicked.
+The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches `arch-update` via the [arch-update.desktop file](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
 
-Alternatively, if you don't have/want systray support, there's a regular `.desktop` file (under `/usr/share/applications/arch-update.desktop` or `/usr/local/share/applications/arch-update.desktop` if you installed `Arch-Update` [from source](#from-source)). Note that, unlike the systray applet, the `.desktop` icon does **not** dynamically change depending on the current state of your system ('up to date' or 'updates available').
+The systray applet attempts to read the `arch-update.desktop` file at the below paths and in the following order:
+
+- `$XDG_DATA_HOME/applications/arch-update.desktop`
+- `$HOME/.local/share/applications/arch-update.desktop`
+- `$XDG_DATA_DIRS/applications/arch-update.desktop`
+- `/usr/local/share/applications/arch-update.desktop` <-- Default installation path when installing Arch-Update [from source](#from-source)
+- `/usr/share/applications/arch-update.desktop` <-- Default installation path when installing Arch-Update [from the AUR](#AUR)
+
+In case you wan't/need to customize the `arch-update.desktop` file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom `arch-update.desktop` file supersedes the default one and that your modifications are not being overwritten on updates).
 
 ### The systemd timer
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To start the systray applet automatically at boot, add the `arch-update --tray` 
 systemctl --user enable --now arch-update-tray.service
 ```
 
-The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches `arch-update` via the [arch-update.desktop file](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
+The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches `arch-update` via the [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop) file.
 
 The systray applet attempts to read the `arch-update.desktop` file at the below paths and in the following order:
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -80,14 +80,18 @@ Display the help message.
 .B The systray applet
 .RB "To start the systray applet automatically at boot, add the " "arch-update --tray " "command to your auto-start commands/WM config or start/enable the associated systemd service like so: " "systemctl \-\-user enable \-\-now arch-update-tray.service"
 .br
-.RB "The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches " "arch-update " "via the " "arch-update.desktop" file.
+.RB "The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches " "arch-update " "via the " "arch-update.desktop " file.
 .br
 .RB "The systray applet attempts to read the " "arch-update.desktop " "file at the below paths and in the following order:"
 .br
 \- $XDG_DATA_HOME/applications/arch-update.desktop
+.br
 \- $HOME/.local/share/applications/arch-update.desktop
+.br
 \- $XDG_DATA_DIRS/applications/arch-update.desktop
+.br
 \- /usr/local/share/applications/arch-update.desktop <-- Default installation path when installing Arch-Update from source
+.br
 \- /usr/share/applications/arch-update.desktop <-- Default installation path when installing Arch-Update from the AUR
 .br
 .RB "In case you want/need to customize the " "arch-update.desktop " "file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom " "arch-update.desktop " "file supersedes the default one and that your modifications are not being overwritten on updates)."

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -90,7 +90,7 @@ Display the help message.
 \- /usr/local/share/applications/arch-update.desktop <-- Default installation path when installing Arch-Update from source
 \- /usr/share/applications/arch-update.desktop <-- Default installation path when installing Arch-Update from the AUR
 .br
-.RB "In case you wan't/need to customize the " "arch-update.desktop " "file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom " "arch-update.desktop " "file supersedes the default one and that your modifications are not being overwritten on updates)."
+.RB "In case you want/need to customize the " "arch-update.desktop " "file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom " "arch-update.desktop " "file supersedes the default one and that your modifications are not being overwritten on updates)."
 
 .TP
 .B The systemd timer

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -80,9 +80,17 @@ Display the help message.
 .B The systray applet
 .RB "To start the systray applet automatically at boot, add the " "arch-update --tray " "command to your auto-start commands/WM config or start/enable the associated systemd service like so: " "systemctl \-\-user enable \-\-now arch-update-tray.service"
 .br
-The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). It will launch the relevant series of functions to perform a complete and proper update when clicked.
+.RB "The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches " "arch-update " "via the " "arch-update.desktop" file.
 .br
-.RB "Alternatively, if you don't have/want systray support, there's a regular .desktop file (under " "/usr/share/applications/arch-update.desktop " "or " "/usr/local/share/applications/arch-update.desktop " "if you installed Arch-Update from source). Note that, unlike the systray applet, the .desktop icon does " "not " "dynamically change depending on the current state of your system ('up to date' or 'updates available')."
+.RB "The systray applet attempts to read the " "arch-update.desktop " "file at the below paths and in the following order:"
+.br
+\- $XDG_DATA_HOME/applications/arch-update.desktop
+\- $HOME/.local/share/applications/arch-update.desktop
+\- $XDG_DATA_DIRS/applications/arch-update.desktop
+\- /usr/local/share/applications/arch-update.desktop <-- Default installation path when installing Arch-Update from source
+\- /usr/share/applications/arch-update.desktop <-- Default installation path when installing Arch-Update from the AUR
+.br
+.RB "In case you wan't/need to customize the " "arch-update.desktop " "file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom " "arch-update.desktop " "file supersedes the default one and that your modifications are not being overwritten on updates)."
 
 .TP
 .B The systemd timer

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -83,7 +83,7 @@ Display the help message.
 .RB "The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches " "arch-update " "via the " "arch-update.desktop " file.
 .br
 .RB "The systray applet attempts to read the " "arch-update.desktop " "file at the below paths and in the following order:"
-.br
+
 \- $XDG_DATA_HOME/applications/arch-update.desktop
 .br
 \- $HOME/.local/share/applications/arch-update.desktop
@@ -93,7 +93,7 @@ Display the help message.
 \- /usr/local/share/applications/arch-update.desktop <-- Default installation path when installing Arch-Update from source
 .br
 \- /usr/share/applications/arch-update.desktop <-- Default installation path when installing Arch-Update from the AUR
-.br
+
 .RB "In case you want/need to customize the " "arch-update.desktop " "file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom " "arch-update.desktop " "file supersedes the default one and that your modifications are not being overwritten on updates)."
 
 .TP

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -81,7 +81,7 @@ Display the help message.
 .RB "To start the systray applet automatically at boot, add the " "arch-update --tray " "command to your auto-start commands/WM config or start/enable the associated systemd service like so: " "systemctl \-\-user enable \-\-now arch-update-tray.service"
 .br
 .RB "The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches " "arch-update " "via the " "arch-update.desktop " file.
-.br
+
 .RB "The systray applet attempts to read the " "arch-update.desktop " "file at the below paths and in the following order:"
 
 \- $XDG_DATA_HOME/applications/arch-update.desktop

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -83,7 +83,7 @@ Afficher le message d'aide.
 .RB "L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance " "arch-update " "via le fichier " "arch-update.desktop".
 .br
 .RB "L'applet systray essaie de lire le fichier " "arch-update.desktop " "dans les chemins ci-dessous avec l'ordre suivant :"
-.br
+
 \- $XDG_DATA_HOME/applications/arch-update.desktop
 .br
 \- $HOME/.local/share/applications/arch-update.desktop
@@ -93,7 +93,7 @@ Afficher le message d'aide.
 \- /usr/local/share/applications/arch-update.desktop <-- Chemin d'installation par défaut lorsque vous installez Arch-Update depuis la source
 .br
 \- /usr/share/applications/arch-update.desktop <-- Chemin d'installation par défaut lorsque vous installez Arch-Update depuis le AUR
-.br
+
 .RB "Dans le cas où vous avez envie/besoin de personnaliser le fichier " "arch-update.desktop" ", copiez le dans un chemin qui a une priorité plus élevée que le chemin d'installation par défaut et modifier le ici (afin d'assurer que votre ficher " "arch-update.desktop " "personnalisé remplace celui par défaut et que vos modifications ne soient pas écrasées à chaque mise à jour)."
 
 .TP

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -85,12 +85,16 @@ Afficher le message d'aide.
 .RB "L'applet systray essaie de lire le fichier " "arch-update.desktop " "dans les chemins ci-dessous avec l'ordre suivant :"
 .br
 \- $XDG_DATA_HOME/applications/arch-update.desktop
+.br
 \- $HOME/.local/share/applications/arch-update.desktop
+.br
 \- $XDG_DATA_DIRS/applications/arch-update.desktop
+.br
 \- /usr/local/share/applications/arch-update.desktop <-- Chemin d'installation par défaut lorsque vous installez Arch-Update depuis la source
+.br
 \- /usr/share/applications/arch-update.desktop <-- Chemin d'installation par défaut lorsque vous installez Arch-Update depuis le AUR
 .br
-.RB "Dans le cas où vous avez envie/besoin de personnaliser le fichier " "arch-update.desktop"", copiez le dans un chemin qui a une priorité plus élevée que le chemin d'installation par défaut et modifier le ici (afin d'assurer que votre ficher " "arch-update.desktop " "personnalisé remplace celui par défaut et que vos modifications ne soient pas écrasées à chaque mise à jour)."
+.RB "Dans le cas où vous avez envie/besoin de personnaliser le fichier " "arch-update.desktop" ", copiez le dans un chemin qui a une priorité plus élevée que le chemin d'installation par défaut et modifier le ici (afin d'assurer que votre ficher " "arch-update.desktop " "personnalisé remplace celui par défaut et que vos modifications ne soient pas écrasées à chaque mise à jour)."
 
 .TP
 .B Le timer systemd

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -81,7 +81,7 @@ Afficher le message d'aide.
 .RB "Pour démarrer l'applet systray automatiquement au démarrage du système, ajouter la commande " "arch-update --tray " "à vos commandes 'auto-start'/configuration de votre WM ou démarrez/activez le service systemd associé comme ceci : " "systemctl \-\-user enable \-\-now arch-update-tray.service"
 .br
 .RB "L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance " "arch-update " "via le fichier " "arch-update.desktop".
-.br
+
 .RB "L'applet systray essaie de lire le fichier " "arch-update.desktop " "dans les chemins ci-dessous avec l'ordre suivant :"
 
 \- $XDG_DATA_HOME/applications/arch-update.desktop

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -80,9 +80,17 @@ Afficher le message d'aide.
 .B L'applet systray
 .RB "Pour démarrer l'applet systray automatiquement au démarrage du système, ajouter la commande " "arch-update --tray " "à vos commandes 'auto-start'/configuration de votre WM ou démarrez/activez le service systemd associé comme ceci : " "systemctl \-\-user enable \-\-now arch-update-tray.service"
 .br
-L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Il lancera la série de fonctions adéquates pour effectuer une mise à jour complète et appropriée lorsque vous cliquez dessus.
+.RB "L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance " "arch-update " "via le fichier " "arch-update.desktop".
 .br
-.RB "Alternativement, si vous n'avez/ne voulez pas le support du systray, il y a un fichier .desktop classique (sous " "/usr/share/applications/arch-update.desktop " "ou " "/usr/local/share/applications/arch-update.desktop " "si vous avez installé Arch-Update depuis la source). Notez que, à l'inverse de l'applet systray, l'icône du fichier .desktop ne change " "pas " "dynamiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles')."
+.RB "L'applet systray essaie de lire le fichier " "arch-update.desktop " "dans les chemins ci-dessous avec l'ordre suivant :"
+.br
+\- $XDG_DATA_HOME/applications/arch-update.desktop
+\- $HOME/.local/share/applications/arch-update.desktop
+\- $XDG_DATA_DIRS/applications/arch-update.desktop
+\- /usr/local/share/applications/arch-update.desktop <-- Chemin d'installation par défaut lorsque vous installez Arch-Update depuis la source
+\- /usr/share/applications/arch-update.desktop <-- Chemin d'installation par défaut lorsque vous installez Arch-Update depuis le AUR
+.br
+.RB "Dans le cas où vous avez envie/besoin de personnaliser le fichier " "arch-update.desktop"", copiez le dans un chemin qui a une priorité plus élevée que le chemin d'installation par défaut et modifier le ici (afin d'assurer que votre ficher " "arch-update.desktop " "personnalisé remplace celui par défaut et que vos modifications ne soient pas écrasées à chaque mise à jour)."
 
 .TP
 .B Le timer systemd

--- a/src/script/arch-update-tray.py
+++ b/src/script/arch-update-tray.py
@@ -25,18 +25,19 @@ if not os.path.isfile(STATE_FILE):
 
 def arch_update():
     """ Launch with desktop file """
+    DESKTOP_FILE = None
     if 'XDG_DATA_HOME' in os.environ:
         DESKTOP_FILE = os.path.join(
             os.environ['XDG_DATA_HOME'], 'applications', 'arch-update.desktop')
-    if not os.path.isfile(DESKTOP_FILE):
+    if not DESKTOP_FILE or not os.path.isfile(DESKTOP_FILE):
         if 'HOME' in os.environ:
             DESKTOP_FILE = os.path.join(
                 os.environ['HOME'], '.local', 'share', 'applications', 'arch-update.desktop')
-    if not os.path.isfile(DESKTOP_FILE):
+    if not DESKTOP_FILE or not os.path.isfile(DESKTOP_FILE):
         if 'XDG_DATA_DIRS' in os.environ:
             DESKTOP_FILE = os.path.join(
                 os.environ['XDG_DATA_DIRS'], 'applications', 'arch-update.desktop')
-    if not os.path.isfile(DESKTOP_FILE):
+    if not DESKTOP_FILE or not os.path.isfile(DESKTOP_FILE):
         DESKTOP_FILE = "/usr/local/share/applications/arch-update.desktop"
     if not os.path.isfile(DESKTOP_FILE):
         DESKTOP_FILE = "/usr/share/applications/arch-update.desktop"

--- a/src/script/arch-update-tray.py
+++ b/src/script/arch-update-tray.py
@@ -24,11 +24,23 @@ if not os.path.isfile(STATE_FILE):
 
 
 def arch_update():
-    """ Launch with terminal """
-    update = "/usr/share/applications/arch-update.desktop"
-    if not os.path.isfile(update):
-        update = "/usr/local/share/applications/arch-update.desktop"
-    subprocess.run(["gio", "launch", update], check=False)
+    """ Launch with desktop file """
+    if 'XDG_DATA_HOME' in os.environ:
+        DESKTOP_FILE = os.path.join(
+	    os.environ['XDG_DATA_HOME'], 'applications', 'arch-update.desktop')
+    if not os.path.isfile(DESKTOP_FILE):
+        if 'HOME' in os.environ:
+            DESKTOP_FILE = os.path.join(
+	        os.environ['HOME'], '.local', 'share', 'applications', 'arch-update.desktop')
+    if not os.path.isfile(DESKTOP_FILE):
+        if 'XDG_DATA_DIRS' in os.environ:
+	    DESKTOP_FILE = os.path.join(
+	        os.environ['XDG_DATA_DIRS'], 'applications', 'arch-update.desktop')
+    if not os.path.isfile(DESKTOP_FILE):
+        DESKTOP_FILE = "/usr/local/share/applications/arch-update.desktop"
+    if not os.path.isfile(DESKTOP_FILE):
+        DESKTOP_FILE = "/usr/share/applications/arch-update.desktop"
+    subprocess.run(["gio", "launch", DESKTOP_FILE], check=False)
 
 
 class ArchUpdateQt6:

--- a/src/script/arch-update-tray.py
+++ b/src/script/arch-update-tray.py
@@ -27,15 +27,15 @@ def arch_update():
     """ Launch with desktop file """
     if 'XDG_DATA_HOME' in os.environ:
         DESKTOP_FILE = os.path.join(
-	    os.environ['XDG_DATA_HOME'], 'applications', 'arch-update.desktop')
+            os.environ['XDG_DATA_HOME'], 'applications', 'arch-update.desktop')
     if not os.path.isfile(DESKTOP_FILE):
         if 'HOME' in os.environ:
             DESKTOP_FILE = os.path.join(
-	        os.environ['HOME'], '.local', 'share', 'applications', 'arch-update.desktop')
+                os.environ['HOME'], '.local', 'share', 'applications', 'arch-update.desktop')
     if not os.path.isfile(DESKTOP_FILE):
         if 'XDG_DATA_DIRS' in os.environ:
-	    DESKTOP_FILE = os.path.join(
-	        os.environ['XDG_DATA_DIRS'], 'applications', 'arch-update.desktop')
+            DESKTOP_FILE = os.path.join(
+                os.environ['XDG_DATA_DIRS'], 'applications', 'arch-update.desktop')
     if not os.path.isfile(DESKTOP_FILE):
         DESKTOP_FILE = "/usr/local/share/applications/arch-update.desktop"
     if not os.path.isfile(DESKTOP_FILE):


### PR DESCRIPTION
This PR makes the systray applet searching for the .desktop file in the following path (in that specific order):

- $XDG_DATA_HOME/applications/arch-update.desktop
- $HOME/.local/share/applications/arch-update.desktop
- $XDG_DATA_DIRS/applications/arch-update.desktop
- /usr/local/share/applications/arch-update.desktop
- /usr/share/applications/arch-update.desktop

That would allow users to be able to provide a customized `.desktop` file for the systray applet to execute if needed (e.g. force Arch-Update to launch in a specific terminal emulator that is [not supported](https://github.com/Antiz96/arch-update/blob/main/src/script/arch-update-tray.py#L15) by gio/glib2).

Fixes https://github.com/Antiz96/arch-update/issues/151