### PR TITLE
fix: Fix dates parsing on news listing/displaying

### DIFF
--- a/src/script/arch-update.sh
+++ b/src/script/arch-update.sh
@@ -378,7 +378,7 @@ list_news() {
 	
 		if [ -n "${show_news}" ]; then
 			news_titles=$(echo "${news}" | htmlq -a title a | grep ^"View:" | sed "s/View:\ //g" | head -"${news_num}")
-			mapfile -t news_dates < <(echo "${news}" | htmlq td | grep -v "class" | grep "[0-9]" | sed "s/<[^>]*>//g" | head -"${news_num}" | xargs -I{} date -d "{}" "+%s")
+			mapfile -t news_dates < <(echo "${news}" | htmlq td | grep -v "class" | grep "[0-9]" | sed "s/<[^>]*>//g" | sed "s/\.//g" | head -"${news_num}" | xargs -I{} date -d "{}" "+%s")
 	
 			echo
 			main_msg "$(eval_gettext "Arch News:")"
@@ -424,8 +424,8 @@ list_news() {
 						echo
 						warning_msg "$(eval_gettext "Unable to retrieve the selected Arch News (HTTP error response or request timeout)\nPlease, read the selected Arch News at \${news_url} before updating your system")"
 					else
-						news_author=$(echo "${news_content}" | htmlq -t .article-info | cut -f3- -d " ")
-						news_date=$(echo "${news_content}" | htmlq -t .article-info | cut -f1 -d " ")
+						news_author=$(echo "${news_content}" | htmlq -t .article-info | cut -f5- -d " ")
+						news_date=$(echo "${news_content}" | htmlq -t .article-info | cut -f1,2,3 -d " ")
 						news_article=$(echo "${news_content}" | htmlq -t .article-content)
 						title_tag="$(eval_gettext "Title:")"
 						author_tag="$(eval_gettext "Author:")"


### PR DESCRIPTION
### Description

Archweb recently switched date format from `01-01-2024` to `Jan. 01, 2024`, breaking the date parsing during the Arch news listing/displaying. This commit updates the date parsing accordingly to fix the "invalid date" error during the news listing and the incorrect "Author/Date" fields when displaying a news.

### Screenshots / Logs

Before: 

![2024-09-15_18-44](https://github.com/user-attachments/assets/344d5137-dd3d-4d3e-a7d2-2476825f0bd4)

After:

![2024-09-15_18-45](https://github.com/user-attachments/assets/b8dda57d-2a2b-46f5-af5e-76f1a90939fe)