### PR TITLE
chore: Add contribution guidelines (CONTRIBUTING.md)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,10 +16,10 @@ Paste any relevant logs here (if you have some)
 
 <!-- If this pull request is fixing an opened bug report, paste the corresponding issue URL below -->
 
-Fixes "issue_URL"
+Fixes "issue_URL" (if any)
 
 ### Addressed feature request
 
 <!-- If this pull request is addressing an opened feature request, paste the corresponding issue URL below -->
 
-Closes "issue_URL"
+Closes "issue_URL" (if any)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Here are a few examples of the expected commit format:
 ```text
 feat(systray): Add a right click menu to the systray applet
 
-Add a right click menu to the systray applet containing two entries: 
+Add a right click menu to the systray applet containing two entries:
 One to run Arch-Update and one to "exit" (close) the systray applet
 
 Closes https://github.com/Antiz96/arch-update/issues/163

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing
+
+Thank you for considering contributing to [Arch-Update](https://github.com/Antiz96/arch-update)!
+
+With the exception of the [general rules](#general-rules), which must be acknowledged and applied in any contribution/interaction in this project, those guidelines represents an ideal target & discipline I'd like this project to follow but may not all be **strictly** enforced (depending on the situation).  
+Please, don't refrain yourself from contributing if you feel that your contribution may not entirely follow those guidelines (or if you're struggling applying some of them). I value your contribution more than the strict application of these guidelines!
+
+## Table of contents
+
+- [General rules](#general-rules)
+- [Open an issue](#open-an-issue)
+- [Open a pull request](#open-a-pull-request)
+- [Donations](#donations)
+- [Thank you](#thank-you)
+
+## General rules
+
+These general rules apply to **every** contributions (whatever the type). They should **always** be acknowledged and strictly followed in any circumstances:
+
+Basic common sense applies to every contributions & discussions: stay polite and respectful, no flaming/trolling/spamming or any kind of discrimination/harassment, avoid controversial topics *(specifically if it has nothing to do with this project whatsoever)*, etc...
+
+Use English as much as possible for contributions & discussions. If required, I can also speak French, but it's important that contributions & discussions are intelligible to most people.
+
+Arch-Update is developed and tested specifically with *vanilla* Arch Linux in mind. That doesn't mean that Arch-Update won't work with other Arch based distributions (e.g. EndeavourOS,  CachyOS, Garuda...), but keep in mind that such distributions are supported at a "best effort" level. In other words, I'll try my best to keep Arch-Update compatible with derivatives distributions, but there's no guarantee that Arch-Update (or parts of it) will continuously work properly on said distributions.
+
+## Open an issue
+
+Before [opening an issue](https://github.com/Antiz96/arch-update/issues/new/choose), verify that's not any related one already existing.  
+Also, make sure to use the correct type for your issue (`Bug Report` or `Feature Request`) and to provide the requested information. If you have a doubt about which one is the most appropriate for your issue (or if you think that none of these types apply to your issue), feel free to use the general `Other` type.
+
+Providing as much details as possible in your issue will ease its processing.
+
+## Open a pull requests
+
+Read the following before opening a pull request and make sure to provide the information requested in the [pull request template](https://github.com/Antiz96/arch-update/blob/main/.github/PULL_REQUEST_TEMPLATE.md) in your pull request's description.
+
+### Open an issue first
+
+Apart from trivial changes (like simple typo fixes), it is advised to first [open an issue](#open-an-issue) to expose and discuss your changes, verify its feasibility/necessity and agree on the specifications.
+
+### Coding style
+
+When submitting code changes, try to stick as much as possible to the used mechanism and coding style.  
+For instance, for the main bash script:
+
+- Stick to bash syntax
+- Variables should use the `"${var}"` format
+- Use the `{main,info,ask,warning,error}_msg` functions to print messages
+- Use `"$(eval_gettext "string")"` for any string chain that should be included in translations
+- [...]
+
+Bash code is checked with [shellcheck](https://www.shellcheck.net/).  
+Python code is checked with [pylint](https://github.com/pylint-dev/pylint).  
+Markdown syntax is checked with [markdownlint](https://github.com/markdownlint/markdownlint).
+
+### Commit message format
+
+Commits must follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+
+This project uses the following commit types:
+
+- chore: for internal repo changes/miscellaneous tasks
+- feat: for new features (or improvement/addition to existing features)
+- fix: for bug fixes
+- doc: for documentation only changes
+- style: For changes that do not affect the meaning of the code (white-space, formatting, typo fixes, etc...)
+
+An optional scope can be provided to the commit type if relevant (for instance when a change is specific to precise part of the project), like so: `type(scope): commit message`.  
+If a commit introduces a breaking change, it's type must contain a `!` (e.g. `feat!: commit message`) and/or a "BREAKING CHANGE:" mention should be added at the end of your commit message (e.g. `BREAKING CHANGE: description of the breaking change`).
+
+Here are a few examples of the expected commit format:
+
+```text
+feat(systray): Add a right click menu to the systray applet
+
+Add a right click menu to the systray applet containing two entries: One to run Arch-Update and one to "exit" (close) the systray applet
+
+Closes https://github.com/Antiz96/arch-update/issues/163
+```
+
+```text
+fix: Improve parsing on Flatpak cli output to avoid false positives
+
+The current parsing of the Flatpak cli output when looking for pending Flatpak updates is subject to false positives. This commit makes it more robust to avoid such issues.
+
+Fixes https://github.com/Antiz96/arch-update/issues/103
+```
+
+```text
+doc(man): Add the -l/--list option to man pages
+
+The recently introduced -l/--list option was missing from the man page
+```
+
+```text
+style: Typo fixes in README and man pages
+```
+
+### License
+
+By contributing to this project, you agree that your contributions will be licensed under the [GPL-3.0 license](https://github.com/Antiz96/arch-update/blob/main/LICENSE) (or any later version of this license).
+
+## Donations
+
+You can also support this project development (and my work in general) by making a small donation via my [GitHub sponsor page](https://github.com/sponsors/Antiz96).
+
+## Thank you
+
+Once again, thank you for considering contributing to Arch-Update!
+I'd also like to thank everyone that already opened issues, feature requests, pull requests or contributed to Arch-Update in any other way! :heart:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,9 @@
 
 Thank you for considering contributing to [Arch-Update](https://github.com/Antiz96/arch-update)!
 
-With the exception of the [general rules](#general-rules), which must be acknowledged and applied in any contribution/interaction in this project, those guidelines represents an ideal target & discipline I'd like this project to follow but may not all be **strictly** enforced (depending on the situation).  
-Please, don't refrain yourself from contributing if you feel that your contribution may not entirely follow those guidelines (or if you're struggling applying some of them). I value your contribution more than the strict application of these guidelines!
+With the exception of the [general rules](#general-rules), which **must** be acknowledged and applied in any contribution/interaction in this project, these guidelines represents an ideal target & standards that I would like this project to follow but may not all be **strictly** enforced (depending on the situation).
+
+Please, don't refrain yourself from contributing if you feel that your contribution may not entirely follow these guidelines (or if you're struggling applying some of them). I value your contribution more than the strict application of these guidelines!
 
 ## Table of contents
 
@@ -15,24 +16,25 @@ Please, don't refrain yourself from contributing if you feel that your contribut
 
 ## General rules
 
-These general rules apply to **every** contributions (whatever the type). They should **always** be acknowledged and strictly followed in any circumstances:
+These general rules apply to **every** contributions (whatever the type). They should **always** be acknowledged and **strictly** followed in any circumstances:
 
 Basic common sense applies to every contributions & discussions: stay polite and respectful, no flaming/trolling/spamming or any kind of discrimination/harassment, avoid controversial topics *(specifically if it has nothing to do with this project whatsoever)*, etc...
 
-Use English as much as possible for contributions & discussions. If required, I can also speak French, but it's important that contributions & discussions are intelligible to most people.
+Use English as much as possible for contributions & discussions. If required, I can also speak French, but it's important that contributions & discussions remain intelligible to most people.
 
 Arch-Update is developed and tested specifically with *vanilla* Arch Linux in mind. That doesn't mean that Arch-Update won't work with other Arch based distributions (e.g. EndeavourOS,  CachyOS, Garuda...), but keep in mind that such distributions are supported at a "best effort" level. In other words, I'll try my best to keep Arch-Update compatible with derivatives distributions, but there's no guarantee that Arch-Update (or parts of it) will continuously work properly on said distributions.
 
 ## Open an issue
 
-Before [opening an issue](https://github.com/Antiz96/arch-update/issues/new/choose), verify that's not any related one already existing.  
-Also, make sure to use the correct type for your issue (`Bug Report` or `Feature Request`) and to provide the requested information. If you have a doubt about which one is the most appropriate for your issue (or if you think that none of these types apply to your issue), feel free to use the general `Other` type.
+Before [opening an issue](https://github.com/Antiz96/arch-update/issues/new/choose), verify that there isn't one already open on the same (or a similar) subject.
+
+Make sure to use the correct type for your issue (`Bug Report` or `Feature Request`) and to provide the requested information. If you have a doubt about which one is the most appropriate for your issue (or if you think that none of these types apply to your issue), feel free to use the general `Other` type.
 
 Providing as much details as possible in your issue will ease its processing.
 
-## Open a pull requests
+## Open a pull request
 
-Read the following before opening a pull request and make sure to provide the information requested in the [pull request template](https://github.com/Antiz96/arch-update/blob/main/.github/PULL_REQUEST_TEMPLATE.md) in your pull request's description.
+Read the following sub-chapter before opening a pull request and make sure to provide the information requested in the [pull request template](https://github.com/Antiz96/arch-update/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
 
 ### Open an issue first
 
@@ -40,7 +42,7 @@ Apart from trivial changes (like simple typo fixes), it is advised to first [ope
 
 ### Coding style
 
-When submitting code changes, try to stick as much as possible to the used mechanism and coding style.  
+When submitting code changes, try to respect the coding style and the overall way things work as much as possible.  
 For instance, for the main bash script:
 
 - Stick to bash syntax
@@ -59,21 +61,22 @@ Commits must follow the [conventional commits](https://www.conventionalcommits.o
 
 This project uses the following commit types:
 
-- chore: for internal repo changes/miscellaneous tasks
-- feat: for new features (or improvement/addition to existing features)
+- chore: for internal/miscellaneous changes
+- feat: for new features (or improvements/additions to existing features)
 - fix: for bug fixes
 - doc: for documentation only changes
 - style: For changes that do not affect the meaning of the code (white-space, formatting, typo fixes, etc...)
 
 An optional scope can be provided to the commit type if relevant (for instance when a change is specific to precise part of the project), like so: `type(scope): commit message`.  
-If a commit introduces a breaking change, it's type must contain a `!` (e.g. `feat!: commit message`) and/or a "BREAKING CHANGE:" mention should be added at the end of your commit message (e.g. `BREAKING CHANGE: description of the breaking change`).
+If a commit introduces a breaking change, its type must contain a `!` (e.g. `feat!: commit message`) and/or a `BREAKING CHANGE:` mention should be added at the end of your commit message (e.g. `BREAKING CHANGE: description of the breaking change`).
 
 Here are a few examples of the expected commit format:
 
 ```text
 feat(systray): Add a right click menu to the systray applet
 
