### PR TITLE
fix: Optimize the "News" function and avoid unexpected behaviors

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -204,7 +204,7 @@ msgstr ""
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:332
+#: src/script/arch-update.sh:331
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
@@ -214,378 +214,404 @@ msgstr ""
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:342 src/script/arch-update.sh:495
-#: src/script/arch-update.sh:528 src/script/arch-update.sh:570
-#: src/script/arch-update.sh:637 src/script/arch-update.sh:737
+#: src/script/arch-update.sh:342 src/script/arch-update.sh:512
+#: src/script/arch-update.sh:545 src/script/arch-update.sh:587
+#: src/script/arch-update.sh:654 src/script/arch-update.sh:754
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/script/arch-update.sh:342 src/script/arch-update.sh:495
-#: src/script/arch-update.sh:528 src/script/arch-update.sh:570
-#: src/script/arch-update.sh:637 src/script/arch-update.sh:737
+#: src/script/arch-update.sh:342 src/script/arch-update.sh:512
+#: src/script/arch-update.sh:545 src/script/arch-update.sh:587
+#: src/script/arch-update.sh:654 src/script/arch-update.sh:754
 #, sh-format
 msgid "y"
 msgstr ""
 
-#: src/script/arch-update.sh:346
+#: src/script/arch-update.sh:347
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:357
+#, sh-format
+msgid "Looking for recent Arch News..."
+msgstr ""
+
+#: src/script/arch-update.sh:362
+#, sh-format
+msgid ""
+"Unable to retrieve recent Arch News within a reasonable time (possibly "
+"because of a slow or faulty network connection)\\nPlease, look for any "
+"recent news at https://archlinux.org before updating your system"
+msgstr ""
+
+#: src/script/arch-update.sh:371
+#, sh-format
+msgid "No recent Arch News found"
+msgstr ""
+
+#: src/script/arch-update.sh:384
 #, sh-format
 msgid "Arch News:"
 msgstr ""
 
-#: src/script/arch-update.sh:379
+#: src/script/arch-update.sh:389
 #, sh-format
 msgid "[NEW]"
 msgstr ""
 
-#: src/script/arch-update.sh:390
+#: src/script/arch-update.sh:400
 #, sh-format
 msgid ""
 "Select the news to read (e.g. 1 3 5), select 0 to read them all or press "
 "\"enter\" to quit:"
 msgstr ""
 
-#: src/script/arch-update.sh:392
+#: src/script/arch-update.sh:402
 #, sh-format
 msgid ""
 "Select the news to read (e.g. 1 3 5), select 0 to read them all or press "
 "\"enter\" to proceed with update:"
 msgstr ""
 
-#: src/script/arch-update.sh:414
+#: src/script/arch-update.sh:425
+#, sh-format
+msgid ""
+"Unable to retrieve the selected Arch News within a reasonable time (possibly "
+"because of a slow or faulty network connection)\\nPlease, read the selected "
+"Arch News at ${news_url} before updating your system"
+msgstr ""
+
+#: src/script/arch-update.sh:430
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/script/arch-update.sh:415
+#: src/script/arch-update.sh:431
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/script/arch-update.sh:416
+#: src/script/arch-update.sh:432
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/script/arch-update.sh:417
+#: src/script/arch-update.sh:433
 #, sh-format
 msgid "URL:"
 msgstr ""
 
-#: src/script/arch-update.sh:434
+#: src/script/arch-update.sh:451
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:439 src/script/arch-update.sh:453
-#: src/script/arch-update.sh:466
+#: src/script/arch-update.sh:456 src/script/arch-update.sh:470
+#: src/script/arch-update.sh:483
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:448
+#: src/script/arch-update.sh:465
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:462
+#: src/script/arch-update.sh:479
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:473
+#: src/script/arch-update.sh:490
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:485
+#: src/script/arch-update.sh:502
 #, sh-format
 msgid "Orphan Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:489
+#: src/script/arch-update.sh:506
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:491
+#: src/script/arch-update.sh:508
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:497
+#: src/script/arch-update.sh:514
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:501 src/script/arch-update.sh:534
-#: src/script/arch-update.sh:577 src/script/arch-update.sh:587
-#: src/script/arch-update.sh:597 src/script/arch-update.sh:606
+#: src/script/arch-update.sh:518 src/script/arch-update.sh:551
+#: src/script/arch-update.sh:594 src/script/arch-update.sh:604
+#: src/script/arch-update.sh:614 src/script/arch-update.sh:623
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:504 src/script/arch-update.sh:537
+#: src/script/arch-update.sh:521 src/script/arch-update.sh:554
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:509 src/script/arch-update.sh:541
-#: src/script/arch-update.sh:614
+#: src/script/arch-update.sh:526 src/script/arch-update.sh:558
+#: src/script/arch-update.sh:631
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:513
+#: src/script/arch-update.sh:530
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:518
+#: src/script/arch-update.sh:535
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr ""
 
