### PR TITLE
chore: Streamline option checking in arch-update.conf

### DIFF
--- a/src/arch-update.sh
+++ b/src/arch-update.sh
@@ -28,11 +28,11 @@ else
 	exit 14
 fi
 
-# Source the "config" library which contains every configuration parameters, pre-steps and pre-verifications required for Arch-Update to work properly
+# Source the "config" library which checks options set in the arch-update.conf configuration file
 # shellcheck source=src/lib/config.sh
 source "${libdir}/config.sh"
 
-# Source the "common" library which contains variables and functions commonly used across Arch-Update stages
+# Source the "common" library which sets variables, functions and parameters commonly used across the various Arch-Update stages
 # shellcheck source=src/lib/common.sh
 source "${libdir}/common.sh"
 

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -1,8 +1,46 @@
 #!/bin/bash
 
-# common.sh: Set variables and functions commonly used across Arch-Update stages
+# common.sh: Set variables, functions and parameters commonly used across the various Arch-Update stages
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+# Display debug traces if the -D/--debug argument is passed
+for arg in "${@}"; do
+	case "${arg}" in
+		-D|--debug)
+			set -x
+		;;
+	esac
+done
+
+# Reset the option var if it is equal to -D/--debug (to avoid false negative "invalid option" error)
+# shellcheck disable=SC2154
+case "${option}" in
+	-D|--debug)
+		unset option
+	;;
+esac
+
+# Create state and tmp dirs if they don't exist
+# shellcheck disable=SC2154
+statedir="${XDG_STATE_HOME:-${HOME}/.local/state}/${name}"
+tmpdir="${TMPDIR:-/tmp}/${name}-${UID}"
+mkdir -p "${statedir}" "${tmpdir}"
+
+# Declare necessary parameters for translations
+# shellcheck disable=SC1091
+. gettext.sh
+# shellcheck disable=SC2154
+export TEXTDOMAIN="${_name}" # Using "Arch-Update" as TEXTDOMAIN to avoid conflicting with the "arch-update" TEXTDOMAIN used by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
+if [ -f "${XDG_DATA_HOME}/locale/fr/LC_MESSAGES/${_name}.mo" ]; then
+	export TEXTDOMAINDIR="${XDG_DATA_HOME}/locale"
+elif [ -f "${HOME}/.local/share/locale/fr/LC_MESSAGES/${_name}.mo" ]; then
+	export TEXTDOMAINDIR="${HOME}/.local/share/locale"
+elif [ -f "${XDG_DATA_DIRS}/locale/fr/LC_MESSAGES/${_name}.mo" ]; then
+	export TEXTDOMAINDIR="${XDG_DATA_DIRS}/locale"
+elif [ -f "/usr/local/share/locale/fr/LC_MESSAGES/${_name}.mo" ]; then
+	export TEXTDOMAINDIR="/usr/local/share/locale"
+fi
 
 # Definition of the colors for the colorized output
 if [ -z "${no_color}" ]; then

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -123,12 +123,7 @@ if [ -n "${diff_prog}" ]; then
 	fi
 fi
 
