### PR TITLE
Add an option in the configuration file to explicitely set which elevation command to use

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -196,7 +196,7 @@ Les options prises en charge sont :
 - NewsNum=[Num] # Nombre de Arch news à affcher avant la mise à jour et avec l'option `-n/--news` (voir la page de manuel arch-update(1) pour plus de details). La valeur par défaut est 5.
 - KeepOldPackages=[Num] # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
 - KeepUninstalledPackages=[Num] # Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
-- PrivilegeElevationCommand=[Cmd] # Commande à utiliser pour élever les privilèges. Les options valides sont `sudo`, `doas` ou `run0`. Si cette option n'est pas spécifiée, Arch-Update utilisera la première commande disponible dans l'odre suivant: `sudo`, `doas` puis `run0`.
+- PrivilegeElevationCommand=[Cmd] # Commande à utiliser pour l'élévation de privilège. Les options valides sont `sudo`, `doas` ou `run0`. Si cette option n'est pas spécifiée, Arch-Update utilisera la première commande disponible dans l'odre suivant: `sudo`, `doas` puis `run0`.
 
 Les options sont sensibles à la casse, les majuscules doivent donc être respectées.
 ```

--- a/README-fr.md
+++ b/README-fr.md
@@ -166,7 +166,7 @@ Options :
 Codes de sortie :
 0  OK
 1  Option invalide
-2  Aucune méthode d'élévation de privilège (sudo, doas ou run0) n'est installée
+2  Aucune commande d'élévation de privilège (sudo, doas ou run0) n'est installée ou celle définie dans le fichier de configuration `arch-update.conf` n'est pas disponible
 3  Erreur lors du lancement de l'applet systray d'Arch-Update
 4  L'utilisateur n'a pas donné la confirmation de procéder
 5  Erreur lors de la mise à jour des paquets
@@ -196,6 +196,7 @@ Les options prises en charge sont :
 - NewsNum=[Num] # Nombre de Arch news à affcher avant la mise à jour et avec l'option `-n/--news` (voir la page de manuel arch-update(1) pour plus de details). La valeur par défaut est 5.
 - KeepOldPackages=[Num] # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
 - KeepUninstalledPackages=[Num] # Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
+- PrivilegeElevationCommand=[Cmd] # Commande à utiliser pour élever les privilèges. Les options valides sont `sudo`, `doas` ou `run0`. Si cette option n'est pas spécifiée, Arch-Update utilisera la première commande disponible dans l'odre suivant: `sudo`, `doas` puis `run0`.
 
 Les options sont sensibles à la casse, les majuscules doivent donc être respectées.
 ```

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Options:
 Exit Codes:
 0  OK
 1  Invalid option
-2  No privilege elevation method (sudo, doas or run0) is installed
+2  No privilege elevation command (sudo, doas or run0) is installed or the one set in the `arch-update.conf` configuration file isn't found
 3  Error when launching the Arch-Update systray applet
 4  User didn't gave the confirmation to proceed
 5  Error when updating the packages
@@ -196,6 +196,7 @@ The supported options are:
 - NewsNum=[Num] # Number of Arch news to display before updating and with the `-n/--news` option (see the arch-update(1) man page for more details). Defaults to 5.
 - KeepOldPackages=[Num] # Number of old packages' versions to keep in pacman's cache. Defaults to 3.
 - KeepUninstalledPackages=[Num] # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
+- PrivilegeElevationCommand=[Cmd] # Command to be used to elevate privileges. Valid options are `sudo`, `doas` or `run0`. If this option is not set, Arch-Update will use the first available command in the following order: `sudo`, `doas` then `run0`.
 
 Options are case sensitive, so capital letters have to be respected.
 ```

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The supported options are:
 - NewsNum=[Num] # Number of Arch news to display before updating and with the `-n/--news` option (see the arch-update(1) man page for more details). Defaults to 5.
 - KeepOldPackages=[Num] # Number of old packages' versions to keep in pacman's cache. Defaults to 3.
 - KeepUninstalledPackages=[Num] # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
-- PrivilegeElevationCommand=[Cmd] # Command to be used to elevate privileges. Valid options are `sudo`, `doas` or `run0`. If this option is not set, Arch-Update will use the first available command in the following order: `sudo`, `doas` then `run0`.
+- PrivilegeElevationCommand=[Cmd] # Command to be used for privilege elevation. Valid options are `sudo`, `doas` or `run0`. If this option is not set, Arch-Update will use the first available command in the following order: `sudo`, `doas` then `run0`.
 
 Options are case sensitive, so capital letters have to be respected.
 ```

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "May 2024" "Arch-Update 2.0.2" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "June 2024" "Arch-Update 2.0.2" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
@@ -185,7 +185,7 @@ Invalid option
 
 .TP
 .B 2
-No privilege elevation method (sudo, doas or run0) is installed
+No privilege elevation command (sudo, doas or run0) is installed or the one set in the arch-update.conf configuration file isn't found
 
 .TP
 .B 3

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE.CONF" "5" "March 2024" "Arch-Update 2.0.2" "Arch-Update Manual"
+.TH "ARCH-UPDATE.CONF" "5" "June 2024" "Arch-Update 2.0.2" "Arch-Update Manual"
 
 .SH NAME
 arch-update.conf \- arch-update configuration file.
@@ -42,6 +42,10 @@ Number of old packages' versions to keep in pacman's cache. Defaults to 3.
 .TP
 .B KeepUninstalledPackages=[Num]
 Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
+
+.TP
+.B PrivilegeElevationCommand=[Cmd]
+Command to be used to elevate privileges. Valid options are sudo, doas or run0. If this option is not set, Arch-Update will use the first available command in the following order: sudo, doas then run0.
 
 .SH SEE ALSO
 .BR arch-update (1)

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -45,7 +45,7 @@ Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 
 
 .TP
 .B PrivilegeElevationCommand=[Cmd]
-Command to be used to elevate privileges. Valid options are sudo, doas or run0. If this option is not set, Arch-Update will use the first available command in the following order: sudo, doas then run0.
+Command to be used for privilege elevation. Valid options are sudo, doas or run0. If this option is not set, Arch-Update will use the first available command in the following order: sudo, doas then run0.
 
 .SH SEE ALSO
 .BR arch-update (1)

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "Mai 2024" "Arch-Update 2.0.2" "Manuel de Arch-Update"
+.TH "ARCH-UPDATE" "1" "Juin 2024" "Arch-Update 2.0.2" "Manuel de Arch-Update"
 
 .SH NAME
 arch-update \- Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour.
@@ -185,7 +185,7 @@ Option invalide
 
 .TP
 .B 2
