### PR TITLE
fix: Add the missing french translation on the "AUR helper not found" warning

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -26,39 +26,39 @@ msgstr ""
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/lib/common.sh:19
+#: src/lib/common.sh:52
+#, sh-format
+msgid "WARNING"
+msgstr ""
+
+#: src/lib/common.sh:58
+#, sh-format
+msgid "ERROR"
+msgstr ""
+
+#: src/lib/common.sh:63
+#, sh-format
+msgid "Press \"enter\" to continue "
+msgstr ""
+
+#: src/lib/common.sh:69
+#, sh-format
+msgid "Press \"enter\" to quit "
+msgstr ""
+
+#: src/lib/common.sh:85
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the arch-update."
 "conf configuration file is not found\\n"
 msgstr ""
 
-#: src/lib/common.sh:76
-#, sh-format
-msgid "WARNING"
-msgstr ""
-
-#: src/lib/common.sh:82
-#, sh-format
-msgid "ERROR"
-msgstr ""
-
-#: src/lib/common.sh:87
-#, sh-format
-msgid "Press \"enter\" to continue "
-msgstr ""
-
-#: src/lib/common.sh:93
-#, sh-format
-msgid "Press \"enter\" to quit "
-msgstr ""
-
-#: src/lib/common.sh:106
+#: src/lib/common.sh:107
 #, sh-format
 msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
 msgstr ""
 
-#: src/lib/common.sh:111
+#: src/lib/common.sh:112
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the arch-update.conf "

--- a/po/fr.po
+++ b/po/fr.po
@@ -26,41 +26,41 @@ msgstr "${update_number} mise à jour disponible"
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/lib/common.sh:19
+#: src/lib/common.sh:52
+#, sh-format
+msgid "WARNING"
+msgstr "AVERTISSEMENT"
+
+#: src/lib/common.sh:58
+#, sh-format
+msgid "ERROR"
+msgstr "ERREUR"
+
+#: src/lib/common.sh:63
+#, sh-format
+msgid "Press \"enter\" to continue "
+msgstr "Appuyez sur \"entrée\" pour continuer "
+
+#: src/lib/common.sh:69
+#, sh-format
+msgid "Press \"enter\" to quit "
+msgstr "Appuyez sur \"entrée\" pour quitter "
+
+#: src/lib/common.sh:85
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the arch-update."
 "conf configuration file is not found\\n"
 msgstr ""
-"Le AUR helper ${aur_helper} définie pour le support des paquets AUR dans le fichier de configuration " 
-"arch-update.conf n'est pas disponible\\n" 
+"Le AUR helper ${aur_helper} définie pour le support des paquets AUR dans le fichier de configuration "
+"arch-update.conf n'est pas disponible\\n"
 
-#: src/lib/common.sh:76
-#, sh-format
-msgid "WARNING"
-msgstr "AVERTISSEMENT"
-
-#: src/lib/common.sh:82
-#, sh-format
-msgid "ERROR"
-msgstr "ERREUR"
-
-#: src/lib/common.sh:87
-#, sh-format
-msgid "Press \"enter\" to continue "
-msgstr "Appuyez sur \"entrée\" pour continuer "
-
-#: src/lib/common.sh:93
-#, sh-format
-msgid "Press \"enter\" to quit "
-msgstr "Appuyez sur \"entrée\" pour quitter "
-
-#: src/lib/common.sh:106
+#: src/lib/common.sh:107
 #, sh-format
 msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
 msgstr "Une commande d'élévation de privilège est requise (sudo, doas ou run0)\\n"
 
-#: src/lib/common.sh:111
+#: src/lib/common.sh:112
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the arch-update.conf "

--- a/po/fr.po
+++ b/po/fr.po
@@ -52,7 +52,7 @@ msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the arch-update."
 "conf configuration file is not found\\n"
 msgstr ""
-"Le AUR helper ${aur_helper} définie pour le support des paquets AUR dans le fichier de configuration "
+"Le AUR helper ${aur_helper} défini pour le support des paquets AUR dans le fichier de configuration "
 "arch-update.conf n'est pas disponible\\n"
 
 #: src/lib/common.sh:107


### PR DESCRIPTION
### Description

The french translation hasn't been updated to reflect changes made in https://github.com/Antiz96/arch-update/commit/6a4bfe05914f7faab4d93475b99d2c81e41322c7, causing it to be missing.

### Screenshots

Before:

![2024-09-23_23-12](https://github.com/user-attachments/assets/04801927-ee6e-433c-94e7-6f270d6aa554)

After:

![2024-09-23_23-20](https://github.com/user-attachments/assets/bfa6f4f2-5631-46c3-8d1d-3c79091ceaca)

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/238
