### PR TITLE
fix(systray): Prevent multiple instances of the systray applet to be able to run at the same time

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -506,6 +506,11 @@ msgid ""
 "from your app menu"
 msgstr ""
 
+#: src/script/arch-update.sh:763
+#, sh-format
+msgid "There's already a running instance of the Arch-Update systray applet"
+msgstr ""
+
 #: src/script/arch-update-tray.py:118
 msgid "Run Arch-Update"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -548,6 +548,11 @@ msgstr ""
 "immédiatement, vous pouvez lancer l'application \"Arch-Update Systray Applet\" "
 "depuis votre menu d'application"
 
+#: src/script/arch-update.sh:763
+#, sh-format
+msgid "There's already a running instance of the Arch-Update systray applet"
+msgstr "Il y a déjà une instance de l'applet systray d'Arch-Update en cours d'exécution"
+
 #: src/script/arch-update-tray.py:118
 msgid "Run Arch-Update"
 msgstr "Lancer Arch-Update"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -759,7 +759,7 @@ case "${option}" in
 				state_up_to_date
 			fi
 
-			if ps -ef | grep "[a]rch-update-tray"; then
+			if pgrep -f arch-update-tray > /dev/null; then
 				error_msg "$(eval_gettext "There's already a running instance of the Arch-Update systray applet")"
 				exit 3
 			fi

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -759,6 +759,11 @@ case "${option}" in
 				state_up_to_date
 			fi
 
+			if ps -ef | grep "[a]rch-update-tray"; then
+				error_msg "$(eval_gettext "There's already a running instance of the Arch-Update systray applet")"
+				exit 3
+			fi
+
 			arch-update-tray || exit 3
 		fi
 	;;


### PR DESCRIPTION
### Description

Add a test to check if there's already a running instance of the systray applet before starting it to avoid the possibility to have multiple instances running at the same time.

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/196