-Aucune méthode d'élévation de privilège (sudo, doas ou run0) n'est installée
+Aucune commande d'élévation de privilège (sudo, doas ou run0) n'est installée ou celle définie dans le fichier de configuration arch-update.conf n'est pas disponible
 
 .TP
 .B 3

--- a/doc/man/fr/arch-update.conf.5
+++ b/doc/man/fr/arch-update.conf.5
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE.CONF" "5" "Mars 2024" "Arch-Update 2.0.2" "Manuel de Arch-Update"
+.TH "ARCH-UPDATE.CONF" "5" "Juin 2024" "Arch-Update 2.0.2" "Manuel de Arch-Update"
 
 .SH NAME
 arch-update.conf \- fichier de configuration pour arch-update.
@@ -42,6 +42,10 @@ Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La 
 .TP
 .B KeepUninstalledPackages=[Num]
 Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
+
+.TP
+.B PrivilegeElevationCommand=[Cmd]
+Commande à utiliser pour élever les privilèges. Les options valides sont sudo, doas ou run0. Si cette option n'est pas spécifiée, Arch-Update utilisera la première commande disponible dans l'odre suivant: sudo, doas puis run0.
 
 .SH VOIR AUSSI
 .BR arch-update (1)

--- a/doc/man/fr/arch-update.conf.5
+++ b/doc/man/fr/arch-update.conf.5
@@ -45,7 +45,7 @@ Nombre de versions de paquets désinstallés à conserver dans le cache de pacma
 
 .TP
 .B PrivilegeElevationCommand=[Cmd]
-Commande à utiliser pour élever les privilèges. Les options valides sont sudo, doas ou run0. Si cette option n'est pas spécifiée, Arch-Update utilisera la première commande disponible dans l'odre suivant: sudo, doas puis run0.
+Commande à utiliser pour l'élévation de privilège. Les options valides sont sudo, doas ou run0. Si cette option n'est pas spécifiée, Arch-Update utilisera la première commande disponible dans l'odre suivant: sudo, doas puis run0.
 
 .SH VOIR AUSSI
 .BR arch-update (1)

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,47 +16,54 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:127
+#: src/script/arch-update.sh:79
+#, sh-format
+msgid ""
+"The ${su_cmd} command set for privilege escalation in the arch-update.conf "
+"configuration file is not found\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:135
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/script/arch-update.sh:133
+#: src/script/arch-update.sh:141
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/script/arch-update.sh:145
+#: src/script/arch-update.sh:154
 #, sh-format
-msgid "A privilege elevation method is required (sudo, doas or run0)\\n"
+msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:167
+#: src/script/arch-update.sh:177
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:169
+#: src/script/arch-update.sh:179
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:170
+#: src/script/arch-update.sh:180
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:171
+#: src/script/arch-update.sh:181
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:172
+#: src/script/arch-update.sh:182
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -64,12 +71,12 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:174
+#: src/script/arch-update.sh:184
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:175
+#: src/script/arch-update.sh:185
 #, sh-format
 msgid ""
 "  -c, --check       Check for available updates, change the systray icon and "
@@ -77,388 +84,388 @@ msgid ""
 "there are new available updates compared to the last check)"
 msgstr ""
 
-#: src/script/arch-update.sh:176
+#: src/script/arch-update.sh:186
 #, sh-format
 msgid "  -l, --list        Display the list of pending updates"
 msgstr ""
 
-#: src/script/arch-update.sh:177
+#: src/script/arch-update.sh:187
 #, sh-format
 msgid "  -d, --devel       Include AUR development packages updates"
 msgstr ""
 
-#: src/script/arch-update.sh:178
+#: src/script/arch-update.sh:188
 #, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
 "number of Arch news to display with '--news [Num]' (e.g. '--news 10')"
 msgstr ""
 
-#: src/script/arch-update.sh:179
+#: src/script/arch-update.sh:189
 #, sh-format
 msgid "  -D, --debug       Display debug traces"
 msgstr ""
 
-#: src/script/arch-update.sh:180
+#: src/script/arch-update.sh:190
 #, sh-format
 msgid "  --gen-config      Generate a default/example configuration file"
 msgstr ""
 
-#: src/script/arch-update.sh:181
+#: src/script/arch-update.sh:191
 #, sh-format
 msgid "  --tray            Launch the Arch-Update systray applet"
 msgstr ""
 
-#: src/script/arch-update.sh:182
+#: src/script/arch-update.sh:192
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:183
+#: src/script/arch-update.sh:193
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:185
+#: src/script/arch-update.sh:195
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:186
+#: src/script/arch-update.sh:196
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:197
+#: src/script/arch-update.sh:207
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:237 src/script/arch-update.sh:239
+#: src/script/arch-update.sh:247 src/script/arch-update.sh:249
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:244 src/script/arch-update.sh:246
+#: src/script/arch-update.sh:254 src/script/arch-update.sh:256
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:262
+#: src/script/arch-update.sh:272
 #, sh-format
 msgid "Looking for updates...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:283
+#: src/script/arch-update.sh:293
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:288
+#: src/script/arch-update.sh:298
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:293
+#: src/script/arch-update.sh:303
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:300
+#: src/script/arch-update.sh:310
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:307
+#: src/script/arch-update.sh:317
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:310 src/script/arch-update.sh:447
-#: src/script/arch-update.sh:480 src/script/arch-update.sh:522
-#: src/script/arch-update.sh:589 src/script/arch-update.sh:615
+#: src/script/arch-update.sh:320 src/script/arch-update.sh:457
+#: src/script/arch-update.sh:490 src/script/arch-update.sh:532
+#: src/script/arch-update.sh:599 src/script/arch-update.sh:625
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/script/arch-update.sh:310 src/script/arch-update.sh:447
-#: src/script/arch-update.sh:480 src/script/arch-update.sh:522
-#: src/script/arch-update.sh:589 src/script/arch-update.sh:615
+#: src/script/arch-update.sh:320 src/script/arch-update.sh:457
+#: src/script/arch-update.sh:490 src/script/arch-update.sh:532
+#: src/script/arch-update.sh:599 src/script/arch-update.sh:625
 #, sh-format
 msgid "y"
 msgstr ""
 
-#: src/script/arch-update.sh:314
+#: src/script/arch-update.sh:324
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:345
+#: src/script/arch-update.sh:355
 #, sh-format
 msgid "Arch News:"
 msgstr ""
 
-#: src/script/arch-update.sh:350
+#: src/script/arch-update.sh:360
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:361
+#: src/script/arch-update.sh:371
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr ""
 
