### PR TITLE
doc: Improve documentation about starting the systray applet at boot

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -88,14 +88,23 @@ L'utilisation consiste à démarrer [l'applet systray](#lapplet-systray) et à a
 
 ### L'applet systray
 
-Pour démarrer l'applet systray, lancez l'application "Arch-Update Systray Applet" depuis votre menu d'application.  
-Pour la démarrer automatiquement au démarrage du système, vous pouvez soit lancer la commande `arch-update --tray --enable` (c'est la méthode privilégiée pour certains environnements de bureau spécifiques, comme XFCE par exemple) ou vous pouvez démarrer/activer le service systemd associé comme ceci :
+Pour démarrer l'applet systray, lancez l'application "Arch-Update Systray Applet" depuis votre menu d'application.
+
+Pour la démarrer automatiquement au démarrage du système, utilisez l'une des options suivantes :
+
+- Lancer la commande suivante (méthode recommandée pour la plupart des environnements de bureau, utilise [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)):
+
+```bash
+arch-update --tray --enable
+```
+
+- Activer le service systemd associé (dans le cas où votre environnement de bureau ne supporte pas [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)):
 
 ```bash
 systemctl --user enable --now arch-update-tray.service
 ```
 
-*Si vous utilisez un gestionnaire de fenêtre/compositeur Wayland, vous pouvez plutôt ajouter la commande `arch-update --tray` à vôtre fichier de configuration.*
+Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande `arch-update --tray` à vôtre fichier de configuration.
 
 L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance `arch-update` via le fichier [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
 
@@ -109,7 +118,7 @@ L'applet systray essaie de lire le fichier `arch-update.desktop` dans les chemin
 
 Dans le cas où vous avez envie/besoin de personnaliser le fichier `arch-update.desktop`, copiez le dans un chemin qui a une priorité plus élevée que le chemin d'installation par défaut et modifier le ici (afin d'assurer que votre ficher `arch-update.desktop` personnalisé remplace celui par défaut et que vos modifications ne soient pas écrasées à chaque mise à jour).
 
-Cela peut être utile pour forcer le fichier `arch-update.desktop` à lancer `Arch-Update` avec un émulateur de terminal spécifique par exemple.  
+Cela peut être utile pour forcer `Arch-Update` à se lancer avec un émulateur de terminal spécifique lorsque l'on clique sur l'applet systray.  
 **Si cliquer sur l'applet systray ne fait rien**, veuillez lire [ce chapitre](#forcer-le-fichier-desktop-à-se-lancer-avec-un-émulateur-de-terminal-spécifique).
 
 ### Le timer systemd

--- a/README.md
+++ b/README.md
@@ -88,14 +88,23 @@ The usage consist of starting [the systray applet](#the-systray-applet) and enab
 
 ### The systray applet
 
-To start the systray applet, launch the "Arch-Update Systray Applet" application from your app menu.  
-To start it automatically at boot, either run the `arch-update --tray --enable` command (this is the preferred method on some specific desktop environments, like XFCE for instance) or start/enable the associated systemd service like so:
+To start the systray applet, launch the "Arch-Update Systray Applet" application from your app menu.
+
+To start it automatically at boot, you can either:
+
+- Run the following command (preferred method for most Desktop Environments, uses [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)):
+
+```bash
+arch-update --tray --enable
+```
+
+- Enable the associated systemd service (in case your Desktop Environment doesn't support [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)):
 
 ```bash
 systemctl --user enable --now arch-update-tray.service
 ```
 
-*If you use a window manager/Wayland compositor, you can add the `arch-update --tray` command to your configuration file instead.*
+If you use a Window Manager or a Wayland Compositor, you can add the `arch-update --tray` command to your configuration file instead.
 
 The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches `arch-update` via the [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop) file.
 
@@ -109,7 +118,7 @@ The systray applet attempts to read the `arch-update.desktop` file at the below 
 
 In case you want/need to customize the `arch-update.desktop` file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom `arch-update.desktop` file supersedes the default one and that your modifications are not being overwritten on updates).
 
-This can be useful to force the `arch-update.desktop` file to launch `Arch-Update` with a specific terminal emulator for instance.  
+This can be useful to force `Arch-Update` to launch with a specific terminal emulator when clicking the systray applet for instance.  
 **If clicking the systray applet does nothing**, please read [this chapter](#force-the-desktop-file-to-run-with-a-specific-terminal-emulator).
 
 ### The systemd timer

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -76,9 +76,9 @@ Display debug traces.
 .B \-\-tray
 Start the Arch-Update systray applet.
 .br
-.RB "To start it automatically at boot, you can either run the " "arch-update --tray --enable " "command (this is the preferred method on some specific desktop environments, like XFCE for instance) or start/enable the associated systemd service like so: " "systemctl \-\-user enable \-\-now arch-update-tray.service".
+.RB "To start it automatically at boot, you can either run the " "arch-update --tray --enable " "command (preferred method for most Desktop Environments, uses XDG Autostart) or enable the associated systemd service (in case your Desktop Environment doesn't support XDG Autostart) by running " "systemctl \-\-user enable \-\-now arch-update-tray.service".
 .br
-.RB "If you use a window manager/Wayland compositor, you can add the " "arch-update --tray " "command to your configuration file instead."
+.RB "If you use a window manager or a Wayland compositor, you can add the " "arch-update --tray " "command to your configuration file instead."
 
 .TP
 .B \-v, \-\-version

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -76,9 +76,9 @@ Afficher les traces de débogage.
 .B \-\-tray
 Démarrer l'applet systray d'Arch-Update.
 .br
-.RB "Pour la démarrer automatiquement au démarrage du système, vous pouvez soit exécuter la commande " "arch-update --tray --enable " "(c'est la méthode privilégiée pour certains environnements de bureau spécifiques, comme XFCE par exemple) ou vous pouvez démarrer/activer le service systemd associé comme ceci : " "systemctl \-\-user enable \-\-now arch-update-tray.service".
+.RB "Pour la démarrer automatiquement au démarrage du système, vous pouvez soit exécuter la commande " "arch-update --tray --enable " "(méthode recommandée pour la plupart des environnements de bureau, utilise XDG Autostart) ou vous pouvez activer le service systemd associé (dans le cas où vôtre environnement de bureau ne supporte pas XDG Autostart) en exécutant " "systemctl \-\-user enable \-\-now arch-update-tray.service".
 .br
-.RB "Si vous utilisez un gestionnaire de fenêtres/un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update --tray " "à votre fichier de configuration."
+.RB "Si vous utilisez un gestionnaire de fenêtres ou un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update --tray " "à votre fichier de configuration."
 
 .TP
 .B \-v, \-\-version


### PR DESCRIPTION
### Description

Highlight the `arch-update --tray --enable` as the preferred method to automatically start the systray applet at boot. Indeed, XDG Autostart should work with most desktop environments (while the systemd service fails on a bunch of them, e.g. XFCE, LXQT, etc...).