### PR TITLE
chore: Add templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+Name: Bug report
+About: Report a bug
+Labels: 'bug'
+Assignees: 'Antiz96'
+---
+
+<!-- Please, read the contributing guidelines before opening an issue: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->
+
+### Environment
+
+<!-- Please, provide the following information
+Distribution examples are Arch Linux, EndeavourOS, CachyOS, Garuda...
+The Arch-Update version can be retrieved by running `arch-update --version` -->
+
+- Distribution:
+- Arch-Update version:
+
+### Arch-Update configuration
+
+<!-- If you're using an arch-update.conf configuration file, paste it below
+It can be retrieved by running `arch-update --show-config` -->
+
+```text
+Paste your arch-update.conf configuration file here (if you use one)
+```
+
+### Description of the bug
+
+<!-- Describe the issue you're facing -->
+
+### Screenshots / Logs
+
+<!-- If you have any screenshots to illustrate the issue or any relevant logs, paste them below
+For instance, it could be useful to provide debug traces by running `arch-update --debug` (or `arch-update [OPTION] --debug` if the issue you're facing is about a specific option) -->
+
+```text
+Paste any relevant logs here (if you have some)
+```
+
+### Additional context
+
+<!-- If you have any additional context or details about your issue that could help solving it, provide them here -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+Name: Feature request
+About: Suggest an idea or a new feature
+Labels: 'feature/request'
+Assignees: 'Antiz96'
+---
+
+<!-- Please, read the contributing guidelines before opening an issue: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->
+
+### Description
+
+<!-- Describe your idea or the new feature you would like to see implemented -->
+
+### Motivation and context
+
+<!-- Provide some details about the motivation and/or the context of your request
+For instance:  Why is this feature required/beneficial? What problem does it solve? ...
+If it addresses an opened issue, please link to the issue here -->
+
+### Screenshots / Logs
+
+<!-- If you have any screenshots to illustrate your request or any relevant logs, paste them below -->
+
+```text
+Paste any relevant logs here (if you have some)
+```

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,8 @@
+---
+Name: Other (General question or feedback)
+About: Ask a general question or provide a feedback
+Labels: ''
+Assignees: 'Antiz96'
+---
+
+<!-- Please, read the contributing guidelines before opening an issue: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->
+
+### Description
+
+<!-- Describe your changes -->
+
+### Screenshots / Logs
+
+<!-- If you have any screenshots to illustrate your changes or any relevant logs, paste them below -->
+
+```text
+Paste any relevant logs here (if you have some)
+```
+
+### Fixed bug
+
+<!-- If this pull request is fixing an opened bug report, paste the corresponding issue URL below -->
+
+Fixes "issue_URL"
+
+### Addressed feature request
+
+<!-- If this pull request is addressing an opened feature request, paste the corresponding issue URL below -->
+
+Closes "issue_URL"


### PR DESCRIPTION
Add templates for issues and pull requests to categorize each possible issue type properly and ask some relevant details to users in order to ease processing

Partially addresses https://github.com/Antiz96/arch-update/issues/183