-#: src/script/arch-update.sh:363
+#: src/script/arch-update.sh:373
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:384
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:375
+#: src/script/arch-update.sh:385
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:376
+#: src/script/arch-update.sh:386
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:377
+#: src/script/arch-update.sh:387
 #, sh-format
 msgid "URL:"
 msgstr ""
 
-#: src/script/arch-update.sh:390
+#: src/script/arch-update.sh:400
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:395 src/script/arch-update.sh:407
-#: src/script/arch-update.sh:418
+#: src/script/arch-update.sh:405 src/script/arch-update.sh:417
+#: src/script/arch-update.sh:428
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:402
+#: src/script/arch-update.sh:412
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:414
+#: src/script/arch-update.sh:424
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:425
+#: src/script/arch-update.sh:435
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:437
+#: src/script/arch-update.sh:447
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:441
+#: src/script/arch-update.sh:451
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:443
+#: src/script/arch-update.sh:453
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:449
+#: src/script/arch-update.sh:459
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:453 src/script/arch-update.sh:486
-#: src/script/arch-update.sh:529 src/script/arch-update.sh:539
-#: src/script/arch-update.sh:549 src/script/arch-update.sh:558
+#: src/script/arch-update.sh:463 src/script/arch-update.sh:496
+#: src/script/arch-update.sh:539 src/script/arch-update.sh:549
+#: src/script/arch-update.sh:559 src/script/arch-update.sh:568
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:456 src/script/arch-update.sh:489
+#: src/script/arch-update.sh:466 src/script/arch-update.sh:499
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:461 src/script/arch-update.sh:493
-#: src/script/arch-update.sh:566
+#: src/script/arch-update.sh:471 src/script/arch-update.sh:503
+#: src/script/arch-update.sh:576
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:465
+#: src/script/arch-update.sh:475
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:470
+#: src/script/arch-update.sh:480
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:474
+#: src/script/arch-update.sh:484
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:476
+#: src/script/arch-update.sh:486
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:482
+#: src/script/arch-update.sh:492
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:497
+#: src/script/arch-update.sh:507
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:514
+#: src/script/arch-update.sh:524
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:515
+#: src/script/arch-update.sh:525
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:517
+#: src/script/arch-update.sh:527
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:518
+#: src/script/arch-update.sh:528
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:525 src/script/arch-update.sh:545
+#: src/script/arch-update.sh:535 src/script/arch-update.sh:555
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:535 src/script/arch-update.sh:554
+#: src/script/arch-update.sh:545 src/script/arch-update.sh:564
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:570
+#: src/script/arch-update.sh:580
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:579
+#: src/script/arch-update.sh:589
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:583
+#: src/script/arch-update.sh:593
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:585
+#: src/script/arch-update.sh:595
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:591
+#: src/script/arch-update.sh:601
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:595
+#: src/script/arch-update.sh:605
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:598
+#: src/script/arch-update.sh:608
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:602
+#: src/script/arch-update.sh:612
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:611
+#: src/script/arch-update.sh:621
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:612
+#: src/script/arch-update.sh:622
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:625
+#: src/script/arch-update.sh:635
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
 msgstr ""
 
-#: src/script/arch-update.sh:631
+#: src/script/arch-update.sh:641
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:639
+#: src/script/arch-update.sh:649
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:643
+#: src/script/arch-update.sh:653
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:698
+#: src/script/arch-update.sh:708
 #, sh-format
 msgid "Example configuration file not found"
 msgstr ""
 
-#: src/script/arch-update.sh:703
+#: src/script/arch-update.sh:713
 #, sh-format
 msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
 "before generating a new one"
 msgstr ""
 
-#: src/script/arch-update.sh:708
+#: src/script/arch-update.sh:718
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
 msgstr ""

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,54 +16,54 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:79
+#: src/script/arch-update.sh:131
+#, sh-format
+msgid "Press \"enter\" to continue "
+msgstr ""
+
+#: src/script/arch-update.sh:137
+#, sh-format
+msgid "Press \"enter\" to quit "
+msgstr ""
+
+#: src/script/arch-update.sh:150
+#, sh-format
+msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
+msgstr ""
+
+#: src/script/arch-update.sh:155
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the arch-update.conf "
 "configuration file is not found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:135
-#, sh-format
-msgid "Press \"enter\" to continue "
-msgstr ""
-
-#: src/script/arch-update.sh:141
-#, sh-format
-msgid "Press \"enter\" to quit "
-msgstr ""
-
-#: src/script/arch-update.sh:154
-#, sh-format
-msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
-msgstr ""
-
-#: src/script/arch-update.sh:177
+#: src/script/arch-update.sh:178
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:179
+#: src/script/arch-update.sh:180
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:180
+#: src/script/arch-update.sh:181
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:181
+#: src/script/arch-update.sh:182
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:182
+#: src/script/arch-update.sh:183
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -71,12 +71,12 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:184
+#: src/script/arch-update.sh:185
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:185
+#: src/script/arch-update.sh:186
 #, sh-format
 msgid ""
 "  -c, --check       Check for available updates, change the systray icon and "
@@ -84,388 +84,388 @@ msgid ""
 "there are new available updates compared to the last check)"
 msgstr ""
 
-#: src/script/arch-update.sh:186
+#: src/script/arch-update.sh:187
 #, sh-format
 msgid "  -l, --list        Display the list of pending updates"
 msgstr ""
 
-#: src/script/arch-update.sh:187
+#: src/script/arch-update.sh:188
 #, sh-format
 msgid "  -d, --devel       Include AUR development packages updates"
 msgstr ""
 
-#: src/script/arch-update.sh:188
+#: src/script/arch-update.sh:189
 #, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
 "number of Arch news to display with '--news [Num]' (e.g. '--news 10')"
 msgstr ""
 
-#: src/script/arch-update.sh:189
+#: src/script/arch-update.sh:190
 #, sh-format
 msgid "  -D, --debug       Display debug traces"
 msgstr ""
 
-#: src/script/arch-update.sh:190
+#: src/script/arch-update.sh:191
 #, sh-format
 msgid "  --gen-config      Generate a default/example configuration file"
 msgstr ""
 
-#: src/script/arch-update.sh:191
+#: src/script/arch-update.sh:192
 #, sh-format
 msgid "  --tray            Launch the Arch-Update systray applet"
 msgstr ""
 
