### PR TITLE
chore: Move example config to the XDG DATA directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,16 +52,18 @@ install:
 	rm -f "doc/man/fr/${pkgname}.1.gz"
 	rm -f "doc/man/fr/${pkgname}.conf.5.gz"
 
-	# Install documentation and examples
+	# Install documentation
 	install -Dm 644 README.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/README.md"
 	install -Dm 644 README-fr.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/fr/README.md"
-	install -Dm 644 "res/config/${pkgname}.conf.example" "${DESTDIR}${PREFIX}/share/doc/${pkgname}/${pkgname}.conf.example"
+
+	# Install example config
+	install -Dm 644 "res/config/${pkgname}.conf.example" "${DESTDIR}${PREFIX}/share/${pkgname}/config/${pkgname}.conf.example"
 
 uninstall:
 	# Delete main script
 	rm -f "${DESTDIR}${PREFIX}/bin/${pkgname}"
 
-	# Delete data folder (which stores libraries)
+	# Delete data folder (which stores libraries and example config)
 	rm -rf "${DESTDIR}${PREFIX}/share/${pkgname}/"
 
 	# Delete icons
@@ -91,7 +93,7 @@ uninstall:
 	rm -f "${DESTDIR}${PREFIX}/share/man/fr/man1/${pkgname}.1.gz"
 	rm -f "${DESTDIR}${PREFIX}/share/man/fr/man5/${pkgname}.conf.5.gz"
 
-	# Delete documentation and examples
+	# Delete documentation folder
 	rm -rf "${DESTDIR}${PREFIX}/share/doc/${pkgname}/"
 
 test:

--- a/src/lib/gen-config.sh
+++ b/src/lib/gen-config.sh
@@ -5,16 +5,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # shellcheck disable=SC2154
-if [ -f "${XDG_DATA_HOME}/doc/${name}/${name}.conf.example" ]; then
-	example_config_file="${XDG_DATA_HOME}/doc/${name}/${name}.conf.example"
-elif [ -f "${HOME}/.local/share/doc/${name}/${name}.conf.example" ]; then
-	example_config_file="${HOME}/.local/share/doc/${name}/${name}.conf.example"
-elif [ -f "${XDG_DATA_DIRS}/doc/${name}/${name}.conf.example" ]; then
-	example_config_file="${XDG_DATA_DIRS}/doc/${name}/${name}.conf.example"
-elif [ -f "/usr/local/share/doc/${name}/${name}.conf.example" ]; then
-	example_config_file="/usr/local/share/doc/${name}/${name}.conf.example"
-elif [ -f "/usr/share/doc/${name}/${name}.conf.example" ]; then
-	example_config_file="/usr/share/doc/${name}/${name}.conf.example"
+if [ -f "${XDG_DATA_HOME}/${name}/config/${name}.conf.example" ]; then
+	example_config_file="${XDG_DATA_HOME}/${name}/config/${name}.conf.example"
+elif [ -f "${HOME}/.local/share/${name}/config/${name}.conf.example" ]; then
+	example_config_file="${HOME}/.local/share/${name}/config/${name}.conf.example"
+elif [ -f "${XDG_DATA_DIRS}/${name}/config/${name}.conf.example" ]; then
+	example_config_file="${XDG_DATA_DIRS}/${name}/config/${name}.conf.example"
+elif [ -f "/usr/local/share/${name}/config/${name}.conf.example" ]; then
+	example_config_file="/usr/local/share/${name}/config/${name}.conf.example"
+elif [ -f "/usr/share/${name}/config/${name}.conf.example" ]; then
+	example_config_file="/usr/share/${name}/config/${name}.conf.example"
 else
 	error_msg "$(eval_gettext "Example configuration file not found")"
 	exit 8


### PR DESCRIPTION
### Description

Move the arch-update.conf.example configuration file to the DATA system (as defined by XDG base directory): `${PREFIX}/share/arch-update/config/`. According to standards, it makes more sense to have it there than in `${PREFIX}/share/doc/arch-update/`.