### PR TITLE
feat: Add the `--tray --enable` option to automatically set the systray applet in autostart apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ install:
 	install -Dm 664 "src/icons/${pkgname}.svg" "${DESTDIR}${PREFIX}/share/icons/hicolor/scalable/apps/${pkgname}.svg"
 	install -Dm 664 "src/icons/${pkgname}_updates-available.svg" "${DESTDIR}${PREFIX}/share/icons/hicolor/scalable/apps/${pkgname}_updates-available.svg"
 
-	# Install the .desktop file
+	# Install .desktop files
 	install -Dm 644 "res/desktop/${pkgname}.desktop" "${DESTDIR}${PREFIX}/share/applications/${pkgname}.desktop"
+	install -Dm 644 "res/desktop/${pkgname}-tray.desktop" "${DESTDIR}${PREFIX}/share/applications/${pkgname}-tray.desktop"
 
 	# Install systemd units
 	install -Dm 644 "res/systemd/${pkgname}.service" "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.service"
@@ -63,8 +64,9 @@ uninstall:
 	rm -rf "${DESTDIR}${PREFIX}/share/icons/hicolor/scalable/apps/${pkgname}.svg"
 	rm -rf "${DESTDIR}${PREFIX}/share/icons/hicolor/scalable/apps/${pkgname}_updates-available.svg"
 
-	# Delete the .desktop file
+	# Delete .desktop files
 	rm -f "${DESTDIR}${PREFIX}/share/applications/${pkgname}.desktop"
+	rm -f "${DESTDIR}${PREFIX}/share/applications/${pkgname}-tray.desktop"
 
 	# Delete systemd units
 	rm -f "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}.service"