-#: src/script/arch-update.sh:192
+#: src/script/arch-update.sh:193
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:193
+#: src/script/arch-update.sh:194
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:195
+#: src/script/arch-update.sh:196
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:196
+#: src/script/arch-update.sh:197
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:207
+#: src/script/arch-update.sh:208
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:247 src/script/arch-update.sh:249
+#: src/script/arch-update.sh:248 src/script/arch-update.sh:250
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:254 src/script/arch-update.sh:256
+#: src/script/arch-update.sh:255 src/script/arch-update.sh:257
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:272
+#: src/script/arch-update.sh:273
 #, sh-format
 msgid "Looking for updates...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:293
+#: src/script/arch-update.sh:294
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:298
+#: src/script/arch-update.sh:299
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:303
+#: src/script/arch-update.sh:304
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:310
+#: src/script/arch-update.sh:311
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:317
+#: src/script/arch-update.sh:318
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:320 src/script/arch-update.sh:457
-#: src/script/arch-update.sh:490 src/script/arch-update.sh:532
-#: src/script/arch-update.sh:599 src/script/arch-update.sh:625
+#: src/script/arch-update.sh:321 src/script/arch-update.sh:458
+#: src/script/arch-update.sh:491 src/script/arch-update.sh:533
+#: src/script/arch-update.sh:600 src/script/arch-update.sh:626
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/script/arch-update.sh:320 src/script/arch-update.sh:457
-#: src/script/arch-update.sh:490 src/script/arch-update.sh:532
-#: src/script/arch-update.sh:599 src/script/arch-update.sh:625
+#: src/script/arch-update.sh:321 src/script/arch-update.sh:458
+#: src/script/arch-update.sh:491 src/script/arch-update.sh:533
+#: src/script/arch-update.sh:600 src/script/arch-update.sh:626
 #, sh-format
 msgid "y"
 msgstr ""
 
-#: src/script/arch-update.sh:324
+#: src/script/arch-update.sh:325
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:355
+#: src/script/arch-update.sh:356
 #, sh-format
 msgid "Arch News:"
 msgstr ""
 
-#: src/script/arch-update.sh:360
+#: src/script/arch-update.sh:361
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:371
+#: src/script/arch-update.sh:372
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr ""
 
-#: src/script/arch-update.sh:373
+#: src/script/arch-update.sh:374
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 
-#: src/script/arch-update.sh:384
+#: src/script/arch-update.sh:385
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:385
+#: src/script/arch-update.sh:386
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:386
+#: src/script/arch-update.sh:387
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:387
+#: src/script/arch-update.sh:388
 #, sh-format
 msgid "URL:"
 msgstr ""
 
-#: src/script/arch-update.sh:400
+#: src/script/arch-update.sh:401
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:405 src/script/arch-update.sh:417
-#: src/script/arch-update.sh:428
+#: src/script/arch-update.sh:406 src/script/arch-update.sh:418
+#: src/script/arch-update.sh:429
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:412
+#: src/script/arch-update.sh:413
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:424
+#: src/script/arch-update.sh:425
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:435
+#: src/script/arch-update.sh:436
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:447
+#: src/script/arch-update.sh:448
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:451
+#: src/script/arch-update.sh:452
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:453
+#: src/script/arch-update.sh:454
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:459
+#: src/script/arch-update.sh:460
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:463 src/script/arch-update.sh:496
-#: src/script/arch-update.sh:539 src/script/arch-update.sh:549
-#: src/script/arch-update.sh:559 src/script/arch-update.sh:568
+#: src/script/arch-update.sh:464 src/script/arch-update.sh:497
+#: src/script/arch-update.sh:540 src/script/arch-update.sh:550
+#: src/script/arch-update.sh:560 src/script/arch-update.sh:569
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:466 src/script/arch-update.sh:499
+#: src/script/arch-update.sh:467 src/script/arch-update.sh:500
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:471 src/script/arch-update.sh:503
-#: src/script/arch-update.sh:576
+#: src/script/arch-update.sh:472 src/script/arch-update.sh:504
+#: src/script/arch-update.sh:577
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:475
+#: src/script/arch-update.sh:476
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:480
+#: src/script/arch-update.sh:481
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:484
+#: src/script/arch-update.sh:485
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:486
+#: src/script/arch-update.sh:487
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:492
+#: src/script/arch-update.sh:493
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:507
+#: src/script/arch-update.sh:508
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:524
+#: src/script/arch-update.sh:525
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:525
+#: src/script/arch-update.sh:526
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:527
+#: src/script/arch-update.sh:528
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:528
+#: src/script/arch-update.sh:529
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:535 src/script/arch-update.sh:555
+#: src/script/arch-update.sh:536 src/script/arch-update.sh:556
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:545 src/script/arch-update.sh:564
+#: src/script/arch-update.sh:546 src/script/arch-update.sh:565
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:580
+#: src/script/arch-update.sh:581
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:589
+#: src/script/arch-update.sh:590
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:593
+#: src/script/arch-update.sh:594
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:595
+#: src/script/arch-update.sh:596
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:601
+#: src/script/arch-update.sh:602
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:605
+#: src/script/arch-update.sh:606
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:608
+#: src/script/arch-update.sh:609
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:612
+#: src/script/arch-update.sh:613
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:621
+#: src/script/arch-update.sh:622
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:622
+#: src/script/arch-update.sh:623
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:635
+#: src/script/arch-update.sh:636
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
 msgstr ""
 
-#: src/script/arch-update.sh:641
+#: src/script/arch-update.sh:642
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:649
+#: src/script/arch-update.sh:650
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:653
+#: src/script/arch-update.sh:654
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:708
+#: src/script/arch-update.sh:709
 #, sh-format
 msgid "Example configuration file not found"
 msgstr ""
 
-#: src/script/arch-update.sh:713
+#: src/script/arch-update.sh:714
 #, sh-format
 msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
 "before generating a new one"
 msgstr ""
 
-#: src/script/arch-update.sh:718
+#: src/script/arch-update.sh:719
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,7 +16,22 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:79
+#: src/script/arch-update.sh:131
+#, sh-format
+msgid "Press \"enter\" to continue "
+msgstr "Appuyez sur \"entrée\" pour continuer "
+
+#: src/script/arch-update.sh:137
+#, sh-format
+msgid "Press \"enter\" to quit "
+msgstr "Appuyez sur \"entrée\" pour quitter "
+
+#: src/script/arch-update.sh:150
+#, sh-format
+msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
+msgstr "Une commande d'élévation de privilège est requise (sudo, doas ou run0)\\n"
+
+#: src/script/arch-update.sh:155
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the arch-update.conf "
@@ -25,22 +40,7 @@ msgstr ""
 "La command ${su_cmd} définie pour l'élévation de privilège dans le fichier "
 "de configuration arch-update.conf n'est pas disponible\\n"
 
