### PR TITLE
chore: Add simple unit tests to check basic functions with `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ _pkgname=Arch-Update
 
 PREFIX ?= /usr/local
 
-.PHONY: all install uninstall
+.PHONY: all install test uninstall
 
 all:
 
@@ -95,5 +95,5 @@ uninstall:
 	rm -rf "${DESTDIR}${PREFIX}/share/doc/${pkgname}/"
 
 test:
-	# Run the help function of the main script as a simple test
-	"src/script/${pkgname}.sh" --help
+	# Run some simple unit tests on basic functions
+	bats test/case/basic_functions.bats

--- a/README-fr.md
+++ b/README-fr.md
@@ -70,7 +70,7 @@ Pour installer `arch-update`, allez dans le répertoire extrait/cloné et exécu
 sudo make install
 ```
 
-Si vous voulez exécuter des tests unitaires simples, vous pouvez exécuter la commande suivante (requiert l'installation de [bats](https://archlinux.org/packages/extra/any/bats/)) :
+Si vous voulez exécuter des tests unitaires simples, vous pouvez exécuter la commande suivante (requiert [bats](https://archlinux.org/packages/extra/any/bats/)) :
 
 ```bash
 make test

--- a/README-fr.md
+++ b/README-fr.md
@@ -70,7 +70,7 @@ Pour installer `arch-update`, allez dans le répertoire extrait/cloné et exécu
 sudo make install
 ```
 
-Si vous voulez exécuter des tests unitaires simples, vous pouvez exécuter la commande suivante (requiert l'installation de [bats](https://archlinux.org/packages/extra/any/bats/) :
+Si vous voulez exécuter des tests unitaires simples, vous pouvez exécuter la commande suivante (requiert l'installation de [bats](https://archlinux.org/packages/extra/any/bats/)) :
 
 ```bash
 make test

--- a/README-fr.md
+++ b/README-fr.md
@@ -70,6 +70,12 @@ Pour installer `arch-update`, allez dans le répertoire extrait/cloné et exécu
 sudo make install
 ```
 
+Si vous voulez exécuter des tests unitaires simples, vous pouvez exécuter la commande suivante (requiert l'installation de [bats](https://archlinux.org/packages/extra/any/bats/) :
+
+```bash
+make test
+```
+
 Pour désinstaller `arch-update`, allez dans le répertoire extrait/cloné et exécutez la commande suivante :
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ To install `arch-update`, go into the extracted/cloned directory and run the fol
 sudo make install
 ```
 
+If you want to run simple unit tests, you can run the following command (requires [bats](https://archlinux.org/packages/extra/any/bats/) to be installed):
+
+```bash
+make test
+```
+
 To uninstall `arch-update`, go into the extracted/cloned directory and run the following command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To install `arch-update`, go into the extracted/cloned directory and run the fol
 sudo make install
 ```
 
-If you want to run simple unit tests, you can run the following command (requires [bats](https://archlinux.org/packages/extra/any/bats/) to be installed):
+If you want to run simple unit tests, you can run the following command (requires [bats](https://archlinux.org/packages/extra/any/bats/)):
 
 ```bash
 make test

--- a/src/arch-update.sh
+++ b/src/arch-update.sh
@@ -11,7 +11,9 @@ version="2.3.3"
 option="${1}"
 
 # Define the directory containing libraries
-if [ -d "${XDG_DATA_HOME}/${name}/lib" ]; then
+if [ -n "${TEST_LIBDIR}" ]; then # Used in bats test cases for `make test`
+	libdir="${TEST_LIBDIR}"
+elif [ -d "${XDG_DATA_HOME}/${name}/lib" ]; then
         libdir="${XDG_DATA_HOME}/${name}/lib"
 elif [ -d "${HOME}/.local/share/${name}/lib" ]; then
         libdir="${HOME}/.local/share/${name}/lib"

--- a/test/case/basic_functions.bats
+++ b/test/case/basic_functions.bats
@@ -1,0 +1,9 @@
+export TEST_LIBDIR="${PWD}/src/lib"
+
+@test "version" {
+	src/arch-update.sh --version
+}
+
+@test "help" {
+	src/arch-update.sh --help
+}


### PR DESCRIPTION
### Description

Tests are executed with `bats`.
Currently it checks the "version" and "help" function (this notably verifies that libraries are correctly sourced and called from the main script).

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/234
