### PR TITLE
Ask to reboot before restarting the services

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -29,8 +29,8 @@ Fonctionnalités :
 - Vérification et listing automatiques des paquets orphelins et propose de les supprimer.
 - Vérification automatique de la présence d'anciens paquets et/ou paquets désinstallés dans le cache et propose de les supprimer.
 - Listing et aide au traitement des fichiers pacnew/pacsave.
-- Vérification automatique des services nécessitant un redémarrage après mise à jour et propose de les redémarrer s'il y en a.
 - Vérification automatique des mises à jour du noyau en attente nécessitant un redémarrage et propose de redémarrer s'il y en a une.
+- Vérification automatique des services nécessitant un redémarrage après mise à jour et propose de les redémarrer s'il y en a.
 - Support de `sudo`, `doas` et `run0`.
 - Prise en charge optionnelle des paquets AUR (via `yay` ou `paru`).
 - Prise en charge optionnelle des paquets Flatpak.
@@ -155,7 +155,8 @@ Afficher la liste des paquets disponibles pour mise à jour, puis demander la co
 pour procéder à l'installation.
 Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news.
 Après la mise à jour, vérification de la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache,
-de fichiers pacnew/pacsave et de mise à jour du noyau en attente et, s'il y en a, propose de les traiter.
+de fichiers pacnew/pacsave, de mise à jour du noyau en attente ainsi que des services nécessitant un redémarrage après mise à jour
+et, s'il y en a, propose de les traiter.
 
 Options :
 -c, --check       Vérifier les mises à jour disponibles, changer l'icône systray et envoyer une notification de bureau contenant le nombre de mises à jour disponibles (s'il y a des nouvelles mises à jour disponibles depuis le dernier check)

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Features:
 - Automatic check and listing of orphan packages and offers to remove them.
 - Automatic check for old and/or uninstalled cached packages and offers to remove them.
 - Lists and helps you processing pacnew/pacsave files.
-- Automatic check for services requiring a post upgrade restart and offers to do so if there are.
 - Automatic check for pending kernel updates requiring a reboot to be applied and offers to do so if there's one.
+- Automatic check for services requiring a post upgrade restart and offers to do so if there are.
 - Support for `sudo`, `doas` & `run0`.
 - Optional support for AUR packages (through `yay` or `paru`).
 - Optional support for Flatpak packages.
@@ -154,8 +154,9 @@ Run arch-update to perform the main "update" function:
 Display the list of packages available for update, then ask for the user's confirmation
 to proceed with the installation.
 Before performing the update, offer to display the latest Arch Linux news.
-Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files
-and pending kernel update and, if there are, offers to process them.
+Post update, check for orphan/unused packages, old cached packages, pacnew/pacsave files,
+pending kernel update, as well as services requiring a post upgrade restart and, if there are,
+offers to process them.
 
 Options:
 -c, --check       Check for available updates, change the systray icon and send a desktop notification containing the number of available updates (if there are new available updates compared to the last check)

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "July 2024" "Arch-Update 2.3.1" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "August 2024" "Arch-Update 2.3.1" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
@@ -20,7 +20,7 @@ If no option is passed, launch the relevant series of functions to perform a com
 .br
 Before performing the update, it offers to display the latest Arch Linux news to the user. By default, Arch news are only displayed if at least a new one has been published since the last run. Arch news published since the last run or at the same date are tagged as '[NEW]'.
 .br
-Arch-Update also checks for orphan packages, unused Flatpak packages, old and/or uninstalled cached packages in pacman's cache, pacnew/pacsave files, services requiring a post upgrade restart as well as pending kernel update requiring a reboot to be applied and, if there are, offers to process them.
+Arch-Update also checks for orphan packages, unused Flatpak packages, old and/or uninstalled cached packages in pacman's cache, pacnew/pacsave files, pending kernel update requiring a reboot to be applied as well as services requiring a post upgrade restart and, if there are, offers to process them.
 .br
 Those functions are launched when you click on the systray applet.
 

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -20,7 +20,7 @@ Si aucune option n'est passée, lance la série de fonctions adéquates pour eff
 .br
 Avant d'effectuer la mise à jour, propose d'afficher les dernières Arch news à l'utilisateur. Par défaut, les Arch news sont seulement affichées si au moins une nouvelle news a été publiée depuis la dernière exécution. Les Arch news publiées depuis la dernière exécution ou à la même date sont étiquetées comme '[NOUVEAU]'.
 .br
