### PR TITLE
fix: Exit if the diff prog editor set in arch-update.conf isn't found

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -195,6 +195,7 @@ Codes de sortie :
 12 Erreur lors du traitement des fichiers pacnew
 13 Erreur lors de l'édition du fichier de configuration avec l'option `--edit-config`
 14 Le dossier de librairies n'a pas été trouvé
+15 L'éditeur "diff prog" défini dans le fichier de configuration `arch-update.conf` n'est pas disponible
 ```
 
 Pour plus d'informations, consultez la page de manuel arch-update(1).  

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Exit Codes:
 12 Error during the pacnew files processing
 13 Error when editing the configuration file with the `--edit-config` option
 14 Libraries directory not found
+15 The diff prog editor set in the `arch-update.conf` configuration file isn't found
 ```
 
 For more information, see the arch-update(1) man page.  

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -249,6 +249,10 @@ Error when restarting services that require a post upgrade restart
 .B 14
 Libraries directory not found
 
+.TP
+.B 15
+The diff prog editor set in the arch-update.conf configuration file isn't found
+
 .SH SEE ALSO
 .BR checkupdates (8),
 .BR pacman (8),

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -249,6 +249,10 @@ Erreur lors du traitement des fichiers pacnew
 .B 14
 Le dossier de librairies n'a pas été trouvé
 
+.TP
+.B 15
+L'éditeur "diff prog" défini dans le fichier de configuration arch-update.conf n'est pas disponible
+
 .SH VOIR AUSSI
 .BR checkupdates (8),
 .BR pacman (8),

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -26,43 +26,50 @@ msgstr ""
 msgid "${update_number} updates available"
 msgstr ""
 
-#: src/lib/common.sh:52
+#: src/lib/common.sh:90
 #, sh-format
 msgid "WARNING"
 msgstr ""
 
-#: src/lib/common.sh:58
+#: src/lib/common.sh:96
 #, sh-format
 msgid "ERROR"
 msgstr ""
 
-#: src/lib/common.sh:63
+#: src/lib/common.sh:101
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/lib/common.sh:69
+#: src/lib/common.sh:107
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/lib/common.sh:85
+#: src/lib/common.sh:123
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the arch-update."
 "conf configuration file is not found\\n"
 msgstr ""
 
-#: src/lib/common.sh:107
+#: src/lib/common.sh:145
 #, sh-format
 msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
 msgstr ""
 
-#: src/lib/common.sh:112
+#: src/lib/common.sh:150
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the arch-update.conf "
 "configuration file is not found\\n"
+msgstr ""
+
+#: src/lib/common.sh:158
+#, sh-format
+msgid ""
+"The ${diff_prog} editor set for visualizing/editing differences of pacnew "
+"files in the arch-update.conf configuration file is not found\\n"
 msgstr ""
 
 #: src/lib/edit-config.sh:9 src/lib/show-config.sh:9

--- a/po/fr.po
+++ b/po/fr.po
@@ -26,27 +26,27 @@ msgstr "${update_number} mise à jour disponible"
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
 
-#: src/lib/common.sh:52
+#: src/lib/common.sh:90
 #, sh-format
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
-#: src/lib/common.sh:58
+#: src/lib/common.sh:96
 #, sh-format
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: src/lib/common.sh:63
+#: src/lib/common.sh:101
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/lib/common.sh:69
+#: src/lib/common.sh:107
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Appuyez sur \"entrée\" pour quitter "
 
-#: src/lib/common.sh:85
+#: src/lib/common.sh:123
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the arch-update."
@@ -55,12 +55,12 @@ msgstr ""
 "Le AUR helper ${aur_helper} défini pour le support des paquets AUR dans le fichier de configuration "
 "arch-update.conf n'est pas disponible\\n"
 
-#: src/lib/common.sh:107
+#: src/lib/common.sh:145
 #, sh-format
 msgid "A privilege elevation command is required (sudo, doas or run0)\\n"
 msgstr "Une commande d'élévation de privilège est requise (sudo, doas ou run0)\\n"
 
-#: src/lib/common.sh:112
+#: src/lib/common.sh:150
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the arch-update.conf "
@@ -68,6 +68,15 @@ msgid ""
 msgstr ""
 "La commande ${su_cmd} définie pour l'élévation de privilège dans le fichier "
 "de configuration arch-update.conf n'est pas disponible\\n"
+
+#: src/lib/common.sh:158
+#, sh-format
+msgid ""
+"The ${diff_prog} editor set for visualizing/editing differences of pacnew "
+"files in the arch-update.conf configuration file is not found\\n"
+msgstr ""
+"L'éditeur ${diff_prog} défini pour la visualisation/l'édition des différences des fichiers pacnew "
+"dans le fichier de configuration arch-update.conf n'est pas disponible\\n"
 
 #: src/lib/edit-config.sh:9 src/lib/show-config.sh:9
 #, sh-format

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -154,10 +154,15 @@ fi
 
 # Definition of the diff program to use (if it is set in the arch-update.conf configuration file)
 if [ -n "${diff_prog}" ]; then
-	if [ "${su_cmd}" == "sudo" ]; then
-		diff_prog_opt=("DIFFPROG=${diff_prog}")
-	elif [ "${su_cmd}" == "run0" ]; then
-		diff_prog_opt+=("--setenv=DIFFPROG=${diff_prog}")
+	if ! command -v "${diff_prog}" > /dev/null; then
+		error_msg "$(eval_gettext "The \${diff_prog} editor set for visualizing/editing differences of pacnew files in the arch-update.conf configuration file is not found\n")" && quit_msg
+		exit 15
+	else
+		if [ "${su_cmd}" == "sudo" ]; then
+			diff_prog_opt=("DIFFPROG=${diff_prog}")
+		elif [ "${su_cmd}" == "run0" ]; then
+			diff_prog_opt+=("--setenv=DIFFPROG=${diff_prog}")
+		fi
 	fi
 fi
 


### PR DESCRIPTION
### Description

Check if the diff prog editor set in the arch-update.conf configuration file is found. If not, exit (code 15).

This is to avoid having `pacdiff` failing on a non existing diff program.