-#: src/script/arch-update.sh:135
-#, sh-format
-msgid "Press \"enter\" to continue "
-msgstr "Appuyez sur \"entrée\" pour continuer "
-
-#: src/script/arch-update.sh:141
-#, sh-format
-msgid "Press \"enter\" to quit "
-msgstr "Appuyez sur \"entrée\" pour quitter "
-
-#: src/script/arch-update.sh:154
-#, sh-format
-msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
-msgstr "Une commande d'élévation de privilège est requise (sudo, doas ou run0)\\n"
-
-#: src/script/arch-update.sh:177
+#: src/script/arch-update.sh:178
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
@@ -49,12 +49,12 @@ msgstr ""
 "Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les "
 "tâches importantes d'avant/après mise à jour."
 
-#: src/script/arch-update.sh:179
+#: src/script/arch-update.sh:180
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr "Lancez ${name} pour exécuter la fonction principale 'update' :"
 
-#: src/script/arch-update.sh:180
+#: src/script/arch-update.sh:181
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
@@ -63,14 +63,14 @@ msgstr ""
 "Afficher la liste des paquets disponibles pour mise à jour, puis demander la confirmation de l'utilisateur "
 "pour procéder à l'installation."
 
-#: src/script/arch-update.sh:181
+#: src/script/arch-update.sh:182
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 "Avant d'effectuer la mise à jour, propose d'afficher les dernières news d'Arch Linux."
 
-#: src/script/arch-update.sh:182
+#: src/script/arch-update.sh:183
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -81,12 +81,12 @@ msgstr ""
 "pacsave et de mise à jour du noyau en attente et, s'il y en a, "
 "propose de les traiter."
 
-#: src/script/arch-update.sh:184
+#: src/script/arch-update.sh:185
 #, sh-format
 msgid "Options:"
 msgstr "Options :"
 
-#: src/script/arch-update.sh:185
+#: src/script/arch-update.sh:186
 #, sh-format
 msgid ""
 "  -c, --check       Check for available updates, change the systray icon and "
@@ -97,17 +97,17 @@ msgstr ""
 "envoie une notification de bureau contenant le nombre de mises à jour disponibles (s'"
 "il y a des nouvelles mises à jour depuis le dernier check)"
 
-#: src/script/arch-update.sh:186
+#: src/script/arch-update.sh:187
 #, sh-format
 msgid "  -l, --list        Display the list of pending updates"
 msgstr "  -l, --list        Afficher les mises à jours en attente"
 
-#: src/script/arch-update.sh:187
+#: src/script/arch-update.sh:188
 #, sh-format
 msgid "  -d, --devel       Include AUR development packages updates"
 msgstr "  -d, --devel       Inclure les mises à jour des paquets de développement AUR"
 
-#: src/script/arch-update.sh:188
+#: src/script/arch-update.sh:189
 #, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
@@ -116,37 +116,37 @@ msgstr ""
 "  -n, --news [Num]  Afficher les dernières Arch news, vous pouvez optionellement spécifier le "
 "nombre de Arch news à afficher avec '--news [Num]' (e.g. '--news 10')"
 
-#: src/script/arch-update.sh:189
+#: src/script/arch-update.sh:190
 #, sh-format
 msgid "  -D, --debug       Display debug traces"
 msgstr "  -D, --debug       Afficher les traces de débogage"
 
-#: src/script/arch-update.sh:190
+#: src/script/arch-update.sh:191
 #, sh-format
 msgid "  --gen-config      Generate a default/example configuration file"
 msgstr "  --gen-config      Générer un fichier de configuration par défaut/exemple"
 
-#: src/script/arch-update.sh:191
+#: src/script/arch-update.sh:192
 #, sh-format
 msgid "  --tray            Launch the Arch-Update systray applet"
 msgstr "  --tray            Lancer l'applet systray d'Arch-Update"
 
-#: src/script/arch-update.sh:192
+#: src/script/arch-update.sh:193
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr "  -h, --help        Afficher ce message d'aide et quitter"
 
-#: src/script/arch-update.sh:193
+#: src/script/arch-update.sh:194
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr "  -V, --version     Afficher les informations de version et quitter"
 
-#: src/script/arch-update.sh:195
+#: src/script/arch-update.sh:196
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr "Pour plus d'informations, consultez la page de manuel ${name}(1)."
 
-#: src/script/arch-update.sh:196
+#: src/script/arch-update.sh:197
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
@@ -155,7 +155,7 @@ msgstr ""
 "Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration ${name}.conf, "
 "voir la page de manuel ${name}.conf(5)."
 
-#: src/script/arch-update.sh:207
+#: src/script/arch-update.sh:208
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
@@ -164,114 +164,114 @@ msgstr ""
 "${name}: option invalide -- '${option}'\\nEssayez '${name} --help' pour plus "
 "d'informations."
 
-#: src/script/arch-update.sh:247 src/script/arch-update.sh:249
+#: src/script/arch-update.sh:248 src/script/arch-update.sh:250
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} mise à jour disponible"
 
-#: src/script/arch-update.sh:254 src/script/arch-update.sh:256
+#: src/script/arch-update.sh:255 src/script/arch-update.sh:257
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/script/arch-update.sh:272
+#: src/script/arch-update.sh:273
 #, sh-format
 msgid "Looking for updates...\\n"
 msgstr "Recherche de mises à jour...\\n"
 
-#: src/script/arch-update.sh:293
+#: src/script/arch-update.sh:294
 #, sh-format
 msgid "Packages:"
 msgstr "Paquets :"
 
-#: src/script/arch-update.sh:298
+#: src/script/arch-update.sh:299
 #, sh-format
 msgid "AUR Packages:"
 msgstr "Paquets AUR :"
 
-#: src/script/arch-update.sh:303
+#: src/script/arch-update.sh:304
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/script/arch-update.sh:310
+#: src/script/arch-update.sh:311
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
 
-#: src/script/arch-update.sh:317
+#: src/script/arch-update.sh:318
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:320 src/script/arch-update.sh:457
-#: src/script/arch-update.sh:490 src/script/arch-update.sh:532
-#: src/script/arch-update.sh:599 src/script/arch-update.sh:625
+#: src/script/arch-update.sh:321 src/script/arch-update.sh:458
+#: src/script/arch-update.sh:491 src/script/arch-update.sh:533
+#: src/script/arch-update.sh:600 src/script/arch-update.sh:626
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/script/arch-update.sh:320 src/script/arch-update.sh:457
-#: src/script/arch-update.sh:490 src/script/arch-update.sh:532
-#: src/script/arch-update.sh:599 src/script/arch-update.sh:625
+#: src/script/arch-update.sh:321 src/script/arch-update.sh:458
+#: src/script/arch-update.sh:491 src/script/arch-update.sh:533
+#: src/script/arch-update.sh:600 src/script/arch-update.sh:626
 #, sh-format
 msgid "y"
 msgstr "o"
 