-Arch-Update vérifie aussi la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache, de fichiers pacnew/pacsave, de services nécessitant un redémarrage après mise à jour, ainsi que les mises à jour du noyau en attente et, s'il y en a, propose de les traiter.
+Arch-Update vérifie aussi la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache, de fichiers pacnew/pacsave, les mises à jour du noyau en attente ainsi que les services nécessitant un redémarrage après mise à jour et, s'il y en a, propose de les traiter.
 .br
 Ces fonctions sont lancées quand vous cliquez sur l'applet systray.
 

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "Juillet 2024" "Arch-Update 2.3.1" "Manuel de Arch-Update"
+.TH "ARCH-UPDATE" "1" "Août 2024" "Arch-Update 2.3.1" "Manuel de Arch-Update"
 
 .SH NAME
 arch-update \- Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour.

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -78,8 +78,8 @@ msgstr ""
 #, sh-format
 msgid ""
 "Post update, it checks for orphan/unused packages, old cached packages, "
-"pacnew/pacsave files, services requiring a post upgrade restart as well as "
-"pending kernel update and, if there are, offers to process them."
+"pacnew/pacsave files, pending kernel update as well as services requiring a "
+"post upgrade restart and, if there are, offers to process them."
 msgstr ""
 
 #: src/script/arch-update.sh:204

--- a/po/fr.po
+++ b/po/fr.po
@@ -86,12 +86,12 @@ msgstr ""
 #, sh-format
 msgid ""
 "Post update, it checks for orphan/unused packages, old cached packages, "
-"pacnew/pacsave files, services requiring a post upgrade restart as well as "
-"pending kernel update and, if there are, offers to process them."
+"pacnew/pacsave files, pending kernel update as well as services requiring a "
+"post upgrade restart and, if there are, offers to process them."
 msgstr ""
 "Après la mise à jour, elle vérifie la présence de paquets orphelins/inutilisés, d'anciens paquets mis en cache, "
-"de fichiers pacnew/pacsave, de services nécessitant un redémarrage après mise à jour ainsi que "
-"les mises à jour du noyau en attente et, s'il y en a, propose de les traiter."
+"de fichiers pacnew/pacsave, les mises à jour du noyau en attente, ainsi que les services nécessitant un "
+"redémarrage d'après mise à jour et, s'il y en a, propose de les traiter."
 
 #: src/script/arch-update.sh:204
 #, sh-format

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -794,8 +794,8 @@ full_upgrade() {
 	orphan_packages
 	packages_cache
 	pacnew_files
-	restart_services
 	kernel_reboot
+	restart_services
 	quit_msg
 }
 

--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -199,7 +199,7 @@ $(eval_gettext "An update notifier/applier for Arch Linux that assists you with 
 $(eval_gettext "Run \${name} to perform the main 'update' function:")
 $(eval_gettext "Display the list of packages available for update, then ask for the user's confirmation to proceed with the installation.")
 $(eval_gettext "Before performing the update, it offers to display the latest Arch Linux news.")
-$(eval_gettext "Post update, it checks for orphan/unused packages, old cached packages, pacnew/pacsave files, services requiring a post upgrade restart as well as pending kernel update and, if there are, offers to process them.")
+$(eval_gettext "Post update, it checks for orphan/unused packages, old cached packages, pacnew/pacsave files, pending kernel update as well as services requiring a post upgrade restart and, if there are, offers to process them.")
 
 $(eval_gettext "Options:")
 $(eval_gettext "  -c, --check       Check for available updates, change the systray icon and send a desktop notification containing the number of available updates (if there are new available updates compared to the last check)")


### PR DESCRIPTION

<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

<!-- Describe your changes -->
Currently, when an update requires both to reboot and restart the services, it proposes first to restart the services and then to reboot.
If the reboot is proposed and accepted, then restarting the services is a useless operation.
I propose thus to propose the reboot before restarting the services.


### Addressed feature request

<!-- If this pull request is addressing an opened feature request, paste the corresponding issue URL below -->

Closes https://github.com/Antiz96/arch-update/issues/224