-#: src/script/arch-update.sh:522
+#: src/script/arch-update.sh:539
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:524
+#: src/script/arch-update.sh:541
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:530
+#: src/script/arch-update.sh:547
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:545
+#: src/script/arch-update.sh:562
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:562
+#: src/script/arch-update.sh:579
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:563
+#: src/script/arch-update.sh:580
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:565
+#: src/script/arch-update.sh:582
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:566
+#: src/script/arch-update.sh:583
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:573 src/script/arch-update.sh:593
+#: src/script/arch-update.sh:590 src/script/arch-update.sh:610
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:583 src/script/arch-update.sh:602
+#: src/script/arch-update.sh:600 src/script/arch-update.sh:619
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr ""
 
-#: src/script/arch-update.sh:618
+#: src/script/arch-update.sh:635
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:627
+#: src/script/arch-update.sh:644
 #, sh-format
 msgid "Pacnew Files:"
 msgstr ""
 
-#: src/script/arch-update.sh:631
+#: src/script/arch-update.sh:648
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:633
+#: src/script/arch-update.sh:650
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr ""
 
-#: src/script/arch-update.sh:639
+#: src/script/arch-update.sh:656
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:643
+#: src/script/arch-update.sh:660
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:646
+#: src/script/arch-update.sh:663
 #, sh-format
 msgid "An error occurred during the pacnew file(s) processing\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:652
+#: src/script/arch-update.sh:669
 #, sh-format
 msgid ""
 "The pacnew file(s) processing hasn't been applied\\nPlease, consider "
 "processing them promptly\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:656
+#: src/script/arch-update.sh:673
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:668
+#: src/script/arch-update.sh:685
 #, sh-format
 msgid "Services:\\nThe following service requires a post upgrade restart\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:670
+#: src/script/arch-update.sh:687
 #, sh-format
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:680
+#: src/script/arch-update.sh:697
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
 "or press \"enter\" to continue without restarting the service(s):"
 msgstr ""
 
-#: src/script/arch-update.sh:686 src/script/arch-update.sh:713
+#: src/script/arch-update.sh:703 src/script/arch-update.sh:730
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:689 src/script/arch-update.sh:716
+#: src/script/arch-update.sh:706 src/script/arch-update.sh:733
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
 "above service(s) status\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:702
+#: src/script/arch-update.sh:719
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr ""
 
-#: src/script/arch-update.sh:704
+#: src/script/arch-update.sh:721
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr ""
 
-#: src/script/arch-update.sh:720
+#: src/script/arch-update.sh:737
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
 "services that have been updated to fully apply the upgrade\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:724
+#: src/script/arch-update.sh:741
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:733
+#: src/script/arch-update.sh:750
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:734
+#: src/script/arch-update.sh:751
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/script/arch-update.sh:747
+#: src/script/arch-update.sh:764
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
 msgstr ""
 
-#: src/script/arch-update.sh:753
+#: src/script/arch-update.sh:770
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:761
+#: src/script/arch-update.sh:778
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:765
+#: src/script/arch-update.sh:782
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr ""
 
-#: src/script/arch-update.sh:821
+#: src/script/arch-update.sh:838
 #, sh-format
 msgid "Example configuration file not found"
 msgstr ""
 
-#: src/script/arch-update.sh:826
+#: src/script/arch-update.sh:843
 #, sh-format
 msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
 "before generating a new one"
 msgstr ""
 
-#: src/script/arch-update.sh:831
+#: src/script/arch-update.sh:848
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
 msgstr ""
 
-#: src/script/arch-update.sh:836 src/script/arch-update.sh:844
+#: src/script/arch-update.sh:853 src/script/arch-update.sh:861
 #, sh-format
 msgid ""
 "No configuration file found\\nYou can generate one with \"arch-update --gen-"
 "config\""
 msgstr ""
 
-#: src/script/arch-update.sh:848
+#: src/script/arch-update.sh:865
 #, sh-format
 msgid ""
 "Unable to determine the editor to use\\nThe \"EDITOR\" environment variable "
 "is not set and \"nano\" (fallback option) is not installed"
 msgstr ""
 
-#: src/script/arch-update.sh:866
+#: src/script/arch-update.sh:883
 #, sh-format
 msgid "Arch-Update tray desktop file not found"
 msgstr ""
 
-#: src/script/arch-update.sh:873
+#: src/script/arch-update.sh:890
 #, sh-format
 msgid "The '${tray_desktop_file_autostart}' file already exists"
 msgstr ""
 
-#: src/script/arch-update.sh:878
+#: src/script/arch-update.sh:895
 #, sh-format
 msgid ""
 "The '${tray_desktop_file_autostart}' file has been created, the Arch-Update "
@@ -594,7 +620,7 @@ msgid ""
 "from your app menu"
 msgstr ""
 
