### PR TITLE
Assign the STATE_FILE var before it is accessed in arch-update-tray.py script

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -463,10 +463,10 @@ msgstr ""
 msgid "The '${config_file}' configuration file has been generated"
 msgstr ""
 
-#: src/script/arch-update-tray.py:117
+#: src/script/arch-update-tray.py:118
 msgid "Run Arch-Update"
 msgstr ""
 
-#: src/script/arch-update-tray.py:118
+#: src/script/arch-update-tray.py:119
 msgid "Exit"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -497,10 +497,10 @@ msgstr ""
 msgid "The '${config_file}' configuration file has been generated"
 msgstr "Le fichier de configuration '${config_file}' a été généré"
 
-#: src/script/arch-update-tray.py:117
+#: src/script/arch-update-tray.py:118
 msgid "Run Arch-Update"
 msgstr "Lancer Arch-Update"
 
-#: src/script/arch-update-tray.py:118
+#: src/script/arch-update-tray.py:119
 msgid "Exit"
 msgstr "Quitter"

--- a/src/script/arch-update-tray.py
+++ b/src/script/arch-update-tray.py
@@ -13,6 +13,7 @@ from PyQt6.QtCore import QFileSystemWatcher
 log = logging.getLogger(__name__)
 
 # Find Statefile
+STATE_FILE = None
 if 'XDG_STATE_HOME' in os.environ:
     STATE_FILE = os.path.join(
         os.environ['XDG_STATE_HOME'], 'arch-update', 'current_state')


### PR DESCRIPTION
This is to address pylint [E0606](https://pylint.pycqa.org/en/latest/user_guide/messages/error/possibly-used-before-assignment.html) warning in CI.