### PR TITLE
fix(news): Make curl fail on http server errors responses when checking for recent news

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -241,7 +241,7 @@ msgstr ""
 #: src/script/arch-update.sh:362
 #, sh-format
 msgid ""
-"Unable to retrieve recent Arch News within a reasonable time (request "
+"Unable to retrieve recent Arch News (HTTP error response or request "
 "timeout)\\nPlease, look for any recent news at https://archlinux.org before "
 "updating your system"
 msgstr ""
@@ -278,9 +278,9 @@ msgstr ""
 #: src/script/arch-update.sh:425
 #, sh-format
 msgid ""
-"Unable to retrieve the selected Arch News within a reasonable time (possibly "
-"because of a slow or faulty network connection)\\nPlease, read the selected "
-"Arch News at ${news_url} before updating your system"
+"Unable to retrieve the selected Arch News (HTTP error response or request "
+"timeout)\\nPlease, read the selected Arch News at ${news_url} before "
+"updating your system"
 msgstr ""
 
 #: src/script/arch-update.sh:430

--- a/po/fr.po
+++ b/po/fr.po
@@ -269,11 +269,11 @@ msgstr "Recherche des Arch News récentes..."
 #: src/script/arch-update.sh:362
 #, sh-format
 msgid ""
-"Unable to retrieve recent Arch News within a reasonable time (request "
+"Unable to retrieve recent Arch News (HTTP error response or request "
 "timeout)\\nPlease, look for any recent news at https://archlinux.org before "
 "updating your system"
 msgstr ""
-"Impossible de récupérer les Arch News récentes dans un délai raisonnable (délai "
+"Impossible de récupérer les Arch News récentes (réponse HTTP en erreur ou délai "
 "d'attente de la demande dépassé)\\nVeuillez consultez les dernières "
 "news à l'adresse suivante avant de mettre à jour votre système : https://archlinux.org"
 
@@ -313,12 +313,12 @@ msgstr ""
 #: src/script/arch-update.sh:425
 #, sh-format
 msgid ""
-"Unable to retrieve the selected Arch News within a reasonable time (possibly "
-"because of a slow or faulty network connection)\\nPlease, read the selected "
-"Arch News at ${news_url} before updating your system"
+"Unable to retrieve the selected Arch News (HTTP error response or request "
+"timeout)\\nPlease, read the selected Arch News at ${news_url} before "
+"updating your system"
 msgstr ""
-"Impossible de récupérer la news sélectionnée dans un délai raisonnable (possiblement " 
-"à cause d'une connexion réseau lente ou défectueuse)\\nVeuillez consultez la news sélectionnée "
+"Impossible de récupérer la news sélectionnée (réponse HTTP en erreur ou délai d'attente "
+"de la demande dépassé)\\nVeuillez consultez la news sélectionnée "
 "à l'adresse suivante avant de mettre à jour votre système : ${news_url}"
 
 #: src/script/arch-update.sh:430

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -359,7 +359,7 @@ list_news() {
 
 	if [ "${news}" == "timeout" ]; then
 		echo
-		warning_msg "$(eval_gettext "Unable to retrieve recent Arch News within a reasonable time (request timeout)\nPlease, look for any recent news at https://archlinux.org before updating your system")"
+		warning_msg "$(eval_gettext "Unable to retrieve recent Arch News (HTTP error response or request timeout)\nPlease, look for any recent news at https://archlinux.org before updating your system")"
 	else
 		if [ -z "${show_news}" ]; then
 			echo "${news}" | htmlq -a title a | grep ^"View:" | sed "s/View:\ //g" | head -1 > "${statedir}/current_news_check"
@@ -422,7 +422,7 @@ list_news() {
 
 					if [ "${news_content}" == "timeout" ]; then
 						echo
-						warning_msg "$(eval_gettext "Unable to retrieve the selected Arch News within a reasonable time (possibly because of a slow or faulty network connection)\nPlease, read the selected Arch News at \${news_url} before updating your system")"
+						warning_msg "$(eval_gettext "Unable to retrieve the selected Arch News (HTTP error response or request timeout)\nPlease, read the selected Arch News at \${news_url} before updating your system")"
 					else
 						news_author=$(echo "${news_content}" | htmlq -t .article-info | cut -f3- -d " ")
 						news_date=$(echo "${news_content}" | htmlq -t .article-info | cut -f1 -d " ")

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -355,7 +355,7 @@ list_packages() {
 # Definition of the list_news function: Display the latest Arch news and offers to read them
 list_news() {
 	info_msg "$(eval_gettext "Looking for recent Arch News...")"
-	news=$(curl -m 30 -Ls https://www.archlinux.org/news || echo "timeout")
+	news=$(curl -m 30 -Lfs https://www.archlinux.org/news || echo "timeout")
 
 	if [ "${news}" == "timeout" ]; then
 		echo
@@ -418,7 +418,7 @@ list_news() {
 					news_selected=$(sed -n "${num}"p <<< "${news_titles}")
 					news_path=$(echo "${news_selected}" | sed s/\ -//g | sed s/\ /-/g | sed s/[.]//g | sed s/=//g | sed s/\>//g | sed s/\<//g | sed s/\`//g | sed s/://g | sed s/+//g | sed s/[[]//g | sed s/]//g | sed s/,//g | sed s/\(//g | sed s/\)//g | sed s/[/]//g | sed s/@//g | sed s/\'//g | sed s/--/-/g | awk '{print tolower($0)}')
 					news_url="https://www.archlinux.org/news/${news_path}"
-					news_content=$(curl -m 30 -Ls "${news_url}" || echo "timeout")
+					news_content=$(curl -m 30 -Lfs "${news_url}" || echo "timeout")
 
 					if [ "${news_content}" == "timeout" ]; then
 						echo


### PR DESCRIPTION
### Description

This commit makes curl fail on http server errors response (e.g. archlinux.org is down or under huge loads, responding http error code 504, 502, etc...).  
This is to prevent getting wrongly formatted news list in such scenarios, resulting in an unexpected error and incorrectly formatted news display.

### Screenshots / Logs

```
==> Arch News:
/usr/bin/arch-update: line 388: [: : integer expression expected
1 - 
```