-#: src/script/arch-update.sh:886
+#: src/script/arch-update.sh:903
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -232,7 +232,7 @@ msgstr "Paquets AUR :"
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/script/arch-update.sh:332
+#: src/script/arch-update.sh:331
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
@@ -242,36 +242,57 @@ msgstr "Aucune mise à jour disponible\\n"
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/script/arch-update.sh:342 src/script/arch-update.sh:495
-#: src/script/arch-update.sh:528 src/script/arch-update.sh:570
-#: src/script/arch-update.sh:637 src/script/arch-update.sh:737
+#: src/script/arch-update.sh:342 src/script/arch-update.sh:512
+#: src/script/arch-update.sh:545 src/script/arch-update.sh:587
+#: src/script/arch-update.sh:654 src/script/arch-update.sh:754
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/script/arch-update.sh:342 src/script/arch-update.sh:495
-#: src/script/arch-update.sh:528 src/script/arch-update.sh:570
-#: src/script/arch-update.sh:637 src/script/arch-update.sh:737
+#: src/script/arch-update.sh:342 src/script/arch-update.sh:512
+#: src/script/arch-update.sh:545 src/script/arch-update.sh:587
+#: src/script/arch-update.sh:654 src/script/arch-update.sh:754
 #, sh-format
 msgid "y"
 msgstr "o"
 
-#: src/script/arch-update.sh:346
+#: src/script/arch-update.sh:347
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
 
-#: src/script/arch-update.sh:374
+#: src/script/arch-update.sh:357
+#, sh-format
+msgid "Looking for recent Arch News..."
+msgstr "Recherche des Arch News récentes..."
+
+#: src/script/arch-update.sh:362
+#, sh-format
+msgid ""
+"Unable to retrieve recent Arch News within a reasonable time (possibly "
+"because of a slow or faulty network connection)\\nPlease, look for any "
+"recent news at https://archlinux.org before updating your system"
+msgstr ""
+"Impossible de récupérer les Arch News récentes dans un délai raisonnable (possiblement "
+"à cause d'une connexion réseau lente ou défectueuse)\\nVeuillez consultez les dernières "
+"news à l'adresse suivante avant de mettre à jour votre système : https://archlinux.org"
+
+#: src/script/arch-update.sh:371
+#, sh-format
+msgid "No recent Arch News found"
+msgstr "Aucune Arch News récente trouvée"
+
+#: src/script/arch-update.sh:384
 #, sh-format
 msgid "Arch News:"
 msgstr "Arch News :"
 
-#: src/script/arch-update.sh:379
+#: src/script/arch-update.sh:389
 #, sh-format
 msgid "[NEW]"
 msgstr "[NOUVEAU]"
 
-#: src/script/arch-update.sh:390
+#: src/script/arch-update.sh:400
 #, sh-format
 msgid ""
 "Select the news to read (e.g. 1 3 5), select 0 to read them all or press "
@@ -280,7 +301,7 @@ msgstr ""
 "Sélectionnez les news à lire (par exemple: 1 3 5), sélectionnez 0 pour toutes les lire "
 "ou appuyez sur \"entrée\" pour quitter :"
 
-#: src/script/arch-update.sh:392
+#: src/script/arch-update.sh:402
 #, sh-format
 msgid ""
 "Select the news to read (e.g. 1 3 5), select 0 to read them all or press "
@@ -289,33 +310,44 @@ msgstr ""
 "Sélectionnez les news à lire (par exemple: 1 3 5), sélectionnez 0 pour toutes les lire "
 "ou appuyez sur \"entrée\" pour procéder à la mise à jour :"
 
-#: src/script/arch-update.sh:414
+#: src/script/arch-update.sh:425
+#, sh-format
+msgid ""
+"Unable to retrieve the selected Arch News within a reasonable time (possibly "
+"because of a slow or faulty network connection)\\nPlease, read the selected "
+"Arch News at ${news_url} before updating your system"
+msgstr ""
+"Impossible de récupérer la news sélectionnée dans un délai raisonnable (possiblement " 
+"à cause d'une connexion réseau lente ou défectueuse)\\nVeuillez consultez la news sélectionnée "
+"à l'adresse suivante avant de mettre à jour votre système : ${news_url}"
+
+#: src/script/arch-update.sh:430
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/script/arch-update.sh:415
+#: src/script/arch-update.sh:431
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/script/arch-update.sh:416
+#: src/script/arch-update.sh:432
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/script/arch-update.sh:417
+#: src/script/arch-update.sh:433
 #, sh-format
 msgid "URL:"
 msgstr "URL :"
 
-#: src/script/arch-update.sh:434
+#: src/script/arch-update.sh:451
 #, sh-format
 msgid "Updating Packages...\\n"
 msgstr "Mise à jour des paquets...\\n"
 
-#: src/script/arch-update.sh:439 src/script/arch-update.sh:453
-#: src/script/arch-update.sh:466
+#: src/script/arch-update.sh:456 src/script/arch-update.sh:470
+#: src/script/arch-update.sh:483
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
@@ -324,27 +356,27 @@ msgstr ""
 "Une erreur est survenue pendant le processus de mise à jour\\nLa mise à jour a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:448