--- a/README-fr.md
+++ b/README-fr.md
@@ -79,11 +79,14 @@ L'utilisation consiste à démarrer [l'applet systray](#lapplet-systray) et à a
 
 ### L'applet systray
 
-Pour démarrer l'applet systray automatiquement au démarrage du système, ajoutez la commande `arch-update --tray` a vos commandes 'auto-start'/configuration de votre WM ou démarrez/activez le service systemd associé comme ceci :
+Pour démarrer l'applet systray, lancez l'application "Arch-Update Systray Applet" depuis votre menu d'application.  
+Pour la démarrer automatiquement au démarrage du système, vous pouvez soit lancer la commande `arch-update --tray --enable` c'est la méthode privilégiée pour certains environnement de bureau spécifiques, comme XFCE par exemple) ou vous pouvez démarrer/activer le service systemd associé comme ceci :
 
 ```bash
 systemctl --user enable --now arch-update-tray.service
 ```
+
+*Si vous utilisez un gestionnaire de fenêtre/compositeur Wayland, vous pouvez plutôt ajouter la commande `arch-update --tray` à vôtre fichier de configuration.*
 
 L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance `arch-update` via le fichier [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
 
@@ -161,7 +164,7 @@ Options :
 -D, --debug       Afficher les traces de débogage
 --gen-config      Générer un fichier de configuration par défaut/exemple (voir la page de manuel arch-update.conf(5) pour plus de détails)
 --show-config     Afficher le fichier de configuration `arch-update.conf` actuellement utilisé (s'il existe)
---tray            Lancer l'applet systray d'Arch-Update
+--tray            Lancer l'applet systray d'Arch-Update, vous pouvez optionnellement ajouter l'argument `--enable` pour la démarrer automatiquement au démarrage du système.
 -h, --help        Afficher ce message d'aide et quitter
 -V, --version     Afficher les informations de version et quitter
 
@@ -176,6 +179,7 @@ Codes de sortie :
 7  Aucune mise à jour en attente durant l'utilisation de l'option `-l/--list`
 8  Erreur lors de la génération d'un fichier de configuration avec l'option `--gen-config`
 9  Erreur lors de la lecture du fichier de configuration avec l'option `--show-config`
+10  Erreur lors de la creation du fichier desktop autostart pour l'applet systray avec l'option `--tray --enable`
 ```
 
 Pour plus d'informations, consultez la page de manuel arch-update(1).  

--- a/README-fr.md
+++ b/README-fr.md
@@ -80,7 +80,7 @@ L'utilisation consiste à démarrer [l'applet systray](#lapplet-systray) et à a
 ### L'applet systray
 
 Pour démarrer l'applet systray, lancez l'application "Arch-Update Systray Applet" depuis votre menu d'application.  
-Pour la démarrer automatiquement au démarrage du système, vous pouvez soit lancer la commande `arch-update --tray --enable` c'est la méthode privilégiée pour certains environnement de bureau spécifiques, comme XFCE par exemple) ou vous pouvez démarrer/activer le service systemd associé comme ceci :
+Pour la démarrer automatiquement au démarrage du système, vous pouvez soit lancer la commande `arch-update --tray --enable` (c'est la méthode privilégiée pour certains environnements de bureau spécifiques, comme XFCE par exemple) ou vous pouvez démarrer/activer le service systemd associé comme ceci :
 
 ```bash
 systemctl --user enable --now arch-update-tray.service

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The usage consist of starting [the systray applet](#the-systray-applet) and enab
 ### The systray applet
 
 To start the systray applet, launch the "Arch-Update Systray Applet" application from your app menu.  
-To start it automatically at boot, either run the `arch-update --tray --enable` command (preferred method on some specific desktop environment, like XFCE for instance) or start/enable the associated systemd service like so:
+To start it automatically at boot, either run the `arch-update --tray --enable` command (this is the preferred method on some specific desktop environments, like XFCE for instance) or start/enable the associated systemd service like so:
 
 ```bash
 systemctl --user enable --now arch-update-tray.service

--- a/README.md
+++ b/README.md
@@ -79,11 +79,14 @@ The usage consist of starting [the systray applet](#the-systray-applet) and enab
 
 ### The systray applet
 
-To start the systray applet automatically at boot, add the `arch-update --tray` command to your auto-start commands/WM config or start/enable the associated systemd service like so:
+To start the systray applet, launch the "Arch-Update Systray Applet" application from your app menu.  
+To start it automatically at boot, either run the `arch-update --tray --enable` command (preferred method on some specific desktop environment, like XFCE for instance) or start/enable the associated systemd service like so:
 
 ```bash
 systemctl --user enable --now arch-update-tray.service
 ```
+
+*If you use a window manager/Wayland compositor, you can add the `arch-update --tray` command to your configuration file instead.*
 
 The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches `arch-update` via the [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop) file.
 
@@ -161,7 +164,7 @@ Options:
 -D, --debug       Display debug traces
 --gen-config      Generate a default/example configuration file (see the arch-update.conf(5) man page for more details)
 --show-config     Display the `arch-update.conf` configuration file currently used (if it exists)
---tray            Launch the Arch-Update systray applet
+--tray            Launch the Arch-Update systray applet, you can optionally add the `--enable` argument to start it automatically at boot.
 -h, --help        Display this help message and exit
 -V, --version     Display version information and exit
 
@@ -176,6 +179,7 @@ Exit Codes:
 7  No pending update when using the `-l/--list` option
 8  Error when generating a configuration file with the `--gen-config` option
 9  Error when reading the configuration file with the `--show-config` option
+10 Error when creating the autostart desktop file for the systray applet with the `--tray --enable` option
 ```
 
 For more information, see the arch-update(1) man page.  

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "June 2024" "Arch-Update 2.1.0" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "July 2024" "Arch-Update 2.1.0" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
@@ -66,7 +66,9 @@ Display debug traces.
 
 .TP
 .B \-\-tray
-.RB "Launch the Arch-Update systray applet (you can alternatively start/enable the associated systemd service like so: " "systemctl \-\-user enable \-\-now arch-update-tray.service").
+Start the Arch-Update systray applet.
+.RB "To start it automatically at boot, you can either run the " "arch-update --tray --enable " "command (this is the preferred method on some specific desktop environment, like XFCE for instance) or start/enable the associated systemd service like so: " "systemctl \-\-user enable \-\-now arch-update-tray.service").
+.RB "If you use a window manager/Wayland compositor, you can add the " "arch-update --tray " "command to your configuration file instead."
 
 .TP
 .B \-v, \-\-version
@@ -218,6 +220,10 @@ Error when calling the reboot command to apply a pending kernel update
 .TP
 .B 9
 .RB "Error when reading the configuration file with the " "--show-config " "option"
+
+.TP
+.B 10
+.RB "Error when creating the autostart desktop file for the systray applet with the " "--tray --enable " "option"
 
 .SH SEE ALSO
 .BR checkupdates (8),

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -67,7 +67,9 @@ Display debug traces.
 .TP
 .B \-\-tray
 Start the Arch-Update systray applet.
-.RB "To start it automatically at boot, you can either run the " "arch-update --tray --enable " "command (this is the preferred method on some specific desktop environment, like XFCE for instance) or start/enable the associated systemd service like so: " "systemctl \-\-user enable \-\-now arch-update-tray.service").
+.br
+.RB "To start it automatically at boot, you can either run the " "arch-update --tray --enable " "command (this is the preferred method on some specific desktop environments, like XFCE for instance) or start/enable the associated systemd service like so: " "systemctl \-\-user enable \-\-now arch-update-tray.service".
+.br
 .RB "If you use a window manager/Wayland compositor, you can add the " "arch-update --tray " "command to your configuration file instead."
 
 .TP

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -67,7 +67,9 @@ Afficher les traces de débogage.
 .TP
 .B \-\-tray
 Démarrer l'applet systray d'Arch-Update.
-.RB "Pour la démarrer automatiquement au démarrage du système, vous pouvez soit exécuter la commande " "arch-update --tray --enable " "(c'est la méthode privilégiée pour certains environnement de bureau spécifiques, comme XFCE par exemple) ou vous pouvez démarrer/activer le service systemd associé comme ceci : " "systemctl \-\-user enable \-\-now arch-update-tray.service").
+.br
+.RB "Pour la démarrer automatiquement au démarrage du système, vous pouvez soit exécuter la commande " "arch-update --tray --enable " "(c'est la méthode privilégiée pour certains environnements de bureau spécifiques, comme XFCE par exemple) ou vous pouvez démarrer/activer le service systemd associé comme ceci : " "systemctl \-\-user enable \-\-now arch-update-tray.service".
+.br
 .RB "Si vous utilisez un gestionnaire de fenêtres/un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update --tray " "à votre fichier de configuration."
 
 .TP

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "Juin 2024" "Arch-Update 2.1.0" "Manuel de Arch-Update"
+.TH "ARCH-UPDATE" "1" "Juillet 2024" "Arch-Update 2.1.0" "Manuel de Arch-Update"
 
 .SH NAME
 arch-update \- Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour.