-#: src/script/arch-update.sh:324
+#: src/script/arch-update.sh:325
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
 
-#: src/script/arch-update.sh:355
+#: src/script/arch-update.sh:356
 #, sh-format
 msgid "Arch News:"
 msgstr "Arch News :"
 
-#: src/script/arch-update.sh:360
+#: src/script/arch-update.sh:361
 #, sh-format
 msgid "[NEW]"
 msgstr "[NOUVEAU]"
 
-#: src/script/arch-update.sh:371
+#: src/script/arch-update.sh:372
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour quitter) :"
 
-#: src/script/arch-update.sh:373
+#: src/script/arch-update.sh:374
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour procéder à la mise à jour) :"
 
-#: src/script/arch-update.sh:384
+#: src/script/arch-update.sh:385
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/script/arch-update.sh:385
+#: src/script/arch-update.sh:386
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/script/arch-update.sh:386
+#: src/script/arch-update.sh:387
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:387
+#: src/script/arch-update.sh:388
 #, sh-format
 msgid "URL:"
 msgstr "URL :"
 
-#: src/script/arch-update.sh:400
+#: src/script/arch-update.sh:401
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:405 src/script/arch-update.sh:417
-#: src/script/arch-update.sh:428
+#: src/script/arch-update.sh:406 src/script/arch-update.sh:418
+#: src/script/arch-update.sh:429
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -280,27 +280,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:412
+#: src/script/arch-update.sh:413
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:424
+#: src/script/arch-update.sh:425
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:435
+#: src/script/arch-update.sh:436
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:447
+#: src/script/arch-update.sh:448
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:451
+#: src/script/arch-update.sh:452
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -309,7 +309,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:453
+#: src/script/arch-update.sh:454
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -318,14 +318,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:459
+#: src/script/arch-update.sh:460
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:463 src/script/arch-update.sh:496
-#: src/script/arch-update.sh:539 src/script/arch-update.sh:549
-#: src/script/arch-update.sh:559 src/script/arch-update.sh:568
+#: src/script/arch-update.sh:464 src/script/arch-update.sh:497
+#: src/script/arch-update.sh:540 src/script/arch-update.sh:550
+#: src/script/arch-update.sh:560 src/script/arch-update.sh:569
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -334,118 +334,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:466 src/script/arch-update.sh:499
+#: src/script/arch-update.sh:467 src/script/arch-update.sh:500
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:471 src/script/arch-update.sh:503
-#: src/script/arch-update.sh:576
+#: src/script/arch-update.sh:472 src/script/arch-update.sh:504
+#: src/script/arch-update.sh:577
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:475
+#: src/script/arch-update.sh:476
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:480
+#: src/script/arch-update.sh:481
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:484
+#: src/script/arch-update.sh:485
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:486
+#: src/script/arch-update.sh:487
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:492
+#: src/script/arch-update.sh:493
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:507
+#: src/script/arch-update.sh:508
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:524
+#: src/script/arch-update.sh:525
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:525
+#: src/script/arch-update.sh:526
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:527
+#: src/script/arch-update.sh:528
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:528
+#: src/script/arch-update.sh:529
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:535 src/script/arch-update.sh:555
+#: src/script/arch-update.sh:536 src/script/arch-update.sh:556
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:545 src/script/arch-update.sh:564
+#: src/script/arch-update.sh:546 src/script/arch-update.sh:565
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:580
+#: src/script/arch-update.sh:581
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:589
+#: src/script/arch-update.sh:590
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:593
+#: src/script/arch-update.sh:594
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:595
+#: src/script/arch-update.sh:596
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:601
+#: src/script/arch-update.sh:602
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:605
+#: src/script/arch-update.sh:606
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:608
+#: src/script/arch-update.sh:609
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:612
+#: src/script/arch-update.sh:613
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:621
+#: src/script/arch-update.sh:622
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -454,17 +454,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:622
+#: src/script/arch-update.sh:623
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:635
+#: src/script/arch-update.sh:636
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
 msgstr "Redémarrage dans ${sec}...\\r"
 
-#: src/script/arch-update.sh:641
+#: src/script/arch-update.sh:642
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -473,7 +473,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:649
+#: src/script/arch-update.sh:650
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -482,17 +482,17 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:653
+#: src/script/arch-update.sh:654
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"
 
-#: src/script/arch-update.sh:708
+#: src/script/arch-update.sh:709
 #, sh-format
 msgid "Example configuration file not found"
 msgstr "Fichier de configuration exemple non trouvé"
 
-#: src/script/arch-update.sh:713
+#: src/script/arch-update.sh:714
 #, sh-format
 msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
@@ -501,7 +501,7 @@ msgstr ""
 "Le fichier de configuration '${config_file}' existe déjà.\\nVeuillez le supprimer "
 "avant d'en générer un nouveau"
 
-#: src/script/arch-update.sh:718
+#: src/script/arch-update.sh:719
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
 msgstr "Le fichier de configuration '${config_file}' a été généré"

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,22 +16,31 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:127
+#: src/script/arch-update.sh:79
+#, sh-format
+msgid ""
+"The ${su_cmd} command set for privilege escalation in the arch-update.conf "
+"configuration file is not found\\n"
+msgstr ""
+"La command ${su_cmd} définie pour l'élévation de privilège dans le fichier "
+"de configuration arch-update.conf n'est pas disponible\\n"
+
+#: src/script/arch-update.sh:135
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/script/arch-update.sh:133
+#: src/script/arch-update.sh:141
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Appuyez sur \"entrée\" pour quitter "
 
-#: src/script/arch-update.sh:145
+#: src/script/arch-update.sh:154
 #, sh-format
-msgid "A privilege elevation method is required (sudo, doas or run0)\\n"
-msgstr "Une méthode d'élévation de privilège est requise (sudo, doas ou run0)\\n"
+msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
+msgstr "Une commande d'élévation de privilège est requise (sudo, doas ou run0)\\n"
 
-#: src/script/arch-update.sh:167
+#: src/script/arch-update.sh:177
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
@@ -40,12 +49,12 @@ msgstr ""
 "Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les "
 "tâches importantes d'avant/après mise à jour."
 