+#: src/script/arch-update.sh:465
 #, sh-format
 msgid "Updating AUR Packages...\\n"
 msgstr "Mise à jour des paquets AUR...\\n"
 
-#: src/script/arch-update.sh:462
+#: src/script/arch-update.sh:479
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
 msgstr "Mise à jour des paquets Flatpak...\\n"
 
-#: src/script/arch-update.sh:473
+#: src/script/arch-update.sh:490
 #, sh-format
 msgid "The update has been applied\\n"
 msgstr "La mise à jour a été appliquée\\n"
 
-#: src/script/arch-update.sh:485
+#: src/script/arch-update.sh:502
 #, sh-format
 msgid "Orphan Packages:"
 msgstr "Paquets orphelins :"
 
-#: src/script/arch-update.sh:489
+#: src/script/arch-update.sh:506
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
@@ -353,7 +385,7 @@ msgstr ""
 "Voulez-vous supprimer ce paquet orphelin (et ses potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:491
+#: src/script/arch-update.sh:508
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
@@ -362,14 +394,14 @@ msgstr ""
 "Voulez-vous supprimer ces paquets orphelins (et leurs potentielles "
 "dépendances) maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:497
+#: src/script/arch-update.sh:514
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
 msgstr "Suppression des paquets orphelins...\\n"
 
-#: src/script/arch-update.sh:501 src/script/arch-update.sh:534
-#: src/script/arch-update.sh:577 src/script/arch-update.sh:587
-#: src/script/arch-update.sh:597 src/script/arch-update.sh:606
+#: src/script/arch-update.sh:518 src/script/arch-update.sh:551
+#: src/script/arch-update.sh:594 src/script/arch-update.sh:604
+#: src/script/arch-update.sh:614 src/script/arch-update.sh:623
 #, sh-format
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
@@ -378,113 +410,113 @@ msgstr ""
 "Une erreur est survenue pendant le processus de suppression\\nLa suppression a été "
 "abandonnée\\n"
 
-#: src/script/arch-update.sh:504 src/script/arch-update.sh:537
+#: src/script/arch-update.sh:521 src/script/arch-update.sh:554
 #, sh-format
 msgid "The removal has been applied\\n"
 msgstr "La suppression a été appliquée\\n"
 
-#: src/script/arch-update.sh:509 src/script/arch-update.sh:541
-#: src/script/arch-update.sh:614
+#: src/script/arch-update.sh:526 src/script/arch-update.sh:558
+#: src/script/arch-update.sh:631
 #, sh-format
 msgid "The removal hasn't been applied\\n"
 msgstr "La suppression n'a pas été appliquée\\n"
 
-#: src/script/arch-update.sh:513
+#: src/script/arch-update.sh:530
 #, sh-format
 msgid "No orphan package found\\n"
 msgstr "Aucun paquet orphelin n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:518
+#: src/script/arch-update.sh:535
 #, sh-format
 msgid "Flatpak Unused Packages:"
 msgstr "Paquets Flatpak inutilisés :"
 
-#: src/script/arch-update.sh:522
+#: src/script/arch-update.sh:539
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
 msgstr "Voulez-vous supprimer ce paquet Flatpak inutilisé maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:524
+#: src/script/arch-update.sh:541
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
 msgstr "Voulez-vous supprimer ces paquets Flatpak inutilisés maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:530
+#: src/script/arch-update.sh:547
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
 msgstr "Suppression des paquets Flatpak inutilisés..."
 
-#: src/script/arch-update.sh:545
+#: src/script/arch-update.sh:562
 #, sh-format
 msgid "No Flatpak unused package found\\n"
 msgstr "Aucun paquet Flatpak inutilisé n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:562
+#: src/script/arch-update.sh:579
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
 msgstr "Paquets mis en cache :\\nIl y a un paquet ancien ou désinstallé mis en cache\\n"
 
-#: src/script/arch-update.sh:563
+#: src/script/arch-update.sh:580
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
 msgstr "Voulez-vous le supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:565
+#: src/script/arch-update.sh:582
 #, sh-format
 msgid "Cached Packages:\\nThere are old and/or uninstalled cached packages\\n"
 msgstr "Paquets mis en cache :\\nIl y a plusieurs paquets anciens ou désinstallés mis en cache\\n"
 
-#: src/script/arch-update.sh:566
+#: src/script/arch-update.sh:583
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
 msgstr "Voulez-vous les supprimer du cache maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:573 src/script/arch-update.sh:593
+#: src/script/arch-update.sh:590 src/script/arch-update.sh:610
 #, sh-format
 msgid "Removing old cached packages..."
 msgstr "Suppression des anciens paquets mis en cache..."
 
