### PR TITLE
Add the `--show-config` option that displays the current configuration file

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -159,6 +159,7 @@ Options :
 -n, --news [Num]  Afficher les dernieres Arch News, vous pouvez optionellement spécifier le nombre de Arch news à afficher avec `--news [Num]` (e.g. `--news 10`)
 -D, --debug       Afficher les traces de débogage
 --gen-config      Générer un fichier de configuration par défaut/exemple (voir la page de manuel arch-update.conf(5) pour plus de détails)
+--show-config     Afficher le fichier de configuration `arch-update.conf` actuellement utilisé (s'il existe)
 --tray            Lancer l'applet systray d'Arch-Update
 -h, --help        Afficher ce message d'aide et quitter
 -V, --version     Afficher les informations de version et quitter
@@ -173,6 +174,7 @@ Codes de sortie :
 6  Erreur lors de l'appel de la commande reboot pour appliquer une mise à jour du noyau en attente
 7  Aucune mise à jour en attente durant l'utilisation de l'option `-l/--list`
 8  Erreur lors de la génération d'un fichier de configuration avec l'option `--gen-config`
+9  Erreur lors de la lecture du fichier de configuration avec l'option `--show-config`
 ```
 
 Pour plus d'informations, consultez la page de manuel arch-update(1).  

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Options:
 -n, --news [Num]  Display latest Arch News, you can optionally specify the number of Arch news to display with `--news [Num]` (e.g. `--news 10`)
 -D, --debug       Display debug traces
 --gen-config      Generate a default/example configuration file (see the arch-update.conf(5) man page for more details)
+--show-config     Display the `arch-update.conf` configuration file currently used (if it exists)
 --tray            Launch the Arch-Update systray applet
 -h, --help        Display this help message and exit
 -V, --version     Display version information and exit
@@ -173,6 +174,7 @@ Exit Codes:
 6  Error when calling the reboot command to apply a pending kernel update
 7  No pending update when using the `-l/--list` option
 8  Error when generating a configuration file with the `--gen-config` option
+9  Error when reading the configuration file with the `--show-config` option
 ```
 
 For more information, see the arch-update(1) man page.  

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -61,6 +61,10 @@ Display debug traces.
 .RB "Generate a default/example configuration file (see the " "arch-update.conf(5) " "man page for more details)."
 
 .TP
+.B \-\-show\-config
+.RB "Display the " "arch-update.conf " "configuration file currently used (if it exists)."
+
+.TP
 .B \-\-tray
 .RB "Launch the Arch-Update systray applet (you can alternatively start/enable the associated systemd service like so: " "systemctl \-\-user enable \-\-now arch-update-tray.service").
 
@@ -210,6 +214,10 @@ Error when calling the reboot command to apply a pending kernel update
 .TP
 .B 8
 .RB "Error when generating a configuration file with the " "--gen-config " "option"
+
+.TP
+.B 9
+.RB "Error when reading the configuration file with the " "--show-config " "option"
 
 .SH SEE ALSO
 .BR checkupdates (8),

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -61,6 +61,10 @@ Afficher les traces de débogage.
 .RB "Générer un fichier de configuration par défaut/exemple (voir la page de manuel " "arch-update.conf(5) " "pour plus de détails)."
 
 .TP
+.B \-\-show\-config
+.RB "Afficher le fichier de configuration " "arch-update.conf " "actuellement utilisé (s'il existe)."
+
+.TP
 .B \-\-tray
 .RB "Lancer l'applet systray d'Arch-Update (alternativement, vous pouvez démarrer/activer le service systemd associé comme ceci : " "systemctl \-\-user enable \-\-now arch-update-tray.service").
 
@@ -210,6 +214,10 @@ Erreur lors de l'appel de la commande reboot pour appliquer une mise à jour du 
 .TP
 .B 8
 .RB "Erreur lors de la génération d'un fichier de configuration avec l'option " "--gen-config"
+
+.TP
+.B 9
+.RB "Erreur lors de la lecture du fichier de configuration avec l'option " "--show-config"
 
 .SH VOIR AUSSI
 .BR checkupdates (8),

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -470,6 +470,11 @@ msgstr ""
 msgid "The '${config_file}' configuration file has been generated"
 msgstr ""
 
+#: src/script/arch-update.sh:724
+#, sh-format
+msgid "No configuration file found"
+msgstr ""
+
 #: src/script/arch-update-tray.py:118
 msgid "Run Arch-Update"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -506,6 +506,11 @@ msgstr ""
 msgid "The '${config_file}' configuration file has been generated"
 msgstr "Le fichier de configuration '${config_file}' a été généré"
 
+#: src/script/arch-update.sh:724
+#, sh-format
+msgid "No configuration file found"
+msgstr "Aucun fichier de configuration n'a été trouvé"
+
 #: src/script/arch-update-tray.py:118
 msgid "Run Arch-Update"
 msgstr "Lancer Arch-Update"

--- a/res/completions/arch-update.bash
+++ b/res/completions/arch-update.bash
@@ -7,6 +7,7 @@ _arch-update() {
 	       -n --news
 	       -D --debug
 	       --gen-config
+	       --show-config
 	       --tray
 	       -h --help
 	       -V --version')

--- a/res/completions/arch-update.fish
+++ b/res/completions/arch-update.fish
@@ -6,6 +6,7 @@ complete -c arch-update -s d -l devel -d 'Include AUR development packages updat
 complete -c arch-update -s n -l news -d 'Display latest Arch news'
 complete -c arch-update -s D -l debug -d 'Display debug traces'
 complete -c arch-update -l gen-config -d 'Generate a default/example configuration file'
+complete -c arch-update -l show-config -d 'Display the current configuration file'
 complete -c arch-update -l tray -d 'Launch the Arch-Update systray applet'
 complete -c arch-update -s h -l help -d 'Display the help message'
 complete -c arch-update -s V -l version -d 'Display version information'

--- a/res/completions/arch-update.zsh
+++ b/res/completions/arch-update.zsh
@@ -8,6 +8,7 @@ opts=(
     {-n,--news}'[Display latest Arch news]'
     {-D,--debug}'[Display debug traces]'
     {--gen-config}'[Generate a default/example configuration file]'
+    {--show-config}'[Display the current configuration file]'
     {--tray}'[Launch the Arch-Update systray applet]'
     {-h,--help}'[Display the help message]'
     {-V,--version}'[Display version information]'

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -719,6 +719,14 @@ case "${option}" in
 			info_msg "$(eval_gettext "The '\${config_file}' configuration file has been generated")"
 		fi
 	;;
+	--show-config)
+		if [ ! -f "${config_file}" ]; then
+			error_msg "$(eval_gettext "No configuration file found")"
+			exit 9
+		else
+			cat "${config_file}" || exit 9
+		fi
+	;;
 	--tray)
 		if [ ! -f "${statedir}/current_state" ]; then
 			state_up_to_date


### PR DESCRIPTION
This PR introduces the `--show-config` option that displays the current configuration file (arch-update.conf), if it exists.  
This will be useful for debug/analyses during bug report if needed.

Closes https://github.com/Antiz96/arch-update/issues/176