-#: src/script/arch-update.sh:169
+#: src/script/arch-update.sh:179
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr "Lancez ${name} pour exécuter la fonction principale 'update' :"
 
-#: src/script/arch-update.sh:170
+#: src/script/arch-update.sh:180
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
@@ -54,14 +63,14 @@ msgstr ""
 "Afficher la liste des paquets disponibles pour mise à jour, puis demander la confirmation de l'utilisateur "
 "pour procéder à l'installation."
 
-#: src/script/arch-update.sh:171
+#: src/script/arch-update.sh:181
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 "Avant d'effectuer la mise à jour, propose d'afficher les dernières news d'Arch Linux."
 
-#: src/script/arch-update.sh:172
+#: src/script/arch-update.sh:182
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -72,12 +81,12 @@ msgstr ""
 "pacsave et de mise à jour du noyau en attente et, s'il y en a, "
 "propose de les traiter."
 
-#: src/script/arch-update.sh:174
+#: src/script/arch-update.sh:184
 #, sh-format
 msgid "Options:"
 msgstr "Options :"
 
-#: src/script/arch-update.sh:175
+#: src/script/arch-update.sh:185
 #, sh-format
 msgid ""
 "  -c, --check       Check for available updates, change the systray icon and "
@@ -88,17 +97,17 @@ msgstr ""
 "envoie une notification de bureau contenant le nombre de mises à jour disponibles (s'"
 "il y a des nouvelles mises à jour depuis le dernier check)"
 
-#: src/script/arch-update.sh:176
+#: src/script/arch-update.sh:186
 #, sh-format
 msgid "  -l, --list        Display the list of pending updates"
 msgstr "  -l, --list        Afficher les mises à jours en attente"
 
-#: src/script/arch-update.sh:177
+#: src/script/arch-update.sh:187
 #, sh-format
 msgid "  -d, --devel       Include AUR development packages updates"
 msgstr "  -d, --devel       Inclure les mises à jour des paquets de développement AUR"
 
-#: src/script/arch-update.sh:178
+#: src/script/arch-update.sh:188
 #, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
@@ -107,37 +116,37 @@ msgstr ""
 "  -n, --news [Num]  Afficher les dernières Arch news, vous pouvez optionellement spécifier le "
 "nombre de Arch news à afficher avec '--news [Num]' (e.g. '--news 10')"
 
-#: src/script/arch-update.sh:179
+#: src/script/arch-update.sh:189
 #, sh-format
 msgid "  -D, --debug       Display debug traces"
 msgstr "  -D, --debug       Afficher les traces de débogage"
 
-#: src/script/arch-update.sh:180
+#: src/script/arch-update.sh:190
 #, sh-format
 msgid "  --gen-config      Generate a default/example configuration file"
 msgstr "  --gen-config      Générer un fichier de configuration par défaut/exemple"
 
-#: src/script/arch-update.sh:181
+#: src/script/arch-update.sh:191
 #, sh-format
 msgid "  --tray            Launch the Arch-Update systray applet"
 msgstr "  --tray            Lancer l'applet systray d'Arch-Update"
 
-#: src/script/arch-update.sh:182
+#: src/script/arch-update.sh:192
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr "  -h, --help        Afficher ce message d'aide et quitter"
 
-#: src/script/arch-update.sh:183
+#: src/script/arch-update.sh:193
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr "  -V, --version     Afficher les informations de version et quitter"
 
-#: src/script/arch-update.sh:185
+#: src/script/arch-update.sh:195
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr "Pour plus d'informations, consultez la page de manuel ${name}(1)."
 
-#: src/script/arch-update.sh:186
+#: src/script/arch-update.sh:196
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
@@ -146,7 +155,7 @@ msgstr ""
 "Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration ${name}.conf, "
 "voir la page de manuel ${name}.conf(5)."
 
-#: src/script/arch-update.sh:197
+#: src/script/arch-update.sh:207
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
@@ -155,114 +164,114 @@ msgstr ""
 "${name}: option invalide -- '${option}'\\nEssayez '${name} --help' pour plus "
 "d'informations."
 
-#: src/script/arch-update.sh:237 src/script/arch-update.sh:239
+#: src/script/arch-update.sh:247 src/script/arch-update.sh:249
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} mise à jour disponible"
 
-#: src/script/arch-update.sh:244 src/script/arch-update.sh:246
+#: src/script/arch-update.sh:254 src/script/arch-update.sh:256
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/script/arch-update.sh:262
+#: src/script/arch-update.sh:272
 #, sh-format
 msgid "Looking for updates...\\n"
 msgstr "Recherche de mises à jour...\\n"
 
-#: src/script/arch-update.sh:283
+#: src/script/arch-update.sh:293
 #, sh-format
 msgid "Packages:"
 msgstr "Paquets :"
 
-#: src/script/arch-update.sh:288
+#: src/script/arch-update.sh:298
 #, sh-format
 msgid "AUR Packages:"
 msgstr "Paquets AUR :"
 
-#: src/script/arch-update.sh:293
+#: src/script/arch-update.sh:303
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/script/arch-update.sh:300
+#: src/script/arch-update.sh:310
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
 
-#: src/script/arch-update.sh:307
+#: src/script/arch-update.sh:317
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:310 src/script/arch-update.sh:447
-#: src/script/arch-update.sh:480 src/script/arch-update.sh:522
-#: src/script/arch-update.sh:589 src/script/arch-update.sh:615
+#: src/script/arch-update.sh:320 src/script/arch-update.sh:457
+#: src/script/arch-update.sh:490 src/script/arch-update.sh:532
+#: src/script/arch-update.sh:599 src/script/arch-update.sh:625
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/script/arch-update.sh:310 src/script/arch-update.sh:447
-#: src/script/arch-update.sh:480 src/script/arch-update.sh:522
-#: src/script/arch-update.sh:589 src/script/arch-update.sh:615
+#: src/script/arch-update.sh:320 src/script/arch-update.sh:457
+#: src/script/arch-update.sh:490 src/script/arch-update.sh:532
+#: src/script/arch-update.sh:599 src/script/arch-update.sh:625
 #, sh-format
 msgid "y"
 msgstr "o"
 
-#: src/script/arch-update.sh:314
+#: src/script/arch-update.sh:324
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
 
-#: src/script/arch-update.sh:345
+#: src/script/arch-update.sh:355
 #, sh-format
 msgid "Arch News:"
 msgstr "Arch News :"
 
-#: src/script/arch-update.sh:350
+#: src/script/arch-update.sh:360
 #, sh-format
 msgid "[NEW]"
 msgstr "[NOUVEAU]"
 