-#: src/script/arch-update.sh:583 src/script/arch-update.sh:602
+#: src/script/arch-update.sh:600 src/script/arch-update.sh:619
 #, sh-format
 msgid "Removing uninstalled cached packages..."
 msgstr "Suppression des paquets désinstallés mis en cache..."
 
-#: src/script/arch-update.sh:618
+#: src/script/arch-update.sh:635
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
 msgstr "Aucun paquet ancien ou désinstallé mis en cache n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:627
+#: src/script/arch-update.sh:644
 #, sh-format
 msgid "Pacnew Files:"
 msgstr "Fichiers Pacnew :"
 
-#: src/script/arch-update.sh:631
+#: src/script/arch-update.sh:648
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
 msgstr "Voulez-vous traiter ce fichier maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:633
+#: src/script/arch-update.sh:650
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
 msgstr "Voulez-vous traiter ces fichiers maintenant ? [O/n]"
 
-#: src/script/arch-update.sh:639
+#: src/script/arch-update.sh:656
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
 msgstr "Traitement des fichiers pacnew...\\n"
 
-#: src/script/arch-update.sh:643
+#: src/script/arch-update.sh:660
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
 msgstr "Le traitement des fichiers pacnew a été appliqué\\n"
 
-#: src/script/arch-update.sh:646
+#: src/script/arch-update.sh:663
 #, sh-format
 msgid "An error occurred during the pacnew file(s) processing\\n"
 msgstr "Une erreur est survenue durant le traitement du/des fichier(s) pacnew\\n"
 
-#: src/script/arch-update.sh:652
+#: src/script/arch-update.sh:669
 #, sh-format
 msgid ""
 "The pacnew file(s) processing hasn't been applied\\nPlease, consider "
@@ -493,22 +525,22 @@ msgstr ""
 "Le traitement des fichiers pacnew n'a pas été appliqué\\nVeuillez considérer "
 "les traiter promptement\\n"
 
-#: src/script/arch-update.sh:656
+#: src/script/arch-update.sh:673
 #, sh-format
 msgid "No pacnew file found\\n"
 msgstr "Aucun fichier pacnew n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:668
+#: src/script/arch-update.sh:685
 #, sh-format
 msgid "Services:\\nThe following service requires a post upgrade restart\\n"
 msgstr "Services :\\nLe service suivant requiert un redémarrage suite à sa mise à jour\\n"
 
-#: src/script/arch-update.sh:670
+#: src/script/arch-update.sh:687
 #, sh-format
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr "Services :\\nLes services suivants requièrent un redémarrage suite à leur mise à jour\\n"
 
-#: src/script/arch-update.sh:680
+#: src/script/arch-update.sh:697
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -517,12 +549,12 @@ msgstr ""
 "Sélectionnez le(s) service(s) à redémarrer (par exemple: 1 3 5); sélectionnez 0 pour tous les redémarrer "
 "ou appuyez sur \"entrée\" pour continuer sans redémarrer le(s) service(s) :"
 
-#: src/script/arch-update.sh:686 src/script/arch-update.sh:713
+#: src/script/arch-update.sh:703 src/script/arch-update.sh:730
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Service(s) redémarré(s) avec succès\\n"
 
-#: src/script/arch-update.sh:689 src/script/arch-update.sh:716
+#: src/script/arch-update.sh:706 src/script/arch-update.sh:733
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -531,19 +563,19 @@ msgstr ""
 "Une erreur est survenue pendant le redémarrage du/des service(s)\\n Veuillez vérifier "
 "le statut des services ci-dessus\\n"
 
-#: src/script/arch-update.sh:702
+#: src/script/arch-update.sh:719
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "Le service ${service_selected} a été redémarré avec succès"
 
-#: src/script/arch-update.sh:704
+#: src/script/arch-update.sh:721
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr ""
 "Une erreur est survenue pendant le redémarrage du service ${service_selected}"
 
-#: src/script/arch-update.sh:720
+#: src/script/arch-update.sh:737
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -552,12 +584,12 @@ msgstr ""
 "Le redémarrage du/des service(s) n'a pas été appliqué\\nVeuillez considérer redémarrer "
 "les services qui ont été mis à jour pour appliquer complètement la mise à niveau\\n"
 
-#: src/script/arch-update.sh:724
+#: src/script/arch-update.sh:741
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Aucun service nécessitant un redémarrage suite à la mise à jour n'a été trouvé\\n"
 
-#: src/script/arch-update.sh:733
+#: src/script/arch-update.sh:750
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
@@ -566,17 +598,17 @@ msgstr ""
 "Redémarrage nécessaire :\\nIl y a une mise à jour du noyau en attente sur votre système qui nécessite "
 "un redémarrage pour être appliquée\\n"
 
-#: src/script/arch-update.sh:734
+#: src/script/arch-update.sh:751
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/script/arch-update.sh:747
+#: src/script/arch-update.sh:764
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
 msgstr "Redémarrage dans ${sec}...\\r"
 