@@ -66,7 +66,9 @@ Afficher les traces de débogage.
 
 .TP
 .B \-\-tray
-.RB "Lancer l'applet systray d'Arch-Update (alternativement, vous pouvez démarrer/activer le service systemd associé comme ceci : " "systemctl \-\-user enable \-\-now arch-update-tray.service").
+Démarrer l'applet systray d'Arch-Update.
+.RB "Pour la démarrer automatiquement au démarrage du système, vous pouvez soit exécuter la commande " "arch-update --tray --enable " "(c'est la méthode privilégiée pour certains environnement de bureau spécifiques, comme XFCE par exemple) ou vous pouvez démarrer/activer le service systemd associé comme ceci : " "systemctl \-\-user enable \-\-now arch-update-tray.service").
+.RB "Si vous utilisez un gestionnaire de fenêtres/un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update --tray " "à votre fichier de configuration."
 
 .TP
 .B \-v, \-\-version
@@ -218,6 +220,10 @@ Erreur lors de l'appel de la commande reboot pour appliquer une mise à jour du 
 .TP
 .B 9
 .RB "Erreur lors de la lecture du fichier de configuration avec l'option " "--show-config"
+
+.TP
+.B 10
+.RB "Erreur lors de la création du fichier desktop autostart pour l'applet systray avec l'option " "--tray --enable"
 
 .SH VOIR AUSSI
 .BR checkupdates (8),

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -123,7 +123,9 @@ msgstr ""
 
 #: src/script/arch-update.sh:192
 #, sh-format
-msgid "  --tray            Launch the Arch-Update systray applet"
+msgid ""
+"  --tray            Launch the Arch-Update systray applet, you can "
+"optionally add the '--enable' argument to start it automatically at boot"
 msgstr ""
 
 #: src/script/arch-update.sh:193
@@ -483,6 +485,25 @@ msgstr ""
 #: src/script/arch-update.sh:724
 #, sh-format
 msgid "No configuration file found"
