### PR TITLE
doc: Add the exit status 12 documentation in man pages

### DIFF
--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -231,6 +231,10 @@ Error when calling the reboot command to apply a pending kernel update
 .B 11
 Error when restarting services that require a post upgrade restart
 
+.TP
+.B 12
+ Error during the pacnew files processing
+
 .SH SEE ALSO
 .BR checkupdates (8),
 .BR pacman (8),

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -231,6 +231,10 @@ Erreur lors de l'appel de la commande reboot pour appliquer une mise à jour du 
 .B 11
 Erreur lors du redémarrage des services nécessitant un redémarrage après mise à jour
 
+.TP
+.B 12
+Erreur lors du traitement des fichiers pacnew
+
 .SH VOIR AUSSI
 .BR checkupdates (8),
 .BR pacman (8),


### PR DESCRIPTION
### Description

Add the missing documentation for the exist status 12 in man pages