### PR TITLE
chore: Rename "state" functions & file to "(tray) icon"

### DIFF
--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -21,7 +21,7 @@ if [ -n "${notif}" ]; then
 fi
 
 if [ -n "${update_available}" ]; then
-	state_updates_available
+	icon_updates-available
 
 	if [ -n "${notif}" ]; then
 		if ! diff "${statedir}/current_updates_check" "${statedir}/last_updates_check" &> /dev/null; then
@@ -47,7 +47,7 @@ if [ -n "${update_available}" ]; then
 		fi
 	fi
 else
-	state_up_to_date
+	icon_up-to-date
 fi
 
 if [ -f "${statedir}/current_updates_check" ]; then

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -123,13 +123,14 @@ if [ -n "${diff_prog}" ]; then
 	fi
 fi
 
-# Definition of the state_updates_available function: Change state to "updates-available"
-state_updates_available() {
+# Definition of the icon_up-to-date function: Change icon to "up to date"
+icon_up-to-date() {
 	# shellcheck disable=SC2154
-	echo "${name}_updates-available" > "${statedir}/current_state"
+	echo "${name}" > "${statedir}/tray_icon"
 }
 
-# Definition of the state_up_to_date function: Change state to "up to date"
-state_up_to_date() {
-	echo "${name}" > "${statedir}/current_state"
+# Definition of the icon_updates-available function: Change tray icon to "updates available"
+icon_updates-available() {
+	# shellcheck disable=SC2154
+	echo "${name}_updates-available" > "${statedir}/tray_icon"
 }

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -44,14 +44,14 @@ if [ -n "${flatpak_packages}" ]; then
 fi
 
 if [ -z "${packages}" ] && [ -z "${aur_packages}" ] && [ -z "${flatpak_packages}" ]; then
-	state_up_to_date
+	icon_up-to-date
 	info_msg "$(eval_gettext "No update available\n")"
 
 	if [ -n "${list_option}" ]; then
 		exit 7
 	fi
 else
-	state_updates_available
+	icon_updates-available
 	if [ -z "${list_option}" ]; then
 		ask_msg "$(eval_gettext "Proceed with update? [Y/n]")"
 

--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -17,16 +17,16 @@ from PyQt6.QtCore import QFileSystemWatcher
 # Create logger
 log = logging.getLogger(__name__)
 
-# Find Statefile
-STATE_FILE = None
+# Find Icon file
+ICON_FILE = None
 if 'XDG_STATE_HOME' in os.environ:
-    STATE_FILE = os.path.join(
-        os.environ['XDG_STATE_HOME'], 'arch-update', 'current_state')
+    ICON_FILE = os.path.join(
+        os.environ['XDG_STATE_HOME'], 'arch-update', 'tray_icon')
 elif 'HOME' in os.environ:
-    STATE_FILE = os.path.join(
-        os.environ['HOME'], '.local', 'state', 'arch-update', 'current_state')
-if not os.path.isfile(STATE_FILE):
-    log.error("Statefile does not exist: %s", STATE_FILE)
+    ICON_FILE = os.path.join(
+        os.environ['HOME'], '.local', 'state', 'arch-update', 'tray_icon')
+if not os.path.isfile(ICON_FILE):
+    log.error("Statefile does not exist: %s", ICON_FILE)
     sys.exit(1)
 
 # Find translations
@@ -79,13 +79,13 @@ class ArchUpdateQt6:
     """ System Tray using QT6 library """
 
     def file_changed(self):
-        """ Called when statefile contents change """
+        """ Called when icon file content changes """
 
         contents = ""
-        if self.watcher and not self.statefile in self.watcher.files():
-            self.watcher.addPath(self.statefile)
+        if self.watcher and not self.iconfile in self.watcher.files():
+            self.watcher.addPath(self.iconfile)
         try:
-            with open(self.statefile, encoding="utf-8") as f:
+            with open(self.iconfile, encoding="utf-8") as f:
                 contents = f.readline().strip()
         except FileNotFoundError:
             log.error("Statefile Missing")
@@ -102,10 +102,10 @@ class ArchUpdateQt6:
         """ Close systray process """
         sys.exit(0)
 
-    def __init__(self, statefile):
+    def __init__(self, iconfile):
         """ Start Qt6 System Tray """
 
-        self.statefile = statefile
+        self.iconfile = iconfile
         self.watcher = None
 
         # Application
@@ -131,11 +131,11 @@ class ArchUpdateQt6:
         self.tray.setContextMenu(menu)
 
         # File Watcher
-        self.watcher = QFileSystemWatcher([self.statefile])
+        self.watcher = QFileSystemWatcher([self.iconfile])
         self.watcher.fileChanged.connect(self.file_changed)
 
         app.exec()
 
 
 if __name__ == "__main__":
-    ArchUpdateQt6(STATE_FILE)
+    ArchUpdateQt6(ICON_FILE)

--- a/src/lib/tray.sh
+++ b/src/lib/tray.sh
@@ -33,8 +33,8 @@ if [ "${2}" == "--enable" ]; then
 	fi
 else
 	# shellcheck disable=SC2154
-	if [ ! -f "${statedir}/current_state" ]; then
-		state_up_to_date
+	if [ ! -f "${statedir}/tray_icon" ]; then
+		icon_up-to-date
 	fi
 
 	# shellcheck disable=SC2154

--- a/src/lib/update.sh
+++ b/src/lib/update.sh
@@ -10,7 +10,7 @@ if [ -n "${packages}" ]; then
 
 	# shellcheck disable=SC2154
 	if ! "${su_cmd}" pacman --color "${pacman_color_opt}" -Syu; then
-		state_updates_available
+		icon_updates-available
 		echo
 		error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
 		exit 5
@@ -25,7 +25,7 @@ if [ -n "${aur_packages}" ]; then
 
 	# shellcheck disable=SC2154
 	if ! "${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Syu; then
-		state_updates_available
+		icon_updates-available
 		echo
 		error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
 		exit 5
@@ -40,12 +40,12 @@ if [ -n "${flatpak_packages}" ]; then
 	main_msg "$(eval_gettext "Updating Flatpak Packages...\n")"
 
 	if ! flatpak update; then
-		state_updates_available
+		icon_updates-available
 		error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
 		exit 5
 	fi
 fi
 
-state_up_to_date
+icon_up-to-date
 echo
 info_msg "$(eval_gettext "The update has been applied\n")"


### PR DESCRIPTION
### Description

The "current_state" file and the related functions are in fact only used to determine which icon the systray applet should display (depending on the current state of the system). Recording the current state of the system (up to date/updates available) is not necessary for any other stages (not currently at least), so it makes sense adopting a more suited & precise name.