+msgstr ""
+
+#: src/script/arch-update.sh:743
+#, sh-format
+msgid "Arch-Update tray desktop file not found"
+msgstr ""
+
+#: src/script/arch-update.sh:750
+#, sh-format
+msgid "The '${tray_desktop_file_autostart}' file already exists"
+msgstr ""
+
+#: src/script/arch-update.sh:755
+#, sh-format
+msgid ""
+"The '${tray_desktop_file_autostart}' file has been created, the Arch-Update "
+"systray applet will be automatically started at your next log on\\nTo start "
+"it right now, you can launch the \"Arch-Update Systray Applet\" application "
+"from your app menu"
 msgstr ""
 
 #: src/script/arch-update-tray.py:118

--- a/po/fr.po
+++ b/po/fr.po
@@ -138,8 +138,12 @@ msgstr "  --gen-config      Générer un fichier de configuration par défaut/ex
 
 #: src/script/arch-update.sh:192
 #, sh-format
-msgid "  --tray            Launch the Arch-Update systray applet"
-msgstr "  --tray            Lancer l'applet systray d'Arch-Update"
+msgid ""
+"  --tray            Launch the Arch-Update systray applet, you can "
+"optionally add the '--enable' argument to start it automatically at boot"
+msgstr ""
+"  --tray            Lancer l'applet systray d'Arch-Update, vous pouvez "
+"optionnellement ajouter l'argument '--enable' pour la démarrer automatiquement au démarrage du système"
 
 #: src/script/arch-update.sh:193
 #, sh-format
@@ -520,6 +524,29 @@ msgstr "Le fichier de configuration '${config_file}' a été généré"
 #, sh-format
 msgid "No configuration file found"
 msgstr "Aucun fichier de configuration n'a été trouvé"
+
+#: src/script/arch-update.sh:743
+#, sh-format
+msgid "Arch-Update tray desktop file not found"
+msgstr "Le fichier Arch-Update tray desktop n'a pas été trouvé"
+
+#: src/script/arch-update.sh:750
+#, sh-format
+msgid "The '${tray_desktop_file_autostart}' file already exists"
+msgstr "Le fichier '${tray_desktop_file_autostart}' existe déjà"
+
+#: src/script/arch-update.sh:755
+#, sh-format
+msgid ""
+"The '${tray_desktop_file_autostart}' file has been created, the Arch-Update "
+"systray applet will be automatically started at your next log on\\nTo start "
+"it right now, you can launch the \"Arch-Update Systray Applet\" application "
+"from your app menu"
+msgstr ""
+"Le fichier '${tray_desktop_file_autostart}' a été créé, l'applet systray d'Arch-Update "
+"sera automatiquement démarré à votre prochain connexion\\nPour la démarrer "
+"immédiatement, vous pouvez lancer l'application \"Arch-Update Systray Applet\" "
+"depuis votre menu d'application"
 
 #: src/script/arch-update-tray.py:118
 msgid "Run Arch-Update"

--- a/po/fr.po
+++ b/po/fr.po
@@ -544,7 +544,7 @@ msgid ""
 "from your app menu"
 msgstr ""
 "Le fichier '${tray_desktop_file_autostart}' a été créé, l'applet systray d'Arch-Update "
-"sera automatiquement démarré à votre prochain connexion\\nPour la démarrer "
+"sera automatiquement démarré à votre prochaine connexion\\nPour la démarrer "
 "immédiatement, vous pouvez lancer l'application \"Arch-Update Systray Applet\" "
 "depuis votre menu d'application"
 

--- a/res/desktop/arch-update-tray.desktop
+++ b/res/desktop/arch-update-tray.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Arch-Update Systray Applet
+Icon=arch-update_updates-available
+Exec=arch-update --tray
+Categories=Utility


### PR DESCRIPTION
<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

Add the optional `--enable` argument to the `--tray` option to automatically set the systray applet in the autostart apps by copying the "arch-update-tray.desktop" file to `${XDG_CONFIG_HOME:-${HOME}/.config}/autostart/arch-update-tray.desktop`.

### Addressed feature request

<!-- If this pull request is addressing an opened feature request, paste the corresponding issue URL below -->

Closes https://github.com/Antiz96/arch-update/issues/180
