### PR TITLE
feat: Allow to read multiple news at once

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -132,7 +132,7 @@ Quand l'applet systray est cliquée, elle affiche la liste des paquets disponibl
 Par défaut, si au moins une news Arch Linux a été publiée depuis la dernière exécution, `Arch-Update` vous proposera de lire les dernières news Arch Linux directement depuis votre fenêtre de terminal.  
 Les news publiées depuis la dernière exécution sont tagguées comme `[NOUVEAU]` :
 
-![listing_news-FR]((https://github.com/Antiz96/arch-update/assets/53110319/ec4032f3-835e-418c-b19a-b7bd089d6bd9)
+![listing_news-FR](https://github.com/Antiz96/arch-update/assets/53110319/ec4032f3-835e-418c-b19a-b7bd089d6bd9)
 
 Quand la liste des news récentes est affichée, vous pouvez sélectionner les news à lire (par exemple: 1 3 5), sélectionner 0 pour toutes les lire ou appuyer sur "entrée" pour procéder à la mise à jour.  
 Si aucune news n'a été publiée depuis la dernière exécution, `Arch-Update` procédera directement à la mise à jour après que vous ayez donné votre confirmation.

--- a/README-fr.md
+++ b/README-fr.md
@@ -134,7 +134,7 @@ Les news publiées depuis la dernière exécution sont tagguées comme `[NOUVEAU
 
 ![listing_news-FR](https://github.com/Antiz96/arch-update/assets/53110319/72819197-d4f7-4c50-af21-0aac1c60ba41)
 
-Quand la liste des news récentes est affichée, vous pouvez soit taper le nombre associé à une news pour la lire (vous serez invité à nouveau à lire d'autres news par la suite, ce qui vous permettra de lire plusieurs news en une seule exécution), ou simplement appuyez sur "entrée" pour procéder à la mise à jour.  
+Quand la liste des news récentes est affichée, vous pouvez sélectionner les news à lire (par exemple: 1 3 5), sélectionner 0 pour toutes les lire ou appuyer sur "entrée" pour procéder à la mise à jour.  
 Si aucune news n'a été publiée depuis la dernière exécution, `Arch-Update` procédera directement à la mise à jour après que vous ayez donné votre confirmation.
 
 Dans les deux cas, à partir de là, vous avez simplement à laisser `Arch-Update` vous guider à travers les différentes étapes requises pour une mise à jour complète et appropriée de votre système ! :smile:

--- a/README-fr.md
+++ b/README-fr.md
@@ -132,7 +132,7 @@ Quand l'applet systray est cliquée, elle affiche la liste des paquets disponibl
 Par défaut, si au moins une news Arch Linux a été publiée depuis la dernière exécution, `Arch-Update` vous proposera de lire les dernières news Arch Linux directement depuis votre fenêtre de terminal.  
 Les news publiées depuis la dernière exécution sont tagguées comme `[NOUVEAU]` :
 
-![listing_news-FR](https://github.com/Antiz96/arch-update/assets/53110319/72819197-d4f7-4c50-af21-0aac1c60ba41)
+![listing_news-FR]((https://github.com/Antiz96/arch-update/assets/53110319/ec4032f3-835e-418c-b19a-b7bd089d6bd9)
 
 Quand la liste des news récentes est affichée, vous pouvez sélectionner les news à lire (par exemple: 1 3 5), sélectionner 0 pour toutes les lire ou appuyer sur "entrée" pour procéder à la mise à jour.  
 Si aucune news n'a été publiée depuis la dernière exécution, `Arch-Update` procédera directement à la mise à jour après que vous ayez donné votre confirmation.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The news published since the last run are tagged as `[NEW]`:
 
 ![listing_news](https://github.com/Antiz96/arch-update/assets/53110319/4f6f1c84-e5d6-4072-aa57-0c3e80783c01)
 
-When recent news gets listed, either type the number associated to a news to read it (you'll be re-prompted to read other news afterwards so you can read multiple news in one run), or simply press "enter" to proceed with the update.  
+When recent news gets listed, you can select the news to read (e.g. 1 3 5), select 0 to read them all or press "enter" to proceed with update.  
 If no news has been published since the last run, `Arch-Update` will directly proceed to the update after you gave your confirmation.
 
 In both cases, from there, you just have to let `Arch-Update` guide you through the various steps required for a complete and proper update of your system! :smile:

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ When the systray applet is clicked, it prints the list of packages available for
 By default, if at least one Arch Linux news has been published since the last run, `Arch-Update` will offer you to read the latest Arch Linux news directly from your terminal window.  
 The news published since the last run are tagged as `[NEW]`:
 
-![listing_news]((https://github.com/Antiz96/arch-update/assets/53110319/ec4032f3-835e-418c-b19a-b7bd089d6bd9)
+![listing_news](https://github.com/Antiz96/arch-update/assets/53110319/ec4032f3-835e-418c-b19a-b7bd089d6bd9)
 
 When recent news gets listed, you can select the news to read (e.g. 1 3 5), select 0 to read them all or press "enter" to proceed with update.  
 If no news has been published since the last run, `Arch-Update` will directly proceed to the update after you gave your confirmation.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ When the systray applet is clicked, it prints the list of packages available for
 By default, if at least one Arch Linux news has been published since the last run, `Arch-Update` will offer you to read the latest Arch Linux news directly from your terminal window.  
 The news published since the last run are tagged as `[NEW]`:
 
-![listing_news](https://github.com/Antiz96/arch-update/assets/53110319/4f6f1c84-e5d6-4072-aa57-0c3e80783c01)
+![listing_news]((https://github.com/Antiz96/arch-update/assets/53110319/ec4032f3-835e-418c-b19a-b7bd089d6bd9)
 
 When recent news gets listed, you can select the news to read (e.g. 1 3 5), select 0 to read them all or press "enter" to proceed with update.  
 If no news has been published since the last run, `Arch-Update` will directly proceed to the update after you gave your confirmation.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The news published since the last run are tagged as `[NEW]`:
 
 ![listing_news](https://github.com/Antiz96/arch-update/assets/53110319/ec4032f3-835e-418c-b19a-b7bd089d6bd9)
 
-When recent news gets listed, you can select the news to read (e.g. 1 3 5), select 0 to read them all or press "enter" to proceed with update.  
+When recent news get listed, you can select the news to read (e.g. 1 3 5), select 0 to read them all or press "enter" to proceed with update.  
 If no news has been published since the last run, `Arch-Update` will directly proceed to the update after you gave your confirmation.
 
 In both cases, from there, you just have to let `Arch-Update` guide you through the various steps required for a complete and proper update of your system! :smile:

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,64 +16,64 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:120
+#: src/script/arch-update.sh:126
 #, sh-format
 msgid "WARNING"
 msgstr ""
 
-#: src/script/arch-update.sh:126
+#: src/script/arch-update.sh:132
 #, sh-format
 msgid "ERROR"
 msgstr ""
 
-#: src/script/arch-update.sh:131
+#: src/script/arch-update.sh:137
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/script/arch-update.sh:137
+#: src/script/arch-update.sh:143
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/script/arch-update.sh:150
+#: src/script/arch-update.sh:156
 #, sh-format
 msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:155
+#: src/script/arch-update.sh:161
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the arch-update.conf "
 "configuration file is not found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:178
+#: src/script/arch-update.sh:184
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
 "pre/post update tasks."
 msgstr ""
 
-#: src/script/arch-update.sh:180
+#: src/script/arch-update.sh:186
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr ""
 
-#: src/script/arch-update.sh:181
+#: src/script/arch-update.sh:187
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
 msgstr ""
 
-#: src/script/arch-update.sh:182
+#: src/script/arch-update.sh:188
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 
-#: src/script/arch-update.sh:183
+#: src/script/arch-update.sh:189
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -81,12 +81,12 @@ msgid ""
 "them."
 msgstr ""
 
-#: src/script/arch-update.sh:185
+#: src/script/arch-update.sh:191
 #, sh-format
 msgid "Options:"
 msgstr ""
 
-#: src/script/arch-update.sh:186
+#: src/script/arch-update.sh:192
 #, sh-format
 msgid ""
 "  -c, --check       Check for available updates, change the systray icon and "
@@ -94,410 +94,413 @@ msgid ""
 "there are new available updates compared to the last check)"
 msgstr ""
 
-#: src/script/arch-update.sh:187
+#: src/script/arch-update.sh:193
 #, sh-format
 msgid "  -l, --list        Display the list of pending updates"
 msgstr ""
 
-#: src/script/arch-update.sh:188
+#: src/script/arch-update.sh:194
 #, sh-format
 msgid "  -d, --devel       Include AUR development packages updates"
 msgstr ""
 
-#: src/script/arch-update.sh:189
+#: src/script/arch-update.sh:195
 #, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
 "number of Arch news to display with '--news [Num]' (e.g. '--news 10')"
 msgstr ""
 
-#: src/script/arch-update.sh:190
+#: src/script/arch-update.sh:196
 #, sh-format
 msgid "  -D, --debug       Display debug traces"
 msgstr ""
 
-#: src/script/arch-update.sh:191
+#: src/script/arch-update.sh:197
 #, sh-format
 msgid "  --gen-config      Generate a default/example configuration file"
 msgstr ""
 
-#: src/script/arch-update.sh:192
+#: src/script/arch-update.sh:198
 #, sh-format
 msgid ""
 "  --tray            Launch the Arch-Update systray applet, you can "
 "optionally add the '--enable' argument to start it automatically at boot"
 msgstr ""
 
-#: src/script/arch-update.sh:193
+#: src/script/arch-update.sh:199
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:194
+#: src/script/arch-update.sh:200
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr ""
 
-#: src/script/arch-update.sh:196
+#: src/script/arch-update.sh:202
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:197
+#: src/script/arch-update.sh:203
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
 
-#: src/script/arch-update.sh:208
+#: src/script/arch-update.sh:214
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information."
 msgstr ""
 
-#: src/script/arch-update.sh:248 src/script/arch-update.sh:250
+#: src/script/arch-update.sh:254 src/script/arch-update.sh:256
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/script/arch-update.sh:255 src/script/arch-update.sh:257
+#: src/script/arch-update.sh:261 src/script/arch-update.sh:263
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/script/arch-update.sh:273
+#: src/script/arch-update.sh:279
 #, sh-format
 msgid "Looking for updates...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:294
+#: src/script/arch-update.sh:300
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:299
+#: src/script/arch-update.sh:305
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:304
+#: src/script/arch-update.sh:310
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:311
+#: src/script/arch-update.sh:317
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:318
+#: src/script/arch-update.sh:324
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:321 src/script/arch-update.sh:458
-#: src/script/arch-update.sh:491 src/script/arch-update.sh:533
-#: src/script/arch-update.sh:600 src/script/arch-update.sh:626
+#: src/script/arch-update.sh:327 src/script/arch-update.sh:475
+#: src/script/arch-update.sh:508 src/script/arch-update.sh:550
+#: src/script/arch-update.sh:617 src/script/arch-update.sh:643
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/script/arch-update.sh:321 src/script/arch-update.sh:458
-#: src/script/arch-update.sh:491 src/script/arch-update.sh:533
-#: src/script/arch-update.sh:600 src/script/arch-update.sh:626
+#: src/script/arch-update.sh:327 src/script/arch-update.sh:475
+#: src/script/arch-update.sh:508 src/script/arch-update.sh:550
+#: src/script/arch-update.sh:617 src/script/arch-update.sh:643
 #, sh-format
 msgid "y"
 msgstr ""
 
-#: src/script/arch-update.sh:325
+#: src/script/arch-update.sh:331
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:356
+#: src/script/arch-update.sh:359
 #, sh-format
 msgid "Arch News:"
 msgstr ""
 
-#: src/script/arch-update.sh:361
+#: src/script/arch-update.sh:364
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:372
-#, sh-format
-msgid "Select the news to read (or just press \"enter\" to quit):"
-msgstr ""
-
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:375
 #, sh-format
 msgid ""
-"Select the news to read (or just press \"enter\" to proceed with update):"
+"Select the news to read (e.g. 1 3 5), select 0 to read them all or press "
+"\"enter\" to quit:"
 msgstr ""
 
-#: src/script/arch-update.sh:385
+#: src/script/arch-update.sh:377
+#, sh-format
+msgid ""
+"Select the news to read (e.g. 1 3 5), select 0 to read them all or press "
+"\"enter\" to proceed with update:"
+msgstr ""
+
+#: src/script/arch-update.sh:399
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:386
+#: src/script/arch-update.sh:400
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:387
+#: src/script/arch-update.sh:401
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:388
+#: src/script/arch-update.sh:402
 #, sh-format
 msgid "URL:"
 msgstr ""
 
-#: src/script/arch-update.sh:401
+#: src/script/arch-update.sh:418
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:406 src/script/arch-update.sh:418
-#: src/script/arch-update.sh:429
+#: src/script/arch-update.sh:423 src/script/arch-update.sh:435
+#: src/script/arch-update.sh:446
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:413
+#: src/script/arch-update.sh:430
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:425
+#: src/script/arch-update.sh:442
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:436
+#: src/script/arch-update.sh:453
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:448
+#: src/script/arch-update.sh:465
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:452
+#: src/script/arch-update.sh:469
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:454
+#: src/script/arch-update.sh:471
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:460
+#: src/script/arch-update.sh:477
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:464 src/script/arch-update.sh:497
-#: src/script/arch-update.sh:540 src/script/arch-update.sh:550
-#: src/script/arch-update.sh:560 src/script/arch-update.sh:569
+#: src/script/arch-update.sh:481 src/script/arch-update.sh:514
+#: src/script/arch-update.sh:557 src/script/arch-update.sh:567
+#: src/script/arch-update.sh:577 src/script/arch-update.sh:586
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:467 src/script/arch-update.sh:500
+#: src/script/arch-update.sh:484 src/script/arch-update.sh:517
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:472 src/script/arch-update.sh:504
-#: src/script/arch-update.sh:577
+#: src/script/arch-update.sh:489 src/script/arch-update.sh:521
+#: src/script/arch-update.sh:594
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:476
+#: src/script/arch-update.sh:493
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:481
+#: src/script/arch-update.sh:498
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:485
+#: src/script/arch-update.sh:502
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:487
+#: src/script/arch-update.sh:504
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:493
+#: src/script/arch-update.sh:510
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:508
+#: src/script/arch-update.sh:525
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:525
+#: src/script/arch-update.sh:542
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:526
+#: src/script/arch-update.sh:543
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:528
+#: src/script/arch-update.sh:545
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:529
+#: src/script/arch-update.sh:546
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:536 src/script/arch-update.sh:556
+#: src/script/arch-update.sh:553 src/script/arch-update.sh:573
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:546 src/script/arch-update.sh:565
+#: src/script/arch-update.sh:563 src/script/arch-update.sh:582
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:581
+#: src/script/arch-update.sh:598
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:590
+#: src/script/arch-update.sh:607
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:594
+#: src/script/arch-update.sh:611
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:596
+#: src/script/arch-update.sh:613
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:602
+#: src/script/arch-update.sh:619
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:606
+#: src/script/arch-update.sh:623
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:609
+#: src/script/arch-update.sh:626
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:613
+#: src/script/arch-update.sh:630
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:622
+#: src/script/arch-update.sh:639
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:623
+#: src/script/arch-update.sh:640
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:636
+#: src/script/arch-update.sh:653
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
 msgstr ""
 
-#: src/script/arch-update.sh:642
+#: src/script/arch-update.sh:659
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:650
+#: src/script/arch-update.sh:667
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:654
+#: src/script/arch-update.sh:671
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:709
+#: src/script/arch-update.sh:726
 #, sh-format
 msgid "Example configuration file not found"
 msgstr ""
 
-#: src/script/arch-update.sh:714
+#: src/script/arch-update.sh:731
 #, sh-format
 msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
 "before generating a new one"
 msgstr ""
 
-#: src/script/arch-update.sh:719
+#: src/script/arch-update.sh:736
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
 msgstr ""
 
-#: src/script/arch-update.sh:724
+#: src/script/arch-update.sh:741
 #, sh-format
 msgid "No configuration file found"
 msgstr ""
 
-#: src/script/arch-update.sh:743
+#: src/script/arch-update.sh:760
 #, sh-format
 msgid "Arch-Update tray desktop file not found"
 msgstr ""
 
-#: src/script/arch-update.sh:750
+#: src/script/arch-update.sh:767
 #, sh-format
 msgid "The '${tray_desktop_file_autostart}' file already exists"
 msgstr ""
 
-#: src/script/arch-update.sh:755
+#: src/script/arch-update.sh:772
 #, sh-format
 msgid ""
 "The '${tray_desktop_file_autostart}' file has been created, the Arch-Update "
@@ -506,7 +509,7 @@ msgid ""
 "from your app menu"
 msgstr ""
 
-#: src/script/arch-update.sh:763
+#: src/script/arch-update.sh:780
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr ""

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -197,16 +197,16 @@ msgstr ""
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:327 src/script/arch-update.sh:475
-#: src/script/arch-update.sh:508 src/script/arch-update.sh:550
-#: src/script/arch-update.sh:617 src/script/arch-update.sh:643
+#: src/script/arch-update.sh:327 src/script/arch-update.sh:476
+#: src/script/arch-update.sh:509 src/script/arch-update.sh:551
+#: src/script/arch-update.sh:618 src/script/arch-update.sh:644
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/script/arch-update.sh:327 src/script/arch-update.sh:475
-#: src/script/arch-update.sh:508 src/script/arch-update.sh:550
-#: src/script/arch-update.sh:617 src/script/arch-update.sh:643
+#: src/script/arch-update.sh:327 src/script/arch-update.sh:476
+#: src/script/arch-update.sh:509 src/script/arch-update.sh:551
+#: src/script/arch-update.sh:618 src/script/arch-update.sh:644
 #, sh-format
 msgid "y"
 msgstr ""
@@ -260,247 +260,247 @@ msgstr ""
 msgid "URL:"
 msgstr ""
 
-#: src/script/arch-update.sh:418
+#: src/script/arch-update.sh:419
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:423 src/script/arch-update.sh:435
-#: src/script/arch-update.sh:446
+#: src/script/arch-update.sh:424 src/script/arch-update.sh:436
+#: src/script/arch-update.sh:447
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:430
+#: src/script/arch-update.sh:431
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:442
+#: src/script/arch-update.sh:443
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:453
+#: src/script/arch-update.sh:454
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:465
+#: src/script/arch-update.sh:466
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:469
+#: src/script/arch-update.sh:470
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:471
+#: src/script/arch-update.sh:472
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:477
+#: src/script/arch-update.sh:478
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:481 src/script/arch-update.sh:514
-#: src/script/arch-update.sh:557 src/script/arch-update.sh:567
-#: src/script/arch-update.sh:577 src/script/arch-update.sh:586
+#: src/script/arch-update.sh:482 src/script/arch-update.sh:515
+#: src/script/arch-update.sh:558 src/script/arch-update.sh:568
+#: src/script/arch-update.sh:578 src/script/arch-update.sh:587
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:484 src/script/arch-update.sh:517
+#: src/script/arch-update.sh:485 src/script/arch-update.sh:518
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:489 src/script/arch-update.sh:521
-#: src/script/arch-update.sh:594
+#: src/script/arch-update.sh:490 src/script/arch-update.sh:522
+#: src/script/arch-update.sh:595
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:493
+#: src/script/arch-update.sh:494
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:498
+#: src/script/arch-update.sh:499
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:502
+#: src/script/arch-update.sh:503
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:504
+#: src/script/arch-update.sh:505
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:510
+#: src/script/arch-update.sh:511
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:525
+#: src/script/arch-update.sh:526
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:542
+#: src/script/arch-update.sh:543
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:543
+#: src/script/arch-update.sh:544
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:545
+#: src/script/arch-update.sh:546
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:546
+#: src/script/arch-update.sh:547
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:553 src/script/arch-update.sh:573
+#: src/script/arch-update.sh:554 src/script/arch-update.sh:574
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:563 src/script/arch-update.sh:582
+#: src/script/arch-update.sh:564 src/script/arch-update.sh:583
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:598
+#: src/script/arch-update.sh:599
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:607
+#: src/script/arch-update.sh:608
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:611
+#: src/script/arch-update.sh:612
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:613
+#: src/script/arch-update.sh:614
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:619
+#: src/script/arch-update.sh:620
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:623
+#: src/script/arch-update.sh:624
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:626
+#: src/script/arch-update.sh:627
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:630
+#: src/script/arch-update.sh:631
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:639
+#: src/script/arch-update.sh:640
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:640
+#: src/script/arch-update.sh:641
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:653
+#: src/script/arch-update.sh:654
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
 msgstr ""
 
-#: src/script/arch-update.sh:659
+#: src/script/arch-update.sh:660
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:667
+#: src/script/arch-update.sh:668
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:671
+#: src/script/arch-update.sh:672
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:726
+#: src/script/arch-update.sh:727
 #, sh-format
 msgid "Example configuration file not found"
 msgstr ""
 
-#: src/script/arch-update.sh:731
+#: src/script/arch-update.sh:732
 #, sh-format
 msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
 "before generating a new one"
 msgstr ""
 
-#: src/script/arch-update.sh:736
+#: src/script/arch-update.sh:737
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
 msgstr ""
 
-#: src/script/arch-update.sh:741
+#: src/script/arch-update.sh:742
 #, sh-format
 msgid "No configuration file found"
 msgstr ""
 
-#: src/script/arch-update.sh:760
+#: src/script/arch-update.sh:761
 #, sh-format
 msgid "Arch-Update tray desktop file not found"
 msgstr ""
 
-#: src/script/arch-update.sh:767
+#: src/script/arch-update.sh:768
 #, sh-format
 msgid "The '${tray_desktop_file_autostart}' file already exists"
 msgstr ""
 
-#: src/script/arch-update.sh:772
+#: src/script/arch-update.sh:773
 #, sh-format
 msgid ""
 "The '${tray_desktop_file_autostart}' file has been created, the Arch-Update "
@@ -509,7 +509,7 @@ msgid ""
 "from your app menu"
 msgstr ""
 
-#: src/script/arch-update.sh:780
+#: src/script/arch-update.sh:781
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -254,7 +254,7 @@ msgid ""
 "\"enter\" to quit:"
 msgstr ""
 "Sélectionnez les news à lire (par exemple: 1 3 5), sélectionnez 0 pour toutes les lire "
-"ou appuyez sur "entrée" pour quitter"
+"ou appuyez sur \"entrée\" pour quitter"
 
 #: src/script/arch-update.sh:377
 #, sh-format
@@ -263,7 +263,7 @@ msgid ""
 "\"enter\" to proceed with update:"
 msgstr ""
 "Sélectionnez les news à lire (par exemple: 1 3 5), sélectionnez 0 pour toutes les lire "
-"ou appuyez sur "entrée" pour procéder à la mise à jour"
+"ou appuyez sur \"entrée\" pour procéder à la mise à jour"
 
 #: src/script/arch-update.sh:399
 #, sh-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,32 +16,32 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/script/arch-update.sh:120
+#: src/script/arch-update.sh:126
 #, sh-format
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
-#: src/script/arch-update.sh:126
+#: src/script/arch-update.sh:132
 #, sh-format
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: src/script/arch-update.sh:131
+#: src/script/arch-update.sh:137
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/script/arch-update.sh:137
+#: src/script/arch-update.sh:143
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Appuyez sur \"entrée\" pour quitter "
 
-#: src/script/arch-update.sh:150
+#: src/script/arch-update.sh:156
 #, sh-format
 msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
 msgstr "Une commande d'élévation de privilège est requise (sudo, doas ou run0)\\n"
 
-#: src/script/arch-update.sh:155
+#: src/script/arch-update.sh:161
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the arch-update.conf "
@@ -50,7 +50,7 @@ msgstr ""
 "La commande ${su_cmd} définie pour l'élévation de privilège dans le fichier "
 "de configuration arch-update.conf n'est pas disponible\\n"
 
-#: src/script/arch-update.sh:178
+#: src/script/arch-update.sh:184
 #, sh-format
 msgid ""
 "An update notifier/applier for Arch Linux that assists you with important "
@@ -59,12 +59,12 @@ msgstr ""
 "Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les "
 "tâches importantes d'avant/après mise à jour."
 
-#: src/script/arch-update.sh:180
+#: src/script/arch-update.sh:186
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
 msgstr "Lancez ${name} pour exécuter la fonction principale 'update' :"
 
-#: src/script/arch-update.sh:181
+#: src/script/arch-update.sh:187
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
@@ -73,14 +73,14 @@ msgstr ""
 "Afficher la liste des paquets disponibles pour mise à jour, puis demander la confirmation de l'utilisateur "
 "pour procéder à l'installation."
 
-#: src/script/arch-update.sh:182
+#: src/script/arch-update.sh:188
 #, sh-format
 msgid ""
 "Before performing the update, offer to display the latest Arch Linux news."
 msgstr ""
 "Avant d'effectuer la mise à jour, propose d'afficher les dernières news d'Arch Linux."
 
-#: src/script/arch-update.sh:183
+#: src/script/arch-update.sh:189
 #, sh-format
 msgid ""
 "Post update, check for orphan/unused packages, old cached packages, pacnew/"
@@ -91,12 +91,12 @@ msgstr ""
 "pacsave et de mise à jour du noyau en attente et, s'il y en a, "
 "propose de les traiter."
 
-#: src/script/arch-update.sh:185
+#: src/script/arch-update.sh:191
 #, sh-format
 msgid "Options:"
 msgstr "Options :"
 
-#: src/script/arch-update.sh:186
+#: src/script/arch-update.sh:192
 #, sh-format
 msgid ""
 "  -c, --check       Check for available updates, change the systray icon and "
@@ -107,17 +107,17 @@ msgstr ""
 "envoie une notification de bureau contenant le nombre de mises à jour disponibles (s'"
 "il y a des nouvelles mises à jour depuis le dernier check)"
 
-#: src/script/arch-update.sh:187
+#: src/script/arch-update.sh:193
 #, sh-format
 msgid "  -l, --list        Display the list of pending updates"
 msgstr "  -l, --list        Afficher les mises à jours en attente"
 
-#: src/script/arch-update.sh:188
+#: src/script/arch-update.sh:194
 #, sh-format
 msgid "  -d, --devel       Include AUR development packages updates"
 msgstr "  -d, --devel       Inclure les mises à jour des paquets de développement AUR"
 
-#: src/script/arch-update.sh:189
+#: src/script/arch-update.sh:195
 #, sh-format
 msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
@@ -126,17 +126,17 @@ msgstr ""
 "  -n, --news [Num]  Afficher les dernières Arch news, vous pouvez optionnellement spécifier le "
 "nombre de Arch news à afficher avec '--news [Num]' (e.g. '--news 10')"
 
-#: src/script/arch-update.sh:190
+#: src/script/arch-update.sh:196
 #, sh-format
 msgid "  -D, --debug       Display debug traces"
 msgstr "  -D, --debug       Afficher les traces de débogage"
 
-#: src/script/arch-update.sh:191
+#: src/script/arch-update.sh:197
 #, sh-format
 msgid "  --gen-config      Generate a default/example configuration file"
 msgstr "  --gen-config      Générer un fichier de configuration par défaut/exemple"
 
-#: src/script/arch-update.sh:192
+#: src/script/arch-update.sh:198
 #, sh-format
 msgid ""
 "  --tray            Launch the Arch-Update systray applet, you can "
@@ -145,22 +145,22 @@ msgstr ""
 "  --tray            Lancer l'applet systray d'Arch-Update, vous pouvez "
 "optionnellement ajouter l'argument '--enable' pour la démarrer automatiquement au démarrage du système"
 
-#: src/script/arch-update.sh:193
+#: src/script/arch-update.sh:199
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
 msgstr "  -h, --help        Afficher ce message d'aide et quitter"
 
-#: src/script/arch-update.sh:194
+#: src/script/arch-update.sh:200
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
 msgstr "  -V, --version     Afficher les informations de version et quitter"
 
-#: src/script/arch-update.sh:196
+#: src/script/arch-update.sh:202
 #, sh-format
 msgid "For more information, see the ${name}(1) man page."
 msgstr "Pour plus d'informations, consultez la page de manuel ${name}(1)."
 
-#: src/script/arch-update.sh:197
+#: src/script/arch-update.sh:203
 #, sh-format
 msgid ""
 "Certain options can be enabled/disabled or modified via the ${name}.conf "
@@ -169,7 +169,7 @@ msgstr ""
 "Certaines options peuvent être activées/désactivées ou modifiées via le fichier de configuration ${name}.conf, "
 "voir la page de manuel ${name}.conf(5)."
 
-#: src/script/arch-update.sh:208
+#: src/script/arch-update.sh:214
 #, sh-format
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
@@ -178,114 +178,120 @@ msgstr ""
 "${name}: option invalide -- '${option}'\\nEssayez '${name} --help' pour plus "
 "d'informations."
 
-#: src/script/arch-update.sh:248 src/script/arch-update.sh:250
+#: src/script/arch-update.sh:254 src/script/arch-update.sh:256
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} mise à jour disponible"
 
-#: src/script/arch-update.sh:255 src/script/arch-update.sh:257
+#: src/script/arch-update.sh:261 src/script/arch-update.sh:263
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/script/arch-update.sh:273
+#: src/script/arch-update.sh:279
 #, sh-format
 msgid "Looking for updates...\\n"
 msgstr "Recherche de mises à jour...\\n"
 
-#: src/script/arch-update.sh:294
+#: src/script/arch-update.sh:300
 #, sh-format
 msgid "Packages:"
 msgstr "Paquets :"
 
-#: src/script/arch-update.sh:299
+#: src/script/arch-update.sh:305
 #, sh-format
 msgid "AUR Packages:"
 msgstr "Paquets AUR :"
 
-#: src/script/arch-update.sh:304
+#: src/script/arch-update.sh:310
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/script/arch-update.sh:311
+#: src/script/arch-update.sh:317
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
 
-#: src/script/arch-update.sh:318
+#: src/script/arch-update.sh:324
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:321 src/script/arch-update.sh:458
-#: src/script/arch-update.sh:491 src/script/arch-update.sh:533
-#: src/script/arch-update.sh:600 src/script/arch-update.sh:626
+#: src/script/arch-update.sh:327 src/script/arch-update.sh:475
+#: src/script/arch-update.sh:508 src/script/arch-update.sh:550
+#: src/script/arch-update.sh:617 src/script/arch-update.sh:643
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/script/arch-update.sh:321 src/script/arch-update.sh:458
-#: src/script/arch-update.sh:491 src/script/arch-update.sh:533
-#: src/script/arch-update.sh:600 src/script/arch-update.sh:626
+#: src/script/arch-update.sh:327 src/script/arch-update.sh:475
+#: src/script/arch-update.sh:508 src/script/arch-update.sh:550
+#: src/script/arch-update.sh:617 src/script/arch-update.sh:643
 #, sh-format
 msgid "y"
 msgstr "o"
 
-#: src/script/arch-update.sh:325
+#: src/script/arch-update.sh:331
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
 
-#: src/script/arch-update.sh:356
+#: src/script/arch-update.sh:359
 #, sh-format
 msgid "Arch News:"
 msgstr "Arch News :"
 
-#: src/script/arch-update.sh:361
+#: src/script/arch-update.sh:364
 #, sh-format
 msgid "[NEW]"
 msgstr "[NOUVEAU]"
 
-#: src/script/arch-update.sh:372
-#, sh-format
-msgid "Select the news to read (or just press \"enter\" to quit):"
-msgstr "Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour quitter) :"
-
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:375
 #, sh-format
 msgid ""
-"Select the news to read (or just press \"enter\" to proceed with update):"
+"Select the news to read (e.g. 1 3 5), select 0 to read them all or press "
+"\"enter\" to quit:"
 msgstr ""
-"Sélectionnez la news à lire (ou appuyez simplement sur \"entrée\" pour procéder à la mise à jour) :"
+"Sélectionnez les news à lire (par exemple: 1 3 5), sélectionnez 0 pour toutes les lire "
+"ou appuyez sur "entrée" pour quitter"
 
-#: src/script/arch-update.sh:385
+#: src/script/arch-update.sh:377
+#, sh-format
+msgid ""
+"Select the news to read (e.g. 1 3 5), select 0 to read them all or press "
+"\"enter\" to proceed with update:"
+msgstr ""
+"Sélectionnez les news à lire (par exemple: 1 3 5), sélectionnez 0 pour toutes les lire "
+"ou appuyez sur "entrée" pour procéder à la mise à jour"
+
+#: src/script/arch-update.sh:399
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/script/arch-update.sh:386
+#: src/script/arch-update.sh:400
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/script/arch-update.sh:387
+#: src/script/arch-update.sh:401
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:388
+#: src/script/arch-update.sh:402
 #, sh-format
 msgid "URL:"
 msgstr "URL :"
 
-#: src/script/arch-update.sh:401
+#: src/script/arch-update.sh:418
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:406 src/script/arch-update.sh:418
-#: src/script/arch-update.sh:429
+#: src/script/arch-update.sh:423 src/script/arch-update.sh:435
+#: src/script/arch-update.sh:446
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -294,27 +300,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:413
+#: src/script/arch-update.sh:430
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:425
+#: src/script/arch-update.sh:442
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:436
+#: src/script/arch-update.sh:453
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:448
+#: src/script/arch-update.sh:465
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:452
+#: src/script/arch-update.sh:469
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -323,7 +329,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:454
+#: src/script/arch-update.sh:471
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -332,14 +338,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:460
+#: src/script/arch-update.sh:477
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:464 src/script/arch-update.sh:497
-#: src/script/arch-update.sh:540 src/script/arch-update.sh:550
-#: src/script/arch-update.sh:560 src/script/arch-update.sh:569
+#: src/script/arch-update.sh:481 src/script/arch-update.sh:514
+#: src/script/arch-update.sh:557 src/script/arch-update.sh:567
+#: src/script/arch-update.sh:577 src/script/arch-update.sh:586
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -348,118 +354,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:467 src/script/arch-update.sh:500
+#: src/script/arch-update.sh:484 src/script/arch-update.sh:517
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:472 src/script/arch-update.sh:504
-#: src/script/arch-update.sh:577
+#: src/script/arch-update.sh:489 src/script/arch-update.sh:521
+#: src/script/arch-update.sh:594
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:476
+#: src/script/arch-update.sh:493
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:481
+#: src/script/arch-update.sh:498
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:485
+#: src/script/arch-update.sh:502
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:487
+#: src/script/arch-update.sh:504
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:493
+#: src/script/arch-update.sh:510
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:508
+#: src/script/arch-update.sh:525
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:525
+#: src/script/arch-update.sh:542
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:526
+#: src/script/arch-update.sh:543
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:528
+#: src/script/arch-update.sh:545
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:529
+#: src/script/arch-update.sh:546
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:536 src/script/arch-update.sh:556
+#: src/script/arch-update.sh:553 src/script/arch-update.sh:573
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:546 src/script/arch-update.sh:565
+#: src/script/arch-update.sh:563 src/script/arch-update.sh:582
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:581
+#: src/script/arch-update.sh:598
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:590
+#: src/script/arch-update.sh:607
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:594
+#: src/script/arch-update.sh:611
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:596
+#: src/script/arch-update.sh:613
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:602
+#: src/script/arch-update.sh:619
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:606
+#: src/script/arch-update.sh:623
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:609
+#: src/script/arch-update.sh:626
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:613
+#: src/script/arch-update.sh:630
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:622
+#: src/script/arch-update.sh:639
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -468,17 +474,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:623
+#: src/script/arch-update.sh:640
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:636
+#: src/script/arch-update.sh:653
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
 msgstr "Redémarrage dans ${sec}...\\r"
 
-#: src/script/arch-update.sh:642
+#: src/script/arch-update.sh:659
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -487,7 +493,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:650
+#: src/script/arch-update.sh:667
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -496,17 +502,17 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:654
+#: src/script/arch-update.sh:671
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"
 
-#: src/script/arch-update.sh:709
+#: src/script/arch-update.sh:726
 #, sh-format
 msgid "Example configuration file not found"
 msgstr "Fichier de configuration exemple non trouvé"
 
-#: src/script/arch-update.sh:714
+#: src/script/arch-update.sh:731
 #, sh-format
 msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
@@ -515,27 +521,27 @@ msgstr ""
 "Le fichier de configuration '${config_file}' existe déjà.\\nVeuillez le supprimer "
 "avant d'en générer un nouveau"
 
-#: src/script/arch-update.sh:719
+#: src/script/arch-update.sh:736
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
 msgstr "Le fichier de configuration '${config_file}' a été généré"
 
-#: src/script/arch-update.sh:724
+#: src/script/arch-update.sh:741
 #, sh-format
 msgid "No configuration file found"
 msgstr "Aucun fichier de configuration n'a été trouvé"
 
-#: src/script/arch-update.sh:743
+#: src/script/arch-update.sh:760
 #, sh-format
 msgid "Arch-Update tray desktop file not found"
 msgstr "Le fichier Arch-Update tray desktop n'a pas été trouvé"
 
-#: src/script/arch-update.sh:750
+#: src/script/arch-update.sh:767
 #, sh-format
 msgid "The '${tray_desktop_file_autostart}' file already exists"
 msgstr "Le fichier '${tray_desktop_file_autostart}' existe déjà"
 
-#: src/script/arch-update.sh:755
+#: src/script/arch-update.sh:772
 #, sh-format
 msgid ""
 "The '${tray_desktop_file_autostart}' file has been created, the Arch-Update "
@@ -548,7 +554,7 @@ msgstr ""
 "immédiatement, vous pouvez lancer l'application \"Arch-Update Systray Applet\" "
 "depuis votre menu d'application"
 
-#: src/script/arch-update.sh:763
+#: src/script/arch-update.sh:780
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr "Il y a déjà une instance de l'applet systray d'Arch-Update en cours d'exécution"

--- a/po/fr.po
+++ b/po/fr.po
@@ -218,16 +218,16 @@ msgstr "Aucune mise à jour disponible\\n"
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:327 src/script/arch-update.sh:475
-#: src/script/arch-update.sh:508 src/script/arch-update.sh:550
-#: src/script/arch-update.sh:617 src/script/arch-update.sh:643
+#: src/script/arch-update.sh:327 src/script/arch-update.sh:476
+#: src/script/arch-update.sh:509 src/script/arch-update.sh:551
+#: src/script/arch-update.sh:618 src/script/arch-update.sh:644
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/script/arch-update.sh:327 src/script/arch-update.sh:475
-#: src/script/arch-update.sh:508 src/script/arch-update.sh:550
-#: src/script/arch-update.sh:617 src/script/arch-update.sh:643
+#: src/script/arch-update.sh:327 src/script/arch-update.sh:476
+#: src/script/arch-update.sh:509 src/script/arch-update.sh:551
+#: src/script/arch-update.sh:618 src/script/arch-update.sh:644
 #, sh-format
 msgid "y"
 msgstr "o"
@@ -254,7 +254,7 @@ msgid ""
 "\"enter\" to quit:"
 msgstr ""
 "Sélectionnez les news à lire (par exemple: 1 3 5), sélectionnez 0 pour toutes les lire "
-"ou appuyez sur \"entrée\" pour quitter"
+"ou appuyez sur \"entrée\" pour quitter:"
 
 #: src/script/arch-update.sh:377
 #, sh-format
@@ -263,7 +263,7 @@ msgid ""
 "\"enter\" to proceed with update:"
 msgstr ""
 "Sélectionnez les news à lire (par exemple: 1 3 5), sélectionnez 0 pour toutes les lire "
-"ou appuyez sur \"entrée\" pour procéder à la mise à jour"
+"ou appuyez sur \"entrée\" pour procéder à la mise à jour:"
 
 #: src/script/arch-update.sh:399
 #, sh-format
@@ -285,13 +285,13 @@ msgstr "Date de publication :"
 msgid "URL:"
 msgstr "URL :"
 
-#: src/script/arch-update.sh:418
+#: src/script/arch-update.sh:419
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:423 src/script/arch-update.sh:435
-#: src/script/arch-update.sh:446
+#: src/script/arch-update.sh:424 src/script/arch-update.sh:436
+#: src/script/arch-update.sh:447
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -300,27 +300,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:430
+#: src/script/arch-update.sh:431
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:442
+#: src/script/arch-update.sh:443
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:453
+#: src/script/arch-update.sh:454
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:465
+#: src/script/arch-update.sh:466
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:469
+#: src/script/arch-update.sh:470
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -329,7 +329,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:471
+#: src/script/arch-update.sh:472
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -338,14 +338,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:477
+#: src/script/arch-update.sh:478
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:481 src/script/arch-update.sh:514
-#: src/script/arch-update.sh:557 src/script/arch-update.sh:567
-#: src/script/arch-update.sh:577 src/script/arch-update.sh:586
+#: src/script/arch-update.sh:482 src/script/arch-update.sh:515
+#: src/script/arch-update.sh:558 src/script/arch-update.sh:568
+#: src/script/arch-update.sh:578 src/script/arch-update.sh:587
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -354,118 +354,118 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:484 src/script/arch-update.sh:517
+#: src/script/arch-update.sh:485 src/script/arch-update.sh:518
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:489 src/script/arch-update.sh:521
-#: src/script/arch-update.sh:594
+#: src/script/arch-update.sh:490 src/script/arch-update.sh:522
+#: src/script/arch-update.sh:595
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:493
+#: src/script/arch-update.sh:494
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:498
+#: src/script/arch-update.sh:499
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:502
+#: src/script/arch-update.sh:503
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:504
+#: src/script/arch-update.sh:505
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:510
+#: src/script/arch-update.sh:511
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:525
+#: src/script/arch-update.sh:526
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:542
+#: src/script/arch-update.sh:543
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:543
+#: src/script/arch-update.sh:544
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:545
+#: src/script/arch-update.sh:546
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:546
+#: src/script/arch-update.sh:547
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:553 src/script/arch-update.sh:573
+#: src/script/arch-update.sh:554 src/script/arch-update.sh:574
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:563 src/script/arch-update.sh:582
+#: src/script/arch-update.sh:564 src/script/arch-update.sh:583
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:598
+#: src/script/arch-update.sh:599
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:607
+#: src/script/arch-update.sh:608
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:611
+#: src/script/arch-update.sh:612
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:613
+#: src/script/arch-update.sh:614
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:619
+#: src/script/arch-update.sh:620
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:623
+#: src/script/arch-update.sh:624
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:626
+#: src/script/arch-update.sh:627
 #, sh-format
 msgid "The pacnew file(s) processing hasn't been applied\\n"
 msgstr "Le traitement des fichiers pacnew n'a pas été appliqué\\n"
 
-#: src/script/arch-update.sh:630
+#: src/script/arch-update.sh:631
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:639
+#: src/script/arch-update.sh:640
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -474,17 +474,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite " 
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:640
+#: src/script/arch-update.sh:641
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:653
+#: src/script/arch-update.sh:654
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
 msgstr "Redémarrage dans ${sec}...\\r"
 
-#: src/script/arch-update.sh:659
+#: src/script/arch-update.sh:660
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -493,7 +493,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:667
+#: src/script/arch-update.sh:668
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -502,17 +502,17 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:671
+#: src/script/arch-update.sh:672
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"
 
-#: src/script/arch-update.sh:726
+#: src/script/arch-update.sh:727
 #, sh-format
 msgid "Example configuration file not found"
 msgstr "Fichier de configuration exemple non trouvé"
 
-#: src/script/arch-update.sh:731
+#: src/script/arch-update.sh:732
 #, sh-format
 msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
@@ -521,27 +521,27 @@ msgstr ""
 "Le fichier de configuration '${config_file}' existe déjà.\\nVeuillez le supprimer "
 "avant d'en générer un nouveau"
 
-#: src/script/arch-update.sh:736
+#: src/script/arch-update.sh:737
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
 msgstr "Le fichier de configuration '${config_file}' a été généré"
 
-#: src/script/arch-update.sh:741
+#: src/script/arch-update.sh:742
 #, sh-format
 msgid "No configuration file found"
 msgstr "Aucun fichier de configuration n'a été trouvé"
 
-#: src/script/arch-update.sh:760
+#: src/script/arch-update.sh:761
 #, sh-format
 msgid "Arch-Update tray desktop file not found"
 msgstr "Le fichier Arch-Update tray desktop n'a pas été trouvé"
 
-#: src/script/arch-update.sh:767
+#: src/script/arch-update.sh:768
 #, sh-format
 msgid "The '${tray_desktop_file_autostart}' file already exists"
 msgstr "Le fichier '${tray_desktop_file_autostart}' existe déjà"
 
-#: src/script/arch-update.sh:772
+#: src/script/arch-update.sh:773
 #, sh-format
 msgid ""
 "The '${tray_desktop_file_autostart}' file has been created, the Arch-Update "
@@ -554,7 +554,7 @@ msgstr ""
 "immédiatement, vous pouvez lancer l'application \"Arch-Update Systray Applet\" "
 "depuis votre menu d'application"
 
-#: src/script/arch-update.sh:780
+#: src/script/arch-update.sh:781
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr "Il y a déjà une instance de l'applet systray d'Arch-Update en cours d'exécution"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -401,10 +401,11 @@ list_news() {
 				publication_date_tag="$(eval_gettext "Publication date:")"
 				url_tag="$(eval_gettext "URL:")"
 				echo -e "\n${blue}---${color_off}\n${bold}${title_tag}${color_off} ${news_selected}\n${bold}${author_tag}${color_off} ${news_author}\n${bold}${publication_date_tag}${color_off} ${news_date}\n${bold}${url_tag}${color_off} ${news_url}\n${blue}---${color_off}\n\n${news_article}"
+				printed_news="y"
 			fi
 		done
 
-		if [ -z "${news_option}" ]; then
+		if [ -z "${news_option}" ] && [ -n "${printed_news}" ]; then
 			echo
 			continue_msg
 		fi

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -401,13 +401,13 @@ list_news() {
 				publication_date_tag="$(eval_gettext "Publication date:")"
 				url_tag="$(eval_gettext "URL:")"
 				echo -e "\n${blue}---${color_off}\n${bold}${title_tag}${color_off} ${news_selected}\n${bold}${author_tag}${color_off} ${news_author}\n${bold}${publication_date_tag}${color_off} ${news_date}\n${bold}${url_tag}${color_off} ${news_url}\n${blue}---${color_off}\n\n${news_article}"
-
-				if [ -z "${news_option}" ]; then
-					echo
-					continue_msg
-				fi
 			fi
 		done
+
+		if [ -z "${news_option}" ]; then
+			echo
+			continue_msg
+		fi
 	fi
 }
 

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -383,8 +383,8 @@ list_news() {
 				answer_array+=("${i}")
 			done
 		else
-			answer_array=$(printf "%s\n" "${answer_array[@]}")
-			answer_array=($(echo "${answer_array}" | awk '!seen[$0]++'))
+			array_to_string=$(printf "%s\n" "${answer_array[@]}")
+			answer_array=($(echo "${array_to_string}" | awk '!seen[$0]++'))
 		fi
 
 		for num in "${answer_array[@]}"; do

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -384,7 +384,7 @@ list_news() {
 			done
 		else
 			array_to_string=$(printf "%s\n" "${answer_array[@]}")
-			answer_array=($(echo "${array_to_string}" | awk '!seen[$0]++'))
+			mapfile -t answer_array < <(echo "${array_to_string}" | awk '!seen[$0]++')
 		fi
 
 		for num in "${answer_array[@]}"; do


### PR DESCRIPTION
### Description

Add the possibility to read multiple news at once by selecting multiple number entries (e.g. 1 3 5). Selecting 0 reads them all.

### Screenshots / Logs

![image](https://github.com/Antiz96/arch-update/assets/53110319/0fa2476d-d8aa-4c56-80ec-bdf10351ded6)

![image](https://github.com/Antiz96/arch-update/assets/53110319/b3319354-4b62-4598-8edc-48536577f7fa)

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/198
