### PR TITLE
feat: Add the "AURHelper" option in arch-update.conf

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -212,8 +212,9 @@ Les options prises en charge sont :
 - NewsNum=[Num] # Nombre de Arch news à affcher avant la mise à jour et avec l'option `-n/--news` (voir la page de manuel arch-update(1) pour plus de details). La valeur par défaut est 5.
 - KeepOldPackages=[Num] # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
 - KeepUninstalledPackages=[Num] # Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
-- PrivilegeElevationCommand=[Cmd] # Commande à utiliser pour l'élévation de privilège. Les options valides sont `sudo`, `doas` ou `run0`. Si cette option n'est pas spécifiée, Arch-Update utilisera la première commande disponible dans l'odre suivant: `sudo`, `doas` puis `run0`.
+- PrivilegeElevationCommand=[Cmd] # Commande à utiliser pour l'élévation de privilège. Les options valides sont `sudo`, `doas` ou `run0`. Si cette option n'est pas spécifiée, Arch-Update utilisera la première commande disponible dans l'odre suivant : `sudo`, `doas` puis `run0`.
 - DiffProg=[Editeur] # Editeur à utiliser pour visualiser/editer les différences durant le traitement des fichiers pacnew. La valeur par défaut est la valeur de la variable d'environnement `$DIFFPROG` (ou `vimdiff` si `$DIFFPROG` n'est pas paramétrée). Notez qu'en raison de l'absence d'option pour préserver les variables d'environnement dans `doas`, cette option sera ignorée lors de l'utilisation de `doas` comme méthode d'élévation de privilèges.
+- AURHelper=[AUR Helper] # AUR helper à utiliser pour la prise en charge des paquets AUR. Les options valides sont `paru` ou `yay`. Si cette option n'est pas spécifiée, Arch-Update utilisera le premier AUR helper disponible dans l'ordre suivant : `paru` puis `yay` (si aucun des deux n'est installé, Arch-Update ne prendra pas en compte les paquets AUR).
 
 Les options sont sensibles à la casse, les majuscules doivent donc être respectées.
 ```

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The supported options are:
 - KeepUninstalledPackages=[Num] # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
 - PrivilegeElevationCommand=[Cmd] # Command to be used for privilege elevation. Valid options are `sudo`, `doas` or `run0`. If this option is not set, Arch-Update will use the first available command in the following order: `sudo`, `doas` then `run0`.
 - DiffProg=[Editor] # Editor to use to visualize/edit differences during the pacnew files processing. Defaults to the `$DIFFPROG` environment variable's value (or `vimdiff` if `$DIFFPROG` isn't set). Note that, due to the lack of option to preserve environment variable in `doas`, this option will be ignored when using `doas` as the privilege elevation method.
-- AURHelper=[AUR Helper] # AUR helper to be used for AUR packages support. Valid options are `paru` or `yay`. If this option is not set, Arch-Update will use the first available AUR Helper in the following order: `paru` then `yay` (in case none of them is installed, Arch-Update will not take AUR packages into account).
+- AURHelper=[AUR Helper] # AUR helper to be used for AUR packages support. Valid options are `paru` or `yay`. If this option is not set, Arch-Update will use the first available AUR helper in the following order: `paru` then `yay` (in case none of them is installed, Arch-Update will not take AUR packages into account).
 
 Options are case sensitive, so capital letters have to be respected.
 ```

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The supported options are:
 - KeepUninstalledPackages=[Num] # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
 - PrivilegeElevationCommand=[Cmd] # Command to be used for privilege elevation. Valid options are `sudo`, `doas` or `run0`. If this option is not set, Arch-Update will use the first available command in the following order: `sudo`, `doas` then `run0`.
 - DiffProg=[Editor] # Editor to use to visualize/edit differences during the pacnew files processing. Defaults to the `$DIFFPROG` environment variable's value (or `vimdiff` if `$DIFFPROG` isn't set). Note that, due to the lack of option to preserve environment variable in `doas`, this option will be ignored when using `doas` as the privilege elevation method.
