### PR TITLE
chore: Use "true" instead of "y" when setting variables

### DIFF
--- a/src/arch-update.sh
+++ b/src/arch-update.sh
@@ -58,7 +58,7 @@ case "${option}" in
 	;;
 	-l|--list)
 		# Set that the "-l/--list" option is used (required for the "list_packages" library to only print the list of packages available for update without asking for the user confirmation to apply them)
-		list_option="y"
+		list_option="true"
 
 		# Source the "list_packages" library which displays the list of packages available for updates
 		# shellcheck source=src/lib/list_packages.sh
@@ -66,8 +66,8 @@ case "${option}" in
 	;;
 	-n|--news)
 		# Set that news should be shown and that the "-n/--news" option is used (required for the "list_news" library to only print the list of recent Arch news without looking to continue with the update process)
-		show_news="y"
-		news_option="y"
+		show_news="true"
+		news_option="true"
 
 		# Check if the user specified a specific number of news to display
 		if [ "${2}" -gt 0 ] 2> /dev/null; then

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -12,15 +12,15 @@ config_file="${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/${name}.conf"
 if [ -f "${config_file}" ]; then
 	# Check the "NoColor" option in arch-update.conf
 	# shellcheck disable=SC2034
-	no_color=$(grep -Eq '^[[:space:]]*NoColor[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
+	no_color=$(grep -Eq '^[[:space:]]*NoColor[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
 
 	# Check the "NoVersion" option in arch-update.conf
 	# shellcheck disable=SC2034
-	no_version=$(grep -Eq '^[[:space:]]*NoVersion[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
+	no_version=$(grep -Eq '^[[:space:]]*NoVersion[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
 
 	# Check the "AlwaysShowNews" option in arch-update.conf
 	# shellcheck disable=SC2034
-	show_news=$(grep -Eq '^[[:space:]]*AlwaysShowNews[[:space:]]*$' "${config_file}" 2> /dev/null && echo "y")
+	show_news=$(grep -Eq '^[[:space:]]*AlwaysShowNews[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
 
 	# Check the "NewsNum" option in arch-update.conf
 	# shellcheck disable=SC2034

--- a/src/lib/list_news.sh
+++ b/src/lib/list_news.sh
@@ -16,7 +16,7 @@ else
 		echo "${news}" | htmlq -a title a | grep ^"View:" | sed "s/View:\ //g" | head -1 > "${statedir}/current_news_check"
 
 		if ! diff "${statedir}/current_news_check" "${statedir}/last_news_check" &> /dev/null; then
-			show_news="y"
+			show_news="true"
 		else
 			echo
 			info_msg "$(eval_gettext "No recent Arch News found")"
@@ -67,7 +67,7 @@ else
 
 		for num in "${answer_array[@]}"; do
 			if [ "${num}" -le "${news_num}" ] 2> /dev/null && [ "${num}" -gt "0" ]; then
-				printed_news="y"
+				printed_news="true"
 				news_selected=$(sed -n "${num}"p <<< "${news_titles}")
 				news_path=$(echo "${news_selected}" | sed s/\ -//g | sed s/\ /-/g | sed s/[.]//g | sed s/=//g | sed s/\>//g | sed s/\<//g | sed s/\`//g | sed s/://g | sed s/+//g | sed s/[[]//g | sed s/]//g | sed s/,//g | sed s/\(//g | sed s/\)//g | sed s/[/]//g | sed s/@//g | sed s/\'//g | sed s/--/-/g | awk '{print tolower($0)}')
 				news_url="https://www.archlinux.org/news/${news_path}"

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -59,7 +59,7 @@ else
 		case "${answer}" in
 			"$(eval_gettext "Y")"|"$(eval_gettext "y")"|"")
 				# shellcheck disable=SC2034,SC2154
-				proceed_with_update="y"
+				proceed_with_update="true"
 				echo
 			;;
 			*)

--- a/src/lib/restart_services.sh
+++ b/src/lib/restart_services.sh
@@ -40,14 +40,14 @@ if [ -n "${packages_updated}" ]; then
 
 			for num in "${answer_array[@]}"; do
 				if [ "${num}" -le "${services_num}" ] 2> /dev/null && [ "${num}" -gt "0" ]; then
-					service_restarted="y"
+					service_restarted="true"
 					service_selected=$(sed -n "${num}"p <<< "${services}")
 
 					if "${su_cmd}" systemctl restart "${service_selected}"; then
 						info_msg "$(eval_gettext "The \${service_selected} service has been successfully restarted")"
 					else
 						error_msg "$(eval_gettext "An error has occurred during the restart of the \${service_selected} service")"
-						service_fail="y"
+						service_fail="true"
 					fi
 				fi
 			done

--- a/src/lib/update.sh
+++ b/src/lib/update.sh
@@ -15,7 +15,7 @@ if [ -n "${packages}" ]; then
 		error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
 		exit 5
 	else
-		packages_updated="y"
+		packages_updated="true"
 	fi
 fi
 
@@ -31,7 +31,7 @@ if [ -n "${aur_packages}" ]; then
 		exit 5
 	else
 		# shellcheck disable=SC2034
-		packages_updated="y"
+		packages_updated="true"
 	fi
 fi
 


### PR DESCRIPTION
### Description

While "y" may usually be accepted as a valid boolean value, "true" is more standard and meaningful.

To be fair, the actual value of the variables doesn't matter as I use conditionals based on whether the variable is empty or not. Still, "true" is more conventional.
