### PR TITLE
chore(checkservices): Update the checkservices command that parses the list of services to restart

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -677,7 +677,7 @@ pacnew_files() {
 # Definition of the restart_services function: Verify if any services require a post update restart
 restart_services() {
 	if [ -n "${packages_updated}" ]; then
-		services=$(yes No | sudo checkservices -FP 2> /dev/null | grep ".service" | grep -v -e "dbus-broker.service" -e "systemd-logind.service" -e "gdm.service" -e "sddm.service" -e "lightdm.service" -e "lxdm.service" -e "slim.service" -e "xdm.service" -e "greetd.service" -e "nodm.service" -e "ly.service" -e "lemurs.service" | cut -f2 -d "'")
+		services=$(sudo checkservices -F -P -R -i gdm.service -i sddm.service -i lightdm.service -i lxdm.service -i slim.service -i xdm.service -i greetd.service -i nodm.service -i ly.service -i lemurs.service 2> /dev/null | grep ".service"  | cut -f2 -d "'")
 		services_num=$(echo "${services}" | wc -l)
 	
 		if [ -n "${services}" ]; then


### PR DESCRIPTION
### Description

This commit updates the checkservices command used to parse the list of services to restart after upgrades in order to adopt a more elegant way to retrieve the said list, matching the recent upstream changes made to checkservices. 

See https://github.com/archlinux/contrib/compare/20240714...20240720