-# Definition of the tray icon style to use (default to "light" if it isn't set in the arch-update.conf configuration file)
-if [ -z "${tray_icon_style}" ]; then
-	tray_icon_style="light"
-fi
-
-# Definition of the icon_up-to-date function: Change icon to "up to date"
+# Definition of the icon_up-to-date function: Change tray icon to "up to date"
 icon_up-to-date() {
 	# shellcheck disable=SC2154
 	echo "${name}-${tray_icon_style}" > "${statedir}/tray_icon"

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -45,42 +45,45 @@ fi
 # Define the path to the arch-update.conf configuration file
 config_file="${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf"
 
-# Check the "NoColor" option in arch-update.conf
-# shellcheck disable=SC2034
-no_color=$(grep -Eq '^[[:space:]]*NoColor[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
+# Check options in the arch-update.conf configuration file if it exists
+if [ -f "${config_file}" ]; then
+	# Check the "NoColor" option in arch-update.conf
+	# shellcheck disable=SC2034
+	no_color=$(grep -Eq '^[[:space:]]*NoColor[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
 
-# Check the "NoVersion" option in arch-update.conf
-# shellcheck disable=SC2034
-no_version=$(grep -Eq '^[[:space:]]*NoVersion[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
+	# Check the "NoVersion" option in arch-update.conf
+	# shellcheck disable=SC2034
+	no_version=$(grep -Eq '^[[:space:]]*NoVersion[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
 
-# Check the "AlwaysShowNews" option in arch-update.conf
-# shellcheck disable=SC2034
-show_news=$(grep -Eq '^[[:space:]]*AlwaysShowNews[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
+	# Check the "AlwaysShowNews" option in arch-update.conf
+	# shellcheck disable=SC2034
+	show_news=$(grep -Eq '^[[:space:]]*AlwaysShowNews[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
 
-# Check the "NewsNum" option in arch-update.conf
-# shellcheck disable=SC2034
-news_num=$(grep -E '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "5")
+	# Check the "NewsNum" option in arch-update.conf
+	# shellcheck disable=SC2034
+	news_num=$(grep -E '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "5")
 
-# Check the "AURHelper" option in arch-update.conf
-# shellcheck disable=SC2034
-aur_helper=$(grep -E '^[[:space:]]*AURHelper[[:space:]]*=[[:space:]]*(paru|yay)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
+	# Check the "AURHelper" option in arch-update.conf
+	# shellcheck disable=SC2034
+	aur_helper=$(grep -E '^[[:space:]]*AURHelper[[:space:]]*=[[:space:]]*(paru|yay)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 
-# Check the "PrivilegeElevationCommand" option in arch-update.conf
-# shellcheck disable=SC2034
-su_cmd=$(grep -E '^[[:space:]]*PrivilegeElevationCommand[[:space:]]*=[[:space:]]*(sudo|doas|run0)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
+	# Check the "PrivilegeElevationCommand" option in arch-update.conf
+	# shellcheck disable=SC2034
+	su_cmd=$(grep -E '^[[:space:]]*PrivilegeElevationCommand[[:space:]]*=[[:space:]]*(sudo|doas|run0)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 
-# Check the "KeepOldPackages" option in arch-update.conf
-# shellcheck disable=SC2034
-old_packages_num=$(grep -E '^[[:space:]]*KeepOldPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "3")
+	# Check the "KeepOldPackages" option in arch-update.conf
+	# shellcheck disable=SC2034
+	old_packages_num=$(grep -E '^[[:space:]]*KeepOldPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "3")
 
-# Check the "KeepUninstalledPackages" option in arch-update.conf
-# shellcheck disable=SC2034
-uninstalled_packages_num=$(grep -E '^[[:space:]]*KeepUninstalledPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "0")
+	# Check the "KeepUninstalledPackages" option in arch-update.conf
+	# shellcheck disable=SC2034
+	uninstalled_packages_num=$(grep -E '^[[:space:]]*KeepUninstalledPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "0")
 
-# Check the "DiffProg" option in arch-update.conf
-# shellcheck disable=SC2034
-diff_prog=$(grep -E '^[[:space:]]*DiffProg[[:space:]]*=[[:space:]]*[^[:space:]].*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
+	# Check the "DiffProg" option in arch-update.conf
+	# shellcheck disable=SC2034
+	diff_prog=$(grep -E '^[[:space:]]*DiffProg[[:space:]]*=[[:space:]]*[^[:space:]].*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 
-# Check the "TrayIconStyle" option in arch-update.conf
-# shellcheck disable=SC2034
-tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(light|dark|blue)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "light")
+	# Check the "TrayIconStyle" option in arch-update.conf
+	# shellcheck disable=SC2034
+	tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(light|dark|blue)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "light")
+fi

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -46,68 +46,41 @@ fi
 config_file="${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf"
 
 # Check the "NoColor" option in arch-update.conf
-if grep -Eq '^[[:space:]]*NoColor[[:space:]]*$' "${config_file}" 2> /dev/null; then
-	# shellcheck disable=SC2034
-	no_color="y"
-fi
+# shellcheck disable=SC2034
+no_color=$(grep -Eq '^[[:space:]]*NoColor[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
 
 # Check the "NoVersion" option in arch-update.conf
-if grep -Eq '^[[:space:]]*NoVersion[[:space:]]*$' "${config_file}" 2> /dev/null; then
-	# shellcheck disable=SC2034
-	no_version="y"
-fi
+# shellcheck disable=SC2034
+no_version=$(grep -Eq '^[[:space:]]*NoVersion[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
 
 # Check the "AlwaysShowNews" option in arch-update.conf
-if grep -Eq '^[[:space:]]*AlwaysShowNews[[:space:]]*$' "${config_file}" 2> /dev/null; then
-	# shellcheck disable=SC2034
-	show_news="y"
-fi
+# shellcheck disable=SC2034
+show_news=$(grep -Eq '^[[:space:]]*AlwaysShowNews[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
 
 # Check the "NewsNum" option in arch-update.conf
-if grep -Eq '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${config_file}" 2> /dev/null; then
-	# shellcheck disable=SC2034
-	news_num=$(grep -E '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
-else
-	# shellcheck disable=SC2034
-	news_num="5"
-fi
+# shellcheck disable=SC2034
+news_num=$(grep -E '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "5")
 
 # Check the "AURHelper" option in arch-update.conf
-if grep -Eq '^[[:space:]]*AURHelper[[:space:]]*=[[:space:]]*(paru|yay)[[:space:]]*$' "${config_file}" 2> /dev/null; then
-	# shellcheck disable=SC2034
-	aur_helper=$(grep -E '^[[:space:]]*AURHelper[[:space:]]*=[[:space:]]*(paru|yay)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
-fi
+# shellcheck disable=SC2034
+aur_helper=$(grep -E '^[[:space:]]*AURHelper[[:space:]]*=[[:space:]]*(paru|yay)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 
 # Check the "PrivilegeElevationCommand" option in arch-update.conf
-if grep -Eq '^[[:space:]]*PrivilegeElevationCommand[[:space:]]*=[[:space:]]*(sudo|doas|run0)[[:space:]]*$' "${config_file}" 2> /dev/null; then
-	# shellcheck disable=SC2034
-	su_cmd=$(grep -E '^[[:space:]]*PrivilegeElevationCommand[[:space:]]*=[[:space:]]*(sudo|doas|run0)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
-fi
+# shellcheck disable=SC2034
+su_cmd=$(grep -E '^[[:space:]]*PrivilegeElevationCommand[[:space:]]*=[[:space:]]*(sudo|doas|run0)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 
 # Check the "KeepOldPackages" option in arch-update.conf
-if grep -Eq '^[[:space:]]*KeepOldPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null; then
-	old_packages_num=$(grep -E '^[[:space:]]*KeepOldPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
-else
-	# shellcheck disable=SC2034
-	old_packages_num="3"
-fi
+# shellcheck disable=SC2034
+old_packages_num=$(grep -E '^[[:space:]]*KeepOldPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "3")
 
 # Check the "KeepUninstalledPackages" option in arch-update.conf
-if grep -Eq '^[[:space:]]*KeepUninstalledPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null; then
-	uninstalled_packages_num=$(grep -E '^[[:space:]]*KeepUninstalledPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
-else
-	# shellcheck disable=SC2034
-	uninstalled_packages_num="0"
-fi
+# shellcheck disable=SC2034
+uninstalled_packages_num=$(grep -E '^[[:space:]]*KeepUninstalledPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "0")
 
 # Check the "DiffProg" option in arch-update.conf
-if grep -Eq '^[[:space:]]*DiffProg[[:space:]]*=[[:space:]]*[^[:space:]].*[[:space:]]*$' "${config_file}" 2> /dev/null; then
-	# shellcheck disable=SC2034
-	diff_prog=$(grep -E '^[[:space:]]*DiffProg[[:space:]]*=[[:space:]]*[^[:space:]].*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
-fi
+# shellcheck disable=SC2034
+diff_prog=$(grep -E '^[[:space:]]*DiffProg[[:space:]]*=[[:space:]]*[^[:space:]].*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 
 # Check the "TrayIconStyle" option in arch-update.conf
-if grep -Eq '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(light|dark|blue)[[:space:]]*$' "${config_file}" 2> /dev/null; then
-	# shellcheck disable=SC2034
-	tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(light|dark|blue)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
-fi
+# shellcheck disable=SC2034
+tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(light|dark|blue)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "light")

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Define the path to the arch-update.conf configuration file
+# shellcheck disable=SC2154
 config_file="${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf"
 
 # Check options in the arch-update.conf configuration file if it exists

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -1,46 +1,8 @@
 #!/bin/bash
 
-# config.sh: Set configuration parameters, pre-steps and pre-verifications required for Arch-Update to work properly
+# config.sh: Check options set in the arch-update.conf configuration file
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-# Display debug traces if the -D/--debug argument is passed
-for arg in "${@}"; do
-	case "${arg}" in
-		-D|--debug)
-			set -x
-		;;
-	esac
-done
-
-# Reset the option var if it is equal to -D/--debug (to avoid false negative "invalid option" error)
-# shellcheck disable=SC2154
-case "${option}" in
-	-D|--debug)
-		unset option
-	;;
-esac
-
-# Create state and tmp dirs if they don't exist
-# shellcheck disable=SC2154
-statedir="${XDG_STATE_HOME:-${HOME}/.local/state}/${name}"
-tmpdir="${TMPDIR:-/tmp}/${name}-${UID}"
-mkdir -p "${statedir}" "${tmpdir}"
-
-# Declare necessary parameters for translations
-# shellcheck disable=SC1091
-. gettext.sh
-# shellcheck disable=SC2154
-export TEXTDOMAIN="${_name}" # Using "Arch-Update" as TEXTDOMAIN to avoid conflicting with the "arch-update" TEXTDOMAIN used by the arch-update Gnome extension (https://extensions.gnome.org/extension/1010/archlinux-updates-indicator/)
-if [ -f "${XDG_DATA_HOME}/locale/fr/LC_MESSAGES/${_name}.mo" ]; then
-	export TEXTDOMAINDIR="${XDG_DATA_HOME}/locale"
-elif [ -f "${HOME}/.local/share/locale/fr/LC_MESSAGES/${_name}.mo" ]; then
-	export TEXTDOMAINDIR="${HOME}/.local/share/locale"
-elif [ -f "${XDG_DATA_DIRS}/locale/fr/LC_MESSAGES/${_name}.mo" ]; then
-	export TEXTDOMAINDIR="${XDG_DATA_DIRS}/locale"
-elif [ -f "/usr/local/share/locale/fr/LC_MESSAGES/${_name}.mo" ]; then
-	export TEXTDOMAINDIR="/usr/local/share/locale"
-fi
 
 # Define the path to the arch-update.conf configuration file
 config_file="${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf"
@@ -61,7 +23,7 @@ if [ -f "${config_file}" ]; then
 
 	# Check the "NewsNum" option in arch-update.conf
 	# shellcheck disable=SC2034
-	news_num=$(grep -E '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "5")
+	news_num=$(grep -E '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 
 	# Check the "AURHelper" option in arch-update.conf
 	# shellcheck disable=SC2034
@@ -73,11 +35,11 @@ if [ -f "${config_file}" ]; then
 
 	# Check the "KeepOldPackages" option in arch-update.conf
 	# shellcheck disable=SC2034
-	old_packages_num=$(grep -E '^[[:space:]]*KeepOldPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "3")
+	old_packages_num=$(grep -E '^[[:space:]]*KeepOldPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 
 	# Check the "KeepUninstalledPackages" option in arch-update.conf
 	# shellcheck disable=SC2034
-	uninstalled_packages_num=$(grep -E '^[[:space:]]*KeepUninstalledPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "0")
+	uninstalled_packages_num=$(grep -E '^[[:space:]]*KeepUninstalledPackages[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 
 	# Check the "DiffProg" option in arch-update.conf
 	# shellcheck disable=SC2034
@@ -85,5 +47,11 @@ if [ -f "${config_file}" ]; then
 
 	# Check the "TrayIconStyle" option in arch-update.conf
 	# shellcheck disable=SC2034
-	tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(light|dark|blue)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]' || echo "light")
+	tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(light|dark|blue)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 fi
+
+# Set the default/fallback value for options that require it (if the arch-update.conf configuration file doesn't exists, if the concerned option is commented or if the set value is invalid) 
+[ -z "${news_num}" ] && news_num="5"
+[ -z "${old_packages_num}" ] && old_packages_num="3"
+[ -z "${uninstalled_packages_num}" ] && uninstalled_packages_num="0"
+[ -z "${tray_icon_style}" ] && tray_icon_style="light"


### PR DESCRIPTION
### Description

Streamline option checking in the `arch-update.conf` configuration file by optimizing the way each option are checked and the way the related variables are set:

- `lib/config.sh` is now dedicated to checking options set in `arch-update.conf`
- Options are only checked if the `arch-update.conf` file is found/exists
- Values for the variables related to each options are now directly set with the output of `grep` (instead of running grep twice; once to check the validity of the set value and once to affiliate the value with the variable).