### PR TITLE
doc: Add that Arch-Update follows usual system maintenance steps (as described in the Arch Wiki) in documentation

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -21,6 +21,8 @@
 Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour et qui inclut une applet systray cliquable pour une intégration facile avec n'importe quel panneau sur n'importe quel DE/WM.  
 Prise en charge optionnelle des paquets AUR/Flatpak et des notifications de bureau.
 
+Arch-Update est conçu pour suivre les étapes usuelles de maintenance du système, comme indiqué dans le [Arch Wiki](https://wiki.archlinux.org/title/System_maintenance).
+
 Fonctionnalités :
 
 - Inclut une applet systray cliquable qui change dynamiquement pour agir comme un notificateur/applicateur de mise à jour. Facile à intégrer avec n'importe quel panneau sur n'importe quel DE/WM.  

--- a/README-fr.md
+++ b/README-fr.md
@@ -21,7 +21,7 @@
 Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour et qui inclut une applet systray cliquable pour une intégration facile avec n'importe quel panneau sur n'importe quel DE/WM.  
 Prise en charge optionnelle des paquets AUR/Flatpak et des notifications de bureau.
 
-Arch-Update est conçu pour suivre les étapes usuelles de maintenance du système, comme indiqué dans le [Arch Wiki](https://wiki.archlinux.org/title/System_maintenance).
+Arch-Update est conçu pour suivre les étapes usuelles de maintenance du système, telles que décrites dans le [Arch Wiki](https://wiki.archlinux.org/title/System_maintenance).
 
 Fonctionnalités :
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a clickeable systray applet for an easy integration with any panel on any DE/WM.  
 Optional support for AUR/Flatpak packages and desktop notifications.
 
+Arch-Update is designed to follow usual system maintenance steps, as reported in the [Arch Wiki](https://wiki.archlinux.org/title/System_maintenance).
+
 Features:
 
 - Includes a clickeable systray applet that dynamically changes to act as an update notifier/applier. Easy to integrate with any panel on any DE/WM.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a clickeable systray applet for an easy integration with any panel on any DE/WM.  
 Optional support for AUR/Flatpak packages and desktop notifications.
 
-Arch-Update is designed to follow usual system maintenance steps, as reported in the [Arch Wiki](https://wiki.archlinux.org/title/System_maintenance).
+Arch-Update is designed to follow usual system maintenance steps, as described in the [Arch Wiki](https://wiki.archlinux.org/title/System_maintenance).
 
 Features:
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "August 2024" "Arch-Update 2.3.2" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "September 2024" "Arch-Update 2.3.2" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier/applier for Arch Linux that assists you with important pre/post update tasks. 
@@ -11,6 +11,8 @@ arch-update \- An update notifier/applier for Arch Linux that assists you with i
 An update notifier/applier for Arch Linux that assists you with important pre/post update tasks and that includes a clickeable systray applet for an easy integration with any panel on any DE/WM.
 .br
 .RB "Optional support for AUR packages update (through " "yay " "or " "paru" "), Flatpak packages update (through " "flatpak" ") and desktop notifications (through " "libnotify" ")."
+.br
+Arch-Update is designed to follow usual system maintenance steps, as reported in the Arch Wiki (https://wiki.archlinux.org/title/System_maintenance).
 
 .SH OPTIONS
 .PP

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -12,7 +12,7 @@ An update notifier/applier for Arch Linux that assists you with important pre/po
 .br
 .RB "Optional support for AUR packages update (through " "yay " "or " "paru" "), Flatpak packages update (through " "flatpak" ") and desktop notifications (through " "libnotify" ")."
 .br
-Arch-Update is designed to follow usual system maintenance steps, as reported in the Arch Wiki (https://wiki.archlinux.org/title/System_maintenance).
+Arch-Update is designed to follow usual system maintenance steps, as described in the Arch Wiki at https://wiki.archlinux.org/title/System_maintenance.
 
 .SH OPTIONS
 .PP

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "Août 2024" "Arch-Update 2.3.2" "Manuel de Arch-Update"
+.TH "ARCH-UPDATE" "1" "Septembre 2024" "Arch-Update 2.3.2" "Manuel de Arch-Update"
 
 .SH NAME
 arch-update \- Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour.
@@ -11,6 +11,8 @@ arch-update \- Un notificateur/applicateur de mises à jour pour Arch Linux qui 
 Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant/après mise à jour et qui inclut une applet systray cliquable pour une intégration facile avec n'importe quel panneau sur n'importe quel DE/WM.
 .br
 .RB "Prise en charge optionnelle des mises à jour des paquets AUR (via " "yay " "or " "paru" "), des mises à jour des paquets Flatpak (via " "flatpak" ") et des notifications de bureau (via " "libnotify" ")."
+.br
+Arch-Update est conçu pour suivre les étapes usuelles de maintenance du système, comme indiqué dans le Arch Wiki (https://wiki.archlinux.org/title/System_maintenance).
 
 .SH OPTIONS
 .PP

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -12,7 +12,7 @@ Un notificateur/applicateur de mises à jour pour Arch Linux qui vous assiste da
 .br
 .RB "Prise en charge optionnelle des mises à jour des paquets AUR (via " "yay " "or " "paru" "), des mises à jour des paquets Flatpak (via " "flatpak" ") et des notifications de bureau (via " "libnotify" ")."
 .br
-Arch-Update est conçu pour suivre les étapes usuelles de maintenance du système, comme indiqué dans le Arch Wiki (https://wiki.archlinux.org/title/System_maintenance).
+Arch-Update est conçu pour suivre les étapes usuelles de maintenance du système, telles que décrites dans le Arch Wiki à https://wiki.archlinux.org/title/System_maintenance.
 
 .SH OPTIONS
 .PP


### PR DESCRIPTION
### Description

As a precision and justification of the project's overall design, add that Arch-Update follows usual system maintenance steps, as described in the Arch Wiki at https://wiki.archlinux.org/title/System_maintenance.