-Add a right click menu to the systray applet containing two entries: One to run Arch-Update and one to "exit" (close) the systray applet
+Add a right click menu to the systray applet containing two entries: 
+One to run Arch-Update and one to "exit" (close) the systray applet
 
 Closes https://github.com/Antiz96/arch-update/issues/163
 ```
@@ -81,7 +84,8 @@ Closes https://github.com/Antiz96/arch-update/issues/163
 ```text
 fix: Improve parsing on Flatpak cli output to avoid false positives
 
-The current parsing of the Flatpak cli output when looking for pending Flatpak updates is subject to false positives. This commit makes it more robust to avoid such issues.
+The current parsing of the Flatpak cli output when looking for pending Flatpak updates is subject to false positives.
+This commit makes it more robust to avoid such issues.
 
 Fixes https://github.com/Antiz96/arch-update/issues/103
 ```
@@ -106,5 +110,5 @@ You can also support this project development (and my work in general) by making
 
 ## Thank you
 
-Once again, thank you for considering contributing to Arch-Update!
+Once again, thank you for considering contributing to Arch-Update!  
 I'd also like to thank everyone that already opened issues, feature requests, pull requests or contributed to Arch-Update in any other way! :heart:

--- a/README-fr.md
+++ b/README-fr.md
@@ -14,6 +14,7 @@
 - [Documentation](#documentation)
 - [Trucs et astuces](#trucs-et-astuces)
 - [Contribuer](#contribuer)
+- [Licence](#licence)
 
 ## Description
 
@@ -260,5 +261,8 @@ Alternativement, vous pouvez créer un lien symbolique de votre émulateur de te
 
 ## Contribuer
 
-Vous pouvez soulever vos problèmes, commentaires et suggestions dans l'onglet [Issues](https://github.com/Antiz96/arch-update/issues).  
-Les [Pull requests](https://github.com/Antiz96/arch-update/pulls) sont également les bienvenues !
+Veuillez lire le [guide de contribution](https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md).
+
+## Licence
+
+Arch-Update est sous [licence GPL-3.0](https://github.com/Antiz96/arch-update/blob/main/LICENSE) (ou toute version ultérieure de cette licence).

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Documentation](#documentation)
 - [Tips and tricks](#tips-and-tricks)
 - [Contributing](#contributing)
+- [License](#license)
 
 ## Description
 
@@ -260,5 +261,8 @@ Alternatively, you can create a symlink for your terminal emulator that points t
 
 ## Contributing
 
-You can raise your issues, feedbacks and suggestions in the [issues tab](https://github.com/Antiz96/arch-update/issues).  
-[Pull requests](https://github.com/Antiz96/arch-update/pulls) are welcomed as well!
+Please, read the [contributing guidelines](https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md).
+
+## License
+
+Arch-Update is licensed under the [GPL-3.0 license](https://github.com/Antiz96/arch-update/blob/main/LICENSE) (or any later version of that license).


### PR DESCRIPTION
### Description

Add contributing guidelines (CONTRIBUTING.md) to the repo in order to define rules, standard and general guidelines for every future contributions and interactions in this project.

### Addressed feature request

Addresses parts of https://github.com/Antiz96/arch-update/issues/183