-#: src/script/arch-update.sh:361
+#: src/script/arch-update.sh:371
 #, sh-format
 msgid "Select the news to read (or just press \"enter\" to quit):"
 msgstr "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour quitter) :"
 
-#: src/script/arch-update.sh:363
+#: src/script/arch-update.sh:373
 #, sh-format
 msgid ""
 "Select the news to read (or just press \"enter\" to proceed with update):"
 msgstr ""
 "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour procéder à la mise à jour) :"
 
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:384
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/script/arch-update.sh:375
+#: src/script/arch-update.sh:385
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/script/arch-update.sh:376
+#: src/script/arch-update.sh:386
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:377
+#: src/script/arch-update.sh:387
 #, sh-format
 msgid "URL:"
 msgstr "URL :"
 
-#: src/script/arch-update.sh:390
+#: src/script/arch-update.sh:400
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:395 src/script/arch-update.sh:407
-#: src/script/arch-update.sh:418
+#: src/script/arch-update.sh:405 src/script/arch-update.sh:417
+#: src/script/arch-update.sh:428
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -271,27 +280,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:402
+#: src/script/arch-update.sh:412
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:414
+#: src/script/arch-update.sh:424
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:425
+#: src/script/arch-update.sh:435
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:437
+#: src/script/arch-update.sh:447
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:441
+#: src/script/arch-update.sh:451
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -300,7 +309,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:443
+#: src/script/arch-update.sh:453
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -309,14 +318,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:449
+#: src/script/arch-update.sh:459
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:453 src/script/arch-update.sh:486
-#: src/script/arch-update.sh:529 src/script/arch-update.sh:539
-#: src/script/arch-update.sh:549 src/script/arch-update.sh:558
+#: src/script/arch-update.sh:463 src/script/arch-update.sh:496
+#: src/script/arch-update.sh:539 src/script/arch-update.sh:549
+#: src/script/arch-update.sh:559 src/script/arch-update.sh:568
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -325,118 +334,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:456 src/script/arch-update.sh:489
+#: src/script/arch-update.sh:466 src/script/arch-update.sh:499
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:461 src/script/arch-update.sh:493
-#: src/script/arch-update.sh:566
+#: src/script/arch-update.sh:471 src/script/arch-update.sh:503
+#: src/script/arch-update.sh:576
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:465
+#: src/script/arch-update.sh:475
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:470
+#: src/script/arch-update.sh:480
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:474
+#: src/script/arch-update.sh:484
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:476
+#: src/script/arch-update.sh:486
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:482
+#: src/script/arch-update.sh:492
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:497
+#: src/script/arch-update.sh:507
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:514
+#: src/script/arch-update.sh:524
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:515
+#: src/script/arch-update.sh:525
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:517
+#: src/script/arch-update.sh:527
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:518
+#: src/script/arch-update.sh:528
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:525 src/script/arch-update.sh:545
+#: src/script/arch-update.sh:535 src/script/arch-update.sh:555
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:535 src/script/arch-update.sh:554
+#: src/script/arch-update.sh:545 src/script/arch-update.sh:564
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:570
+#: src/script/arch-update.sh:580
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:579
+#: src/script/arch-update.sh:589
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:583
+#: src/script/arch-update.sh:593
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:585
+#: src/script/arch-update.sh:595
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:591
+#: src/script/arch-update.sh:601
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:595
+#: src/script/arch-update.sh:605
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:598
+#: src/script/arch-update.sh:608
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:602
+#: src/script/arch-update.sh:612
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:611
+#: src/script/arch-update.sh:621
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -445,17 +454,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:612
+#: src/script/arch-update.sh:622
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:625
+#: src/script/arch-update.sh:635
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
 msgstr "Redémarrage dans ${sec}...\\r"
 
-#: src/script/arch-update.sh:631
+#: src/script/arch-update.sh:641
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -464,7 +473,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:639
+#: src/script/arch-update.sh:649
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -473,17 +482,17 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:643
+#: src/script/arch-update.sh:653
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"
 
-#: src/script/arch-update.sh:698
+#: src/script/arch-update.sh:708
 #, sh-format
 msgid "Example configuration file not found"
 msgstr "Fichier de configuration exemple non trouvé"
 
-#: src/script/arch-update.sh:703
+#: src/script/arch-update.sh:713
 #, sh-format
 msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
@@ -492,7 +501,7 @@ msgstr ""
 "Le fichier de configuration '${config_file}' existe déjà.\\nVeuillez le supprimer "
 "avant d'en générer un nouveau"
 
-#: src/script/arch-update.sh:708
+#: src/script/arch-update.sh:718
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
 msgstr "Le fichier de configuration '${config_file}' a été généré"

--- a/res/config/arch-update.conf.example
+++ b/res/config/arch-update.conf.example
@@ -8,3 +8,4 @@
 #NewsNum=5
 #KeepOldPackages=3
 #KeepUninstalledPackages=0
+#PrivilegeElevationCommand=sudo

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -75,10 +75,6 @@ fi
 
 if grep -Eq '^[[:space:]]*PrivilegeElevationCommand[[:space:]]*=[[:space:]]*(sudo|doas|run0)[[:space:]]*$' "${config_file}" 2> /dev/null; then
 	su_cmd=$(grep -E '^[[:space:]]*PrivilegeElevationCommand[[:space:]]*=[[:space:]]*(sudo|doas|run0)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
-	if ! command -v "${su_cmd}" > /dev/null; then
-		error_msg "$(eval_gettext "The \${su_cmd} command set for privilege escalation in the arch-update.conf configuration file is not found\n")" && quit_msg
-		exit 2
-	fi
 fi
 
 # Definition of the colors for the colorized output
@@ -152,6 +148,11 @@ if [ -z "${su_cmd}" ]; then
 		su_cmd="run0"
 	else
 		error_msg "$(eval_gettext "A privilege elevation command is required (sudo, doas or run0)\n")" && quit_msg
+		exit 2
+	fi
+else
+	if ! command -v "${su_cmd}" > /dev/null; then
+		error_msg "$(eval_gettext "The \${su_cmd} command set for privilege escalation in the arch-update.conf configuration file is not found\n")" && quit_msg
 		exit 2
 	fi
 fi


### PR DESCRIPTION
This PR introduces the 'PrivilegeElevationCommand' option to the arch-update.conf configuration file which allows to explicitly set the command to be used to elevate privileges (sudo, doas, run0), so people can choose between them if they have multipe of those commands installed.

If this option isn't set, the default behavior is applied (first look for `sudo`, then `doas`, then `run0`).

Closes https://github.com/Antiz96/arch-update/issues/173