### PR TITLE
fix: Fix exit status code 7 for the --list option

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -328,9 +328,9 @@ list_packages() {
 
 	if [ -z "${packages}" ] && [ -z "${aur_packages}" ] && [ -z "${flatpak_packages}" ]; then
 		state_up_to_date
-		if [ -z "${list_option}" ]; then
-			info_msg "$(eval_gettext "No update available\n")"
-		else
+		info_msg "$(eval_gettext "No update available\n")"
+
+		if [ -n "${list_option}" ]; then
 			exit 7
 		fi
 	else
@@ -796,7 +796,7 @@ case "${option}" in
 	;;
 	-l|--list)
 		list_option="y"
-		list_packages | sed '${/^$/d;}'
+		list_packages
 	;;
 	-n|--news)
 		show_news="y"


### PR DESCRIPTION
### Description

The exit status code 7 invoked if there are no pending update when using the `-l/--list` option was not honored because of the `sed` part piped into the call of the `list_package` function. Indeed, piped commands are executed in their own subshell, so the subshell invoked by the `| sed` part is exited with status code 7 instead of the parent subshell (see https://www.gnu.org/software/bash/manual/html_node/Pipelines.html & https://relentlesscoding.com/posts/bash-commands-in-pipelines-subshells/ for more details). Given the very little benefit this `sed` part brings (namely removing the last blank line of the output for purely aesthetic reason), it's not worth wrapping our head too hard on this. Let's just drop it.

This commit also adds an info message that there is no update available for the `-l/--list` option (if that's the case).

### Screenshots / Logs

Before:

![image](https://github.com/Antiz96/arch-update/assets/53110319/a504b15b-0bda-4344-8572-0d3e374a9c61)

After:

![image](https://github.com/Antiz96/arch-update/assets/53110319/c428c2b9-63c6-4500-8231-10dc2163f30f)


### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/211