### PR TITLE
fix: Add fakeroot as an explicit dependency

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -50,7 +50,7 @@ Consultez également la liste des dépendances optionnelles (disponible dans la 
 Installez les dépendances requises :
 
 ```bash
-sudo pacman -S --needed pacman-contrib archlinux-contrib curl htmlq diffutils hicolor-icon-theme python python-pyqt6 qt6-svg glib2
+sudo pacman -S --needed pacman-contrib archlinux-contrib curl fakeroot htmlq diffutils hicolor-icon-theme python python-pyqt6 qt6-svg glib2
 ```
 
 Dépendances optionnelles supplémentaires dont vous pourriez avoir besoin ou que vous pourriez souhaiter :

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See also the list of optional dependencies (available in the ["from source"](#fr
 Install required dependencies:
 
 ```bash
-sudo pacman -S --needed pacman-contrib archlinux-contrib curl htmlq diffutils hicolor-icon-theme python python-pyqt6 qt6-svg glib2
+sudo pacman -S --needed pacman-contrib archlinux-contrib curl fakeroot htmlq diffutils hicolor-icon-theme python python-pyqt6 qt6-svg glib2
 ```
 
 Additional optional dependencies you might need or want:


### PR DESCRIPTION
### Description

fakeroot is now an optional dependency for pacman-contrib (and not a 'hard' dependency anymore). It is required for `checkupdates` and should now be declared as an explicit dependency for Arch-Update

### Screenshots / Logs

https://gitlab.archlinux.org/archlinux/packaging/packages/pacman-contrib/-/merge_requests/1

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/235