+- AURHelper=[AUR Helper] # AUR helper to be used for AUR packages support. Valid options are `paru` or `yay`. If this option is not set, Arch-Update will use the first available AUR Helper in the following order: `paru` then `yay` (in case none of them is installed, Arch-Update will not take AUR packages into account).
 
 Options are case sensitive, so capital letters have to be respected.
 ```

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -53,7 +53,7 @@ Command to be used for privilege elevation. Valid options are sudo, doas or run0
 
 .TP
 .B AURHelper=[AUR Helper]
-AUR helper to be used for AUR packages support. Valid options are paru or yay. If this option is not set, Arch-Update will use the first installed AUR Helper in the following order: paru then yay (in case none of them is installed, Arch-Update will not take AUR packages into account).
+AUR helper to be used for AUR packages support. Valid options are paru or yay. If this option is not set, Arch-Update will use the first installed AUR helper in the following order: paru then yay (in case none of them is installed, Arch-Update will not take AUR packages into account).
 
 .SH SEE ALSO
 .BR arch-update (1)

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -51,6 +51,10 @@ Command to be used for privilege elevation. Valid options are sudo, doas or run0
 .B DiffProg=[Editor]
 .RB "Editor to use to visualize/edit differences during the pacnew files processing. Defaults to the " "$DIFFPROG " "environment variable's value (or " "vimdiff " "if " "$DIFFPROG " "isn't set). Note that, due to the lack of option to preserve environment variable in " "doas " ", this option will be ignored when using " "doas " " as the privilege elevation method."
 
+.TP
+.B AURHelper=[AUR Helper]
+AUR helper to be used for AUR packages support. Valid options are paru or yay. If this option is not set, Arch-Update will use the first installed AUR Helper in the following order: paru then yay (in case none of them is installed, Arch-Update will not take AUR packages into account).
+
 .SH SEE ALSO
 .BR arch-update (1)
 

--- a/doc/man/fr/arch-update.conf.5
+++ b/doc/man/fr/arch-update.conf.5
@@ -51,6 +51,10 @@ Commande à utiliser pour l'élévation de privilège. Les options valides sont 
 .B DiffProg=[Editeur]
 .RB "Editeur à utiliser pour visualiser/editer les différences durant le traitement des fichiers pacnew. La valeur par défaut est la valeur de la variable d'environnement " "$DIFFPROG " "(ou " "vimdiff " "si " "$DIFFPROG " "n'est pas paramétrée). Notez qu'en raison de l'absence d'option pour préserver les variables d'environnement dans " "doas " ", cette option sera ignorée lors de l'utilisation de " "doas " "comme méthode d'élévation de privilèges."
 
+.TP
+.B AURHelper=[AUR Helper]
+AUR helper à utiliser pour la prise en charge des paquets AUR. Les options valides sont paru ou yay. Si cette option n'est pas spécifiée, Arch-Update utilisera le premier AUR helper disponible dans l'ordre suivant : paru puis yay (si aucun des deux n'est installé, Arch-Update ne prendra pas en compte les paquets AUR).
+
 .SH VOIR AUSSI
 .BR arch-update (1)
 

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -26,32 +26,39 @@ msgstr ""
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/lib/common.sh:78
+#: src/lib/common.sh:19
+#, sh-format
+msgid ""
+"The ${aur_helper} AUR helper set for AUR packages support in the arch-update."
+"conf configuration file is not found\\n"
+msgstr ""
+
+#: src/lib/common.sh:76
 #, sh-format
 msgid "WARNING"
 msgstr ""
 
-#: src/lib/common.sh:84
+#: src/lib/common.sh:82
 #, sh-format
 msgid "ERROR"
 msgstr ""
 
-#: src/lib/common.sh:89
+#: src/lib/common.sh:87
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/lib/common.sh:95
+#: src/lib/common.sh:93
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/lib/common.sh:108
+#: src/lib/common.sh:106
 #, sh-format
 msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
 msgstr ""
 
-#: src/lib/common.sh:113
+#: src/lib/common.sh:111
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the arch-update.conf "

--- a/po/fr.po
+++ b/po/fr.po
@@ -26,32 +26,41 @@ msgstr "${update_number} mise à jour disponible"
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/lib/common.sh:78
+#: src/lib/common.sh:19
+#, sh-format
+msgid ""
+"The ${aur_helper} AUR helper set for AUR packages support in the arch-update."
+"conf configuration file is not found\\n"
+msgstr ""
+"Le AUR helper ${aur_helper} définie pour le support des paquets AUR dans le fichier de configuration " 
+"arch-update.conf n'est pas disponible\\n" 
+
+#: src/lib/common.sh:76
 #, sh-format
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
-#: src/lib/common.sh:84
+#: src/lib/common.sh:82
 #, sh-format
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: src/lib/common.sh:89
+#: src/lib/common.sh:87
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/lib/common.sh:95
+#: src/lib/common.sh:93
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Appuyez sur \"entrée\" pour quitter "
 
-#: src/lib/common.sh:108
+#: src/lib/common.sh:106
 #, sh-format
 msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
 msgstr "Une commande d'élévation de privilège est requise (sudo, doas ou run0)\\n"
 
-#: src/lib/common.sh:113
+#: src/lib/common.sh:111
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the arch-update.conf "

--- a/res/config/arch-update.conf.example
+++ b/res/config/arch-update.conf.example
@@ -10,3 +10,4 @@
 #KeepUninstalledPackages=0
 #PrivilegeElevationCommand=sudo
 #DiffProg=$DIFFPROG
+#AURHelper=paru

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -4,30 +4,6 @@
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Definition of the AUR helper to use (depending on if/which one is installed on the system and if it's not already defined in arch-update.conf) for the optional AUR packages support
-# shellcheck disable=SC2034
-if [ -z "${aur_helper}" ]; then
-	if command -v paru > /dev/null; then
-		# shellcheck disable=SC2034
-		aur_helper="paru"
-	elif command -v yay > /dev/null; then
-		# shellcheck disable=SC2034
-		aur_helper="yay"
-	fi
-else
-	if ! command -v "${aur_helper}" > /dev/null; then
-		warning_msg "$(eval_gettext "The \${aur_helper} AUR helper set for AUR packages support in the arch-update.conf configuration file is not found\n")"
-	fi
-fi
-
-# Check if flatpak is installed for the optional Flatpak support
-# shellcheck disable=SC2034
-flatpak=$(command -v flatpak)
-
-# Check if notify-send is installed for the optional desktop notification support
-# shellcheck disable=SC2034
-notif=$(command -v notify-send)
-
 # Definition of the colors for the colorized output
 if [ -z "${no_color}" ]; then
 	bold="\e[1m"
@@ -93,6 +69,30 @@ quit_msg() {
 	msg="$(eval_gettext "Press \"enter\" to quit ")"
 	read -n 1 -r -s -p $"$(info_msg "${msg}")" && echo
 }
+
+# Definition of the AUR helper to use (depending on if/which one is installed on the system and if it's not already defined in arch-update.conf) for the optional AUR packages support
+# shellcheck disable=SC2034
+if [ -z "${aur_helper}" ]; then
+	if command -v paru > /dev/null; then
+		# shellcheck disable=SC2034
+		aur_helper="paru"
+	elif command -v yay > /dev/null; then
+		# shellcheck disable=SC2034
+		aur_helper="yay"
+	fi
+else
+	if ! command -v "${aur_helper}" > /dev/null; then
+		warning_msg "$(eval_gettext "The \${aur_helper} AUR helper set for AUR packages support in the arch-update.conf configuration file is not found\n")"
+	fi
+fi
+
+# Check if flatpak is installed for the optional Flatpak support
+# shellcheck disable=SC2034
+flatpak=$(command -v flatpak)
+
+# Check if notify-send is installed for the optional desktop notification support
+# shellcheck disable=SC2034
+notif=$(command -v notify-send)
 
 # Definition of the elevation command to use (depending on which one is installed on the system and if it's not already defined in arch-update.conf)
 if [ -z "${su_cmd}" ]; then

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -83,6 +83,7 @@ if [ -z "${aur_helper}" ]; then
 else
 	if ! command -v "${aur_helper}" > /dev/null; then
 		warning_msg "$(eval_gettext "The \${aur_helper} AUR helper set for AUR packages support in the arch-update.conf configuration file is not found\n")"
+		unset aur_helper
 	fi
 fi
 

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -4,13 +4,20 @@
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Definition of the AUR helper to use (depending on if/which one is installed on the system) for the optional AUR packages support
-if command -v paru > /dev/null; then
-	# shellcheck disable=SC2034
-	aur_helper="paru"
-elif command -v yay > /dev/null; then
-	# shellcheck disable=SC2034
-	aur_helper="yay"
+# Definition of the AUR helper to use (depending on if/which one is installed on the system and if it's not already defined in arch-update.conf) for the optional AUR packages support
+# shellcheck disable=SC2034
+if [ -z "${aur_helper}" ]; then
+	if command -v paru > /dev/null; then
+		# shellcheck disable=SC2034
+		aur_helper="paru"
+	elif command -v yay > /dev/null; then
+		# shellcheck disable=SC2034
+		aur_helper="yay"
+	fi
+else
+	if ! command -v "${aur_helper}" > /dev/null; then
+		warning_msg "$(eval_gettext "The \${aur_helper} AUR helper set for AUR packages support in the arch-update.conf configuration file is not found\n")"
+	fi
 fi
 
 # Check if flatpak is installed for the optional Flatpak support
@@ -20,15 +27,6 @@ flatpak=$(command -v flatpak)
 # Check if notify-send is installed for the optional desktop notification support
 # shellcheck disable=SC2034
 notif=$(command -v notify-send)
-
-# Definition of the diff program to use (if it is set in the arch-update.conf configuration file)
-if [ -n "${diff_prog}" ]; then
-	if [ "${su_cmd}" == "sudo" ]; then
-		diff_prog_opt=("DIFFPROG=${diff_prog}")
-	elif [ "${su_cmd}" == "run0" ]; then
-		diff_prog_opt+=("--setenv=DIFFPROG=${diff_prog}")
-	fi
-fi
 
 # Definition of the colors for the colorized output
 if [ -z "${no_color}" ]; then
@@ -112,6 +110,15 @@ else
 	if ! command -v "${su_cmd}" > /dev/null; then
 		error_msg "$(eval_gettext "The \${su_cmd} command set for privilege escalation in the arch-update.conf configuration file is not found\n")" && quit_msg
 		exit 2
+	fi
+fi
+
+# Definition of the diff program to use (if it is set in the arch-update.conf configuration file)
+if [ -n "${diff_prog}" ]; then
+	if [ "${su_cmd}" == "sudo" ]; then
+		diff_prog_opt=("DIFFPROG=${diff_prog}")
+	elif [ "${su_cmd}" == "run0" ]; then
+		diff_prog_opt+=("--setenv=DIFFPROG=${diff_prog}")
 	fi
 fi
 

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -91,3 +91,8 @@ if grep -Eq '^[[:space:]]*DiffProg[[:space:]]*=[[:space:]]*[^[:space:]].*[[:spac
 	# shellcheck disable=SC2034
 	diff_prog=$(grep -E '^[[:space:]]*DiffProg[[:space:]]*=[[:space:]]*[^[:space:]].*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 fi
+
+if grep -Eq '^[[:space:]]*AURHelper[[:space:]]*=[[:space:]]*(paru|yay)[[:space:]]*$' "${config_file}" 2> /dev/null; then
+	# shellcheck disable=SC2034
+	aur_helper=$(grep -E '^[[:space:]]*AURHelper[[:space:]]*=[[:space:]]*(paru|yay)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
+fi


### PR DESCRIPTION
### Description

Add the `AURHelper` option in the `arch-update.conf` configuration file to explicitly set which AUR helper to use for the optional AUR packages support.

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/231
