### PR TITLE
fix(translation): Add missing translations for WARNING and ERROR

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,6 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: src/script/arch-update.sh:120
+#, sh-format
+msgid "WARNING"
+msgstr ""
+
+#: src/script/arch-update.sh:126
+#, sh-format
+msgid "ERROR"
+msgstr ""
+
 #: src/script/arch-update.sh:131
 #, sh-format
 msgid "Press \"enter\" to continue "

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,6 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: src/script/arch-update.sh:120
+#, sh-format
+msgid "WARNING"
+msgstr "AVERTISSEMENT"
+
+#: src/script/arch-update.sh:126
+#, sh-format
+msgid "ERROR"
+msgstr "ERREUR"
+
 #: src/script/arch-update.sh:131
 #, sh-format
 msgid "Press \"enter\" to continue "

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -117,13 +117,13 @@ ask_msg() {
 # Definition of the warning_msg function: Display a message as a warning message
 warning_msg() {
 	msg="${1}"
-	echo -e "${yellow}==> WARNING:${color_off}${bold} ${msg}${color_off}"
+	echo -e "${yellow}==> "$(eval_gettext "WARNING")":${color_off}${bold} ${msg}${color_off}"
 }
 
 # Definition of the error_msg function: Display a message as an error message
 error_msg() {
 	msg="${1}"
-	echo -e >&2 "${red}==> ERROR:${color_off}${bold} ${msg}${color_off}"
+	echo -e >&2 "${red}==> "$(eval_gettext "ERROR")":${color_off}${bold} ${msg}${color_off}"
 }
 
 # Definition of the continue_msg function: Display the continue message

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -117,13 +117,13 @@ ask_msg() {
 # Definition of the warning_msg function: Display a message as a warning message
 warning_msg() {
 	msg="${1}"
-	echo -e "${yellow}==> "$(eval_gettext "WARNING")":${color_off}${bold} ${msg}${color_off}"
+	echo -e "${yellow}==> $(eval_gettext "WARNING"):${color_off}${bold} ${msg}${color_off}"
 }
 
 # Definition of the error_msg function: Display a message as an error message
 error_msg() {
 	msg="${1}"
-	echo -e >&2 "${red}==> "$(eval_gettext "ERROR")":${color_off}${bold} ${msg}${color_off}"
+	echo -e >&2 "${red}==> $(eval_gettext "ERROR"):${color_off}${bold} ${msg}${color_off}"
 }
 
 # Definition of the continue_msg function: Display the continue message


### PR DESCRIPTION
### Description

The "WARNING" and "ERROR" words (used when printing a warning or an error messages to users) were missing from the translations files and were thus printed as such whatever language is used.

### Screenshots / Logs

Before the fix:
![image](https://github.com/Antiz96/arch-update/assets/53110319/c9b6557c-e2f8-412f-ae36-792b275f1a1c)

After the fix:
![image](https://github.com/Antiz96/arch-update/assets/53110319/26e57953-6692-4605-9457-a960b65bb74c)

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/182