### PR TITLE
Improve documentation regarding the check function and how to modify the check cycle

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -114,7 +114,7 @@ C'est l'icône à droite de celle du wifi dans la capture d'écran ci-dessous:
 
 Avec [le systemd timer](#le-timer-systemd) activé, `Arch-Update` vérifie automatiquement les mises à jour au démarrage du système puis une fois chaque heure. La vérification peut être manuellement déclenchée en exécutant la commande `arch-update --check`.
 
-Si de nouvelles mises à jour sont disponibles, l'icône systray affichera un cercle rouge et une notification de bureau indiquant le nombre de mises à jour disponibles sera envoyée (nécessite [libnotify/notify-send](https://archlinux.org/packages/extra/x86_64/libnotify/ "paquet libnotify") et un serveur de notification en cours d'exécution) :
+Si de nouvelles mises à jour sont disponibles, l'icône systray affichera un cercle rouge et une notification de bureau indiquant le nombre de mises à jour disponibles sera envoyée s'il y a de nouvelles mises à jour depuis le dernier check (nécessite [libnotify/notify-send](https://archlinux.org/packages/extra/x86_64/libnotify/ "paquet libnotify") et un serveur de notification en cours d'exécution) :
 
 ![notification-FR](https://github.com/Antiz96/arch-update/assets/53110319/28f0b95a-5b8a-43a5-bc3c-df42cd40d87b)
 
@@ -150,7 +150,7 @@ Après la mise à jour, vérification de la présence de paquets orphelins/inuti
 de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, propose de les traiter.
 
 Options :
--c, --check       Vérifier les mises à jour disponibles, envoyer une notification de bureau contenant le nombre de mises à jour disponibles (si libnotify est installé)
+-c, --check       Vérifier les mises à jour disponibles, changer l'icône systray et envoyer une notification de bureau contenant le nombre de mises à jour disponibles (s'il y a des nouvelles mises à jour disponibles depuis le dernier check)
 -l, --list        Afficher la liste des mises à jour en attente
 -d, --devel       Inclure les mises à jour des paquets de développement AUR
 -n, --news [Num]  Afficher les dernieres Arch News, vous pouvez optionellement spécifier le nombre de Arch news à afficher avec `--news [Num]` (e.g. `--news 10`)
@@ -221,16 +221,21 @@ Voir <https://wiki.archlinux.org/title/Desktop_notifications>
 
 Si vous avez activé le [timer systemd](#le-timer-systemd), l'option `--check` est automatiquement lancée au démarrage du système puis une fois par heure.
 
-Si vous souhaitez modifier le cycle de vérification, exécutez la commande `systemctl --user edit arch-update.timer` pour créer une configuration de remplacement pour le timer et saisissez ce qui suit :
+Si vous souhaitez modifier le cycle de vérification, exécutez la commande `systemctl --user edit --full arch-update.timer` et modifiez la valeur `OnUnitActiveSec` à votre convenance.  
+Par exemple, si vous voulez qu'`Arch-Update` vérifie plutôt les nouvelles mises à jour toutes les 10 minutes :
 
 ```text
+[...]
 [Timer]
-OnUnitActiveSec=
+OnStartupSec=15
 OnUnitActiveSec=10m
+[...]
 ```
 
 Les unités de temps sont `s` pour secondes, `m` pour minutes, `h` pour heures, `d` pour jours...  
 Voir <https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans> pour plus de détails.
+
+Dans le cas où vous voulez qu'`Arch-Update` ne vérifie les nouvelles mises à jour qu'une fois au démarrage du système, vous pouvez simplement supprimer la ligne `OnUnitActiveSec` complètement.
 
 ## Contribuer
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -228,7 +228,7 @@ Par exemple, si vous voulez qu'`Arch-Update` vérifie plutôt les nouvelles mise
 [...]
 [Timer]
 OnStartupSec=15
-OnUnitActiveSec=**10m**
+OnUnitActiveSec=10m
 [...]
 ```
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -228,7 +228,7 @@ Par exemple, si vous voulez qu'`Arch-Update` vérifie plutôt les nouvelles mise
 [...]
 [Timer]
 OnStartupSec=15
-OnUnitActiveSec=10m
+OnUnitActiveSec=**10m**
 [...]
 ```
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ For instance, if you want `Arch-Update` to check for new updates every 10 minute
 [...]
 [Timer]
 OnStartupSec=15
-OnUnitActiveSec=10m
+OnUnitActiveSec=**10m**
 [...]
 ```
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ OnUnitActiveSec=10m
 Time units are `s` for seconds, `m` for minutes, `h` for hours, `d` for days...  
 See <https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans> for more details.
 
-In case you want `Arch-Update` to only check for new updates once at boot, you can simply delete the `OnUnitActiveSec` line completely.
+In case you want `Arch-Update` to check for new updates only once at boot, you can simply delete the `OnUnitActiveSec` line completely.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ For instance, if you want `Arch-Update` to check for new updates every 10 minute
 [...]
 [Timer]
 OnStartupSec=15
-OnUnitActiveSec=**10m**
+OnUnitActiveSec=10m
 [...]
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ It is the icon at the right of the 'wifi' one in the screenshot below:
 
 With [the system timer](#the-systemd-timer) enabled, `Arch-Update` automatically checks for updates at boot and then once every hour. The check can be manually triggered by running the `arch-update --check` command.
 
-If there are new available updates, the systray icon will show a red circle and a desktop notification indicating the number of available updates will be sent (requires [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package") and a running notification server):
+If there are new available updates, the systray icon will show a red circle and a desktop notification indicating the number of available updates will be sent if there are new available updates compared to the last check (requires [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/ "libnotify package") and a running notification server):
 
 ![notification](https://github.com/Antiz96/arch-update/assets/53110319/db94c308-526a-4b8f-8f2a-0624d0a83553)
 
@@ -150,7 +150,7 @@ Post update, check for orphan/unused packages, old cached packages, pacnew/pacsa
 and pending kernel update and, if there are, offers to process them.
 
 Options:
--c, --check       Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)
+-c, --check       Check for available updates, change the systray icon and send a desktop notification containing the number of available updates (if there are new available updates compared to the last check)
 -l, --list        Display the list of pending updates
 -d, --devel       Include AUR development packages updates
 -n, --news [Num]  Display latest Arch News, you can optionally specify the number of Arch news to display with `--news [Num]` (e.g. `--news 10`)
@@ -221,16 +221,21 @@ See <https://wiki.archlinux.org/title/Desktop_notifications>
 
 If you enabled the [systemd.timer](#the-systemd-timer), the `--check` option is automatically launched at boot and then once per hour.
 
-If you want to change the check cycle, run `systemctl --user edit arch-update.timer` to create an override configuration for the timer and input the following in it:
+If you want to change the check cycle, run `systemctl --user edit --full arch-update.timer` and modify the `OnUnitActiveSec` value to your liking.  
+For instance, if you want `Arch-Update` to check for new updates every 10 minutes instead:
 
 ```text
+[...]
 [Timer]
-OnUnitActiveSec=
+OnStartupSec=15
 OnUnitActiveSec=10m
+[...]
 ```
 
 Time units are `s` for seconds, `m` for minutes, `h` for hours, `d` for days...  
 See <https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans> for more details.
+
+In case you want `Arch-Update` to only check for new updates once at boot, you can simply delete the `OnUnitActiveSec` line completely.
 
 ## Contributing
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -30,7 +30,7 @@ Those functions are launched when you click on the systray applet.
 .B \-c, \-\-check
 Check for available updates.
 .br
-.RB "It sends a desktop notification containing the number of available updates if " "libnotify " "is installed."
+It changes the systray icon and sends a desktop notification containing the number of available updates (if there are new available updates compared to the last check).
 .br
 .RB "It supports AUR packages update (if " "yay " "or " "paru " "is installed) and Flatpak packages update (if " "flatpak " "is installed)."
 .br
@@ -127,19 +127,28 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 .B Modify the auto-check cycle
 .RB "If you enabled the " "systemd.timer" ", the " "--check " "option is automatically launched at boot and then once per hour."
 .br
-.RB "If you want to change the check cycle, run " "systemctl --user edit arch-update.timer " "to create an override configuration for the timer and input the following in it:"
+.RB "If you want to change the check cycle, run " "systemctl --user edit --full arch-update.timer " "and modify the " "OnUnitActiveSec " "value to your liking."
+.br
+.RB "For instance, if you want " "Arch-Update " "to check for new updates every 10 minutes instead:"
 .br
 
+[...]
+.br
 .B [Timer]
 .br
-.B OnUnitActiveSec=
+.B OnStartupSec=15
 .br
 .B OnUnitActiveSec=10m
+.br
+[...]
 
 .br
 .RB "Time units are " "s " "for seconds, " "m " "for minutes, " "h " "for hours, " "d " "for days..."
 .br
 See https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans for more details.
+.br
+
+.RB "In case you want " "Arch-Update " "to only check for new updates once at boot, you can simple delete the " "OnUnitActiveSec " "line completely."
 
 .SH EXIT STATUS
 .TP

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -138,7 +138,7 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 .br
 OnStartupSec=15
 .br
-.B OnUnitActiveSec=10m
+.RB "OnUnitActiveSec=" "10m"
 .br
 [...]
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -134,9 +134,9 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 
 [...]
 .br
-.B [Timer]
+[Timer]
 .br
-.B OnStartupSec=15
+OnStartupSec=15
 .br
 .B OnUnitActiveSec=10m
 .br
@@ -148,7 +148,7 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 See https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans for more details.
 .br
 
-.RB "In case you want " "Arch-Update " "to only check for new updates once at boot, you can simple delete the " "OnUnitActiveSec " "line completely."
+.RB "In case you want " "Arch-Update " "to check for new updates only once at boot, you can simple delete the " "OnUnitActiveSec " "line completely."
 
 .SH EXIT STATUS
 .TP

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -30,7 +30,7 @@ Ces fonctions sont lancées quand vous cliquez sur l'applet systray.
 .B \-c, \-\-check
 Vérifier les mises à jour disponibles.
 .br
-.RB "Cela envoie une notification de bureau contenant le nombre de mise à jour disponibles si " "libnotify " "est installé."
+Change l'icône systray et envoie une notification de bureau contenant le nombre de mises à jour disponibles (s'il y a des nouvelles mises à jour disponibles depuis le dernier check).
 .br
 .RB "Supporte les mises à jour des paquets AUR (si " "yay " "ou " "paru " "est installé) et les mises à jour des paquets Flatpak (si " "flatpak " "est installé)."
 .br
@@ -127,19 +127,27 @@ Voir https://wiki.archlinux.org/title/Desktop_notifications
 .B Modifier le cycle de vérification automatique
 .RB "Si vous avez activé le " "systemd.timer" ", l'option " "--check " "est automatiquement lancée au démarrage du système puis une fois par heure."
 .br
-.RB "Si vous souhaitez modifier le cycle de vérification, exécutez la commande " "systemctl --user edit arch-update.timer " "pour créer une configuration de remplacement pour le timer et saisissez ce qui suit :"
+.RB "Si vous souhaitez modifier le cycle de vérification, exécutez la commande " "systemctl --user edit --full arch-update.timer " "et modifiez la valeur " "OnUnitActiveSec " "à votre convenance."
+.br
+.RB "Par exemple, si vous voulez qu'" "Arch-Update " "vérifie plutôt les mises à jour toutes les 10 minutes :"
 .br
 
+[...]
 .B [Timer]
 .br
-.B OnUnitActiveSec=
+.B OnStartupSec=15
 .br
 .B OnUnitActiveSec=10m
+.br
+[...]
 
 .br
 .RB "Les unités de temps sont " "s " "pour secondes, " "m " "pour minutes, " "h " "pour heures, " "d " "pour jours..."
 .br
 Voir https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Parsing%20Time%20Spans pour plus de détails.
+.br
+
+.RB "Dans le cas où vous voulez qu'" "Arch-Update " "ne vérifie les nouvelles mises à jour qu'une fois au démarrage du système, vous pouvez simplement supprimer la ligne " "OnUnitActiveSec " "complètement."
 
 .SH EXIT STATUS
 .TP

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -133,6 +133,7 @@ Voir https://wiki.archlinux.org/title/Desktop_notifications
 .br
 
 [...]
+.br
 [Timer]
 .br
 OnStartupSec=15

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -133,9 +133,9 @@ Voir https://wiki.archlinux.org/title/Desktop_notifications
 .br
 
 [...]
-.B [Timer]
+[Timer]
 .br
-.B OnStartupSec=15
+OnStartupSec=15
 .br
 .B OnUnitActiveSec=10m
 .br

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -137,7 +137,7 @@ Voir https://wiki.archlinux.org/title/Desktop_notifications
 .br
 OnStartupSec=15
 .br
-.B OnUnitActiveSec=10m
+.RB "OnUnitActiveSec=" "10m"
 .br
 [...]
 

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -73,8 +73,9 @@ msgstr ""
 #: src/script/arch-update.sh:167
 #, sh-format
 msgid ""
-"  -c, --check       Check for available updates, send a desktop notification "
-"containing the number of available updates (if libnotify is installed)"
+"  -c, --check       Check for available updates, change the systray icon and "
+"send a desktop notification containing the number of available updates (if "
+"there are new available updates compared to the last check)"
 msgstr ""
 
 #: src/script/arch-update.sh:168

--- a/po/fr.po
+++ b/po/fr.po
@@ -87,7 +87,7 @@ msgid ""
 "there are new available updates compared to the last check)"
 msgstr ""
 "  -c, --check       Vérifier les mises à jour disponibles, change l'icône systray et "
-"envoyer une notification de bureau contenant le nombre de mises à jour disponibles (si "
+"envoyer une notification de bureau contenant le nombre de mises à jour disponibles (s'"
 "il y a des nouvelles mises à jour comparé au dernier check)"
 
 #: src/script/arch-update.sh:168

--- a/po/fr.po
+++ b/po/fr.po
@@ -87,7 +87,7 @@ msgid ""
 "there are new available updates compared to the last check)"
 msgstr ""
 "  -c, --check       Vérifier les mises à jour disponibles, change l'icône systray et "
-"envoyer une notification de bureau contenant le nombre de mises à jour disponibles (s'"
+"envoie une notification de bureau contenant le nombre de mises à jour disponibles (s'"
 "il y a des nouvelles mises à jour comparé au dernier check)"
 
 #: src/script/arch-update.sh:168

--- a/po/fr.po
+++ b/po/fr.po
@@ -88,7 +88,7 @@ msgid ""
 msgstr ""
 "  -c, --check       Vérifier les mises à jour disponibles, change l'icône systray et "
 "envoie une notification de bureau contenant le nombre de mises à jour disponibles (s'"
-"il y a des nouvelles mises à jour comparé au dernier check)"
+"il y a des nouvelles mises à jour depuis le dernier check)"
 
 #: src/script/arch-update.sh:168
 #, sh-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -82,11 +82,13 @@ msgstr "Options :"
 #: src/script/arch-update.sh:167
 #, sh-format
 msgid ""
-"  -c, --check       Check for available updates, send a desktop notification "
-"containing the number of available updates (if libnotify is installed)"
+"  -c, --check       Check for available updates, change the systray icon and "
+"send a desktop notification containing the number of available updates (if "
+"there are new available updates compared to the last check)"
 msgstr ""
-"  -c, --check       Vérifier les mises à jour disponibles, envoyer une notification de bureau "
-"contenant le nombre de mises à jour disponibles (si libnotify est installé)"
+"  -c, --check       Vérifier les mises à jour disponibles, change l'icône systray et "
+"envoyer une notification de bureau contenant le nombre de mises à jour disponibles (si "
+"il y a des nouvelles mises à jour comparé au dernier check)"
 
 #: src/script/arch-update.sh:168
 #, sh-format

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -164,7 +164,7 @@ $(eval_gettext "Before performing the update, offer to display the latest Arch L
 $(eval_gettext "Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files and pending kernel update and, if there are, offers to process them.")
 
 $(eval_gettext "Options:")
-$(eval_gettext "  -c, --check       Check for available updates, send a desktop notification containing the number of available updates (if libnotify is installed)")
+$(eval_gettext "  -c, --check       Check for available updates, change the systray icon and send a desktop notification containing the number of available updates (if there are new available updates compared to the last check)")
 $(eval_gettext "  -l, --list        Display the list of pending updates")
 $(eval_gettext "  -d, --devel       Include AUR development packages updates")
 $(eval_gettext "  -n, --news [Num]  Display latest Arch news, you can optionally specify the number of Arch news to display with '--news [Num]' (e.g. '--news 10')")


### PR DESCRIPTION
- Add a precision in the documentation that the check function only sends a desktop notification if the list of pending updates differs from the last check (in other words, that there is at least one **new** update available compared to the last check).
- Advise using `systemctl --user edit --full` instead of a "regular" edit to modify the check cycle. While it is "overkill" in most cases, it is less complex/confusing to use and allow more flexibility (for instance, it allows to get completely rid of a parameters and not just to modify its value). The `arch-update.timer` is not subject to change upstream wise so there's no apparent issue recommanding using a `--full` edit.

Fixes https://github.com/Antiz96/arch-update/issues/164