-#: src/script/arch-update.sh:753
+#: src/script/arch-update.sh:770
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
@@ -585,7 +617,7 @@ msgstr ""
 "Une erreur est survenue pendant le processus de redémarrage\\nLe redémarrage a été "
 "abandonné\\n"
 
-#: src/script/arch-update.sh:761
+#: src/script/arch-update.sh:778
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
@@ -594,17 +626,17 @@ msgstr ""
 "Le redémarrage n'a pas été effectué\\nVeuillez considérer redémarrer votre système pour finaliser "
 "la mise à jour du noyau en attente\\n"
 
-#: src/script/arch-update.sh:765
+#: src/script/arch-update.sh:782
 #, sh-format
 msgid "No pending kernel update found\\n"
 msgstr "Aucune mise à jour du noyau en attente n'a été trouvée\\n"
 
-#: src/script/arch-update.sh:821
+#: src/script/arch-update.sh:838
 #, sh-format
 msgid "Example configuration file not found"
 msgstr "Fichier de configuration exemple non trouvé"
 
-#: src/script/arch-update.sh:826
+#: src/script/arch-update.sh:843
 #, sh-format
 msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
@@ -613,12 +645,12 @@ msgstr ""
 "Le fichier de configuration '${config_file}' existe déjà.\\nVeuillez le supprimer "
 "avant d'en générer un nouveau"
 
-#: src/script/arch-update.sh:831
+#: src/script/arch-update.sh:848
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
 msgstr "Le fichier de configuration '${config_file}' a été généré"
 
-#: src/script/arch-update.sh:836 src/script/arch-update.sh:844
+#: src/script/arch-update.sh:853 src/script/arch-update.sh:861
 #, sh-format
 msgid ""
 "No configuration file found\\nYou can generate one with \"arch-update --gen-"
@@ -627,7 +659,7 @@ msgstr ""
 "Aucun fichier de configuration n'a été trouvé\\nVous pouvez en générer un avec \"arch-update --gen-"
 "config\""
 
-#: src/script/arch-update.sh:848
+#: src/script/arch-update.sh:865
 #, sh-format
 msgid ""
 "Unable to determine the editor to use\\nThe \"EDITOR\" environment variable "
@@ -636,17 +668,17 @@ msgstr ""
 "Impossible de déterminer l'éditeur à utiliser\\n La variable d'environnement \"EDITOR\" "
 "n'est pas paramétrée et \"nano\" (option de secours) n'est pas installé"
 
-#: src/script/arch-update.sh:866
+#: src/script/arch-update.sh:883
 #, sh-format
 msgid "Arch-Update tray desktop file not found"
 msgstr "Le fichier Arch-Update tray desktop n'a pas été trouvé"
 
-#: src/script/arch-update.sh:873
+#: src/script/arch-update.sh:890
 #, sh-format
 msgid "The '${tray_desktop_file_autostart}' file already exists"
 msgstr "Le fichier '${tray_desktop_file_autostart}' existe déjà"
 
-#: src/script/arch-update.sh:878
+#: src/script/arch-update.sh:895
 #, sh-format
 msgid ""
 "The '${tray_desktop_file_autostart}' file has been created, the Arch-Update "
@@ -659,7 +691,7 @@ msgstr ""
 "immédiatement, vous pouvez lancer l'application \"Arch-Update Systray Applet\" "
 "depuis votre menu d'application"
 
-#: src/script/arch-update.sh:886
+#: src/script/arch-update.sh:903
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr "Il y a déjà une instance de l'applet systray d'Arch-Update en cours d'exécution"

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -341,6 +341,7 @@ list_packages() {
 			case "${answer}" in
 				"$(eval_gettext "Y")"|"$(eval_gettext "y")"|"")
 					proceed_with_update="y"
+					echo
 				;;
 				*)
 					error_msg "$(eval_gettext "The update has been aborted\n")" && quit_msg
