### PR TITLE
chore: Add `make test` to the CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Run pylint
         run: find . -name '*.py' -exec pylint -d E0611,E0401,C0103  --output-format=colorized {} +
+
+      - name: Run make test
+        run: make test


### PR DESCRIPTION
### Description

Add a `make test` stage to the CI GitHub action so `make test` is executed on pull request (to ensure the changes made are not breaking units tests).