@@ -353,76 +354,92 @@ list_packages() {
 
 # Definition of the list_news function: Display the latest Arch news and offers to read them
 list_news() {
-	if [ -z "${show_news}" ]; then
-		curl -Ls https://www.archlinux.org/news | htmlq -a title a | grep ^"View:" | sed "s/View:\ //g" | head -1 > "${statedir}/current_news_check"
+	info_msg "$(eval_gettext "Looking for recent Arch News...")"
+	news=$(curl -m 30 -Ls https://www.archlinux.org/news || echo "timeout")
 
-		if ! diff "${statedir}/current_news_check" "${statedir}/last_news_check" &> /dev/null; then
-			show_news="y"
-		fi
-
-		if [ -f "${statedir}/current_news_check" ]; then
-			mv -f "${statedir}/current_news_check" "${statedir}/last_news_check"
-		fi
-	fi
-
-	if [ -n "${show_news}" ]; then
-		news=$(curl -Ls https://www.archlinux.org/news)
-		news_titles=$(echo "${news}" | htmlq -a title a | grep ^"View:" | sed "s/View:\ //g" | head -"${news_num}")
-		mapfile -t news_dates < <(echo "${news}" | htmlq td | grep -v "class" | grep "[0-9]" | sed "s/<[^>]*>//g" | head -"${news_num}" | xargs -I{} date -d "{}" "+%s")
-
+	if [ "${news}" == "timeout" ]; then
 		echo
-		main_msg "$(eval_gettext "Arch News:")"
-
-		i=1
-		while IFS= read -r line; do
-			if [ -z "${news_option}" ] && [ "${news_dates["${i}-1"]}" -ge "$(date -d "$(cat "${statedir}/last_update_run" 2> /dev/null)" +%s)" ]; then
-				new_tag="$(eval_gettext "[NEW]")"
-				echo -e "${i} - ${line} ${green}${new_tag}${color_off}"
+		warning_msg "$(eval_gettext "Unable to retrieve recent Arch News within a reasonable time (possibly because of a slow or faulty network connection)\nPlease, look for any recent news at https://archlinux.org before updating your system")"
+	else
+		if [ -z "${show_news}" ]; then
+			echo "${news}" | htmlq -a title a | grep ^"View:" | sed "s/View:\ //g" | head -1 > "${statedir}/current_news_check"
+	
+			if ! diff "${statedir}/current_news_check" "${statedir}/last_news_check" &> /dev/null; then
+				show_news="y"
 			else
-				echo "${i} - ${line}"
+				echo
+				info_msg "$(eval_gettext "No recent Arch News found")"
 			fi
-			((i=i+1))
-		done < <(printf '%s\n' "${news_titles}")
-
-		echo
-
-		if [ -n "${news_option}" ]; then
-			ask_msg_array "$(eval_gettext "Select the news to read (e.g. 1 3 5), select 0 to read them all or press \"enter\" to quit:")"
-		else
-			ask_msg_array "$(eval_gettext "Select the news to read (e.g. 1 3 5), select 0 to read them all or press \"enter\" to proceed with update:")"
-		fi
-
-		if [ "${answer_array[0]}" -eq 0 ] 2> /dev/null; then
-			answer_array=()
-			for ((i=1; i<=news_num; i++)); do
-				answer_array+=("${i}")
-			done
-		else
-			array_to_string=$(printf "%s\n" "${answer_array[@]}")
-			mapfile -t answer_array < <(echo "${array_to_string}" | awk '!seen[$0]++')
-		fi
-
-		for num in "${answer_array[@]}"; do
-			if [ "${num}" -le "${news_num}" ] 2> /dev/null && [ "${num}" -gt "0" ]; then
-				news_selected=$(sed -n "${num}"p <<< "${news_titles}")
-				news_path=$(echo "${news_selected}" | sed s/\ -//g | sed s/\ /-/g | sed s/[.]//g | sed s/=//g | sed s/\>//g | sed s/\<//g | sed s/\`//g | sed s/://g | sed s/+//g | sed s/[[]//g | sed s/]//g | sed s/,//g | sed s/\(//g | sed s/\)//g | sed s/[/]//g | sed s/@//g | sed s/\'//g | sed s/--/-/g | awk '{print tolower($0)}')
-				news_url="https://www.archlinux.org/news/${news_path}"
-				news_content=$(curl -Ls "${news_url}")
-				news_author=$(echo "${news_content}" | htmlq -t .article-info | cut -f3- -d " ")
-				news_date=$(echo "${news_content}" | htmlq -t .article-info | cut -f1 -d " ")
-				news_article=$(echo "${news_content}" | htmlq -t .article-content)
-				title_tag="$(eval_gettext "Title:")"
-				author_tag="$(eval_gettext "Author:")"
-				publication_date_tag="$(eval_gettext "Publication date:")"
-				url_tag="$(eval_gettext "URL:")"
-				echo -e "\n${blue}---${color_off}\n${bold}${title_tag}${color_off} ${news_selected}\n${bold}${author_tag}${color_off} ${news_author}\n${bold}${publication_date_tag}${color_off} ${news_date}\n${bold}${url_tag}${color_off} ${news_url}\n${blue}---${color_off}\n\n${news_article}"
-				printed_news="y"
+	
+			if [ -f "${statedir}/current_news_check" ]; then
+				mv -f "${statedir}/current_news_check" "${statedir}/last_news_check"
 			fi
-		done
-
-		if [ -z "${news_option}" ] && [ -n "${printed_news}" ]; then
+		fi
+	
+		if [ -n "${show_news}" ]; then
+			news_titles=$(echo "${news}" | htmlq -a title a | grep ^"View:" | sed "s/View:\ //g" | head -"${news_num}")
+			mapfile -t news_dates < <(echo "${news}" | htmlq td | grep -v "class" | grep "[0-9]" | sed "s/<[^>]*>//g" | head -"${news_num}" | xargs -I{} date -d "{}" "+%s")
+	
 			echo
-			continue_msg
+			main_msg "$(eval_gettext "Arch News:")"
+	
+			i=1
+			while IFS= read -r line; do
+				if [ -z "${news_option}" ] && [ "${news_dates["${i}-1"]}" -ge "$(date -d "$(cat "${statedir}/last_update_run" 2> /dev/null)" +%s)" ]; then
+					new_tag="$(eval_gettext "[NEW]")"
+					echo -e "${i} - ${line} ${green}${new_tag}${color_off}"
+				else
+					echo "${i} - ${line}"
+				fi
+				((i=i+1))
+			done < <(printf '%s\n' "${news_titles}")
+	
+			echo
+	
+			if [ -n "${news_option}" ]; then
+				ask_msg_array "$(eval_gettext "Select the news to read (e.g. 1 3 5), select 0 to read them all or press \"enter\" to quit:")"
+			else
+				ask_msg_array "$(eval_gettext "Select the news to read (e.g. 1 3 5), select 0 to read them all or press \"enter\" to proceed with update:")"
+			fi
+	
+			if [ "${answer_array[0]}" -eq 0 ] 2> /dev/null; then
+				answer_array=()
+				for ((i=1; i<=news_num; i++)); do
+					answer_array+=("${i}")
+				done
+			else
+				array_to_string=$(printf "%s\n" "${answer_array[@]}")
+				mapfile -t answer_array < <(echo "${array_to_string}" | awk '!seen[$0]++')
+			fi
+	
+			for num in "${answer_array[@]}"; do
+				if [ "${num}" -le "${news_num}" ] 2> /dev/null && [ "${num}" -gt "0" ]; then
+					printed_news="y"
+					news_selected=$(sed -n "${num}"p <<< "${news_titles}")
+					news_path=$(echo "${news_selected}" | sed s/\ -//g | sed s/\ /-/g | sed s/[.]//g | sed s/=//g | sed s/\>//g | sed s/\<//g | sed s/\`//g | sed s/://g | sed s/+//g | sed s/[[]//g | sed s/]//g | sed s/,//g | sed s/\(//g | sed s/\)//g | sed s/[/]//g | sed s/@//g | sed s/\'//g | sed s/--/-/g | awk '{print tolower($0)}')
+					news_url="https://www.archlinux.org/news/${news_path}"
+					news_content=$(curl -m 30 -Ls "${news_url}" || echo "timeout")
+
+					if [ "${news_content}" == "timeout" ]; then
+						echo
+						warning_msg "$(eval_gettext "Unable to retrieve the selected Arch News within a reasonable time (possibly because of a slow or faulty network connection)\nPlease, read the selected Arch News at \${news_url} before updating your system")"
+					else
+						news_author=$(echo "${news_content}" | htmlq -t .article-info | cut -f3- -d " ")
+						news_date=$(echo "${news_content}" | htmlq -t .article-info | cut -f1 -d " ")
+						news_article=$(echo "${news_content}" | htmlq -t .article-content)
+						title_tag="$(eval_gettext "Title:")"
+						author_tag="$(eval_gettext "Author:")"
+						publication_date_tag="$(eval_gettext "Publication date:")"
+						url_tag="$(eval_gettext "URL:")"
+						echo -e "\n${blue}---${color_off}\n${bold}${title_tag}${color_off} ${news_selected}\n${bold}${author_tag}${color_off} ${news_author}\n${bold}${publication_date_tag}${color_off} ${news_date}\n${bold}${url_tag}${color_off} ${news_url}\n${blue}---${color_off}\n\n${news_article}"
+					fi
+				fi
+			done
+	
+			if [ -z "${news_option}" ] && [ -n "${printed_news}" ]; then
+				echo
+				continue_msg
+			fi
 		fi
 	fi
 }


### PR DESCRIPTION
### Description

This commit brings multiple improvements to the "News" function of the main script in order to optimize it and avoid unexpected behaviors:

- Print a message when Arch-Update is looking for recent Arch News (to avoid people thinking the script is just stuck in case it takes some time due to network instability/slowness)
- Print a message if no recent Arch News has been found since the last run
- Optimize the curl requests by merging the two first ones into a single one
- Add a default 30 sec timeout (`--max-time 30`) to curl requests so they don't end taking multiple minutes on slow/faulty network connection). If the timeout is reached, Arch-Update prints a warning explaining that it wasn't able to retrieve Arch News in a reasonable time, prints the URL of the Arch website or the URL of the selected news (so users can still look that up separately) and move on to the packages updates.

### Screenshots / Logs

![2024-07-09_10-26](https://github.com/Antiz96/arch-update/assets/53110319/732df3a2-873e-4d8a-9efe-269940caa3b2)

![2024-07-09_10-25](https://github.com/Antiz96/arch-update/assets/53110319/439c0a07-a50d-4770-a837-79934371fe95)

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/206