### PR TITLE
doc: Update man pages about how to start the systray applet at boot

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -92,13 +92,13 @@ Pour démarrer l'applet systray, lancez l'application "Arch-Update Systray Apple
 
 Pour la démarrer automatiquement au démarrage du système, utilisez l'une des options suivantes :
 
-- Lancer la commande suivante (méthode recommandée pour la plupart des environnements de bureau, utilise [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)):
+- Lancer la commande suivante (méthode recommandée pour la plupart des environnements de bureau, utilise [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)) :
 
 ```bash
 arch-update --tray --enable
 ```
 
-- Activer le service systemd associé (dans le cas où votre environnement de bureau ne supporte pas [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)):
+- Activer le service systemd associé (dans le cas où votre environnement de bureau ne supporte pas [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)) :
 
 ```bash
 systemctl --user enable --now arch-update-tray.service

--- a/README-fr.md
+++ b/README-fr.md
@@ -106,7 +106,7 @@ systemctl --user enable --now arch-update-tray.service
 
 Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande `arch-update --tray` à vôtre fichier de configuration.
 
-L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance `arch-update` via le fichier [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
+L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, elle lance `arch-update` via le fichier [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
 
 L'applet systray essaie de lire le fichier `arch-update.desktop` dans les chemins ci-dessous avec l'ordre suivant :
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -94,7 +94,15 @@ Display the help message.
 .SH USAGE
 .TP
 .B The systray applet
-.RB "To start the systray applet automatically at boot, add the " "arch-update --tray " "command to your auto-start commands/WM config or start/enable the associated systemd service like so: " "systemctl \-\-user enable \-\-now arch-update-tray.service"
+.RB "To start the systray applet, launch the " "Arch-Update Systray Applet " "application from your app menu."
+.br
+To start it automatically at boot, you can either:
+.br
+.RB "- Run the following command (preferred method for most Desktop Environments, uses XDG Autostart): " "arch-update \-\-tray \-\-enable"
+.br
+.RB "- Enable the associated systemd service (in case your Desktop Environment doesn't support XDG Autostart): " "systemctl \-\-user enable \-\-now arch-update-tray.service"
+.br
+.RB "If you use a Window Manager or a Wayland Compositor, you can add the " "arch-update \-\-tray " "command to your configuration file instead."
 .br
 .RB "The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches " "arch-update " "via the " "arch-update.desktop " file.
 
@@ -119,7 +127,7 @@ Display the help message.
 
 .TP
 .B The systemd timer
-.RB "There is a systemd service in " "/usr/lib/systemd/user/arch-update.service " "(or in " "/etc/systemd/user/arch-update.service " "if you installed arch-update from source) that executes the " "\-\-check " "function when launched. To launch it automatically " "at boot and then once every hour " "enable the associated systemd timer (the auto-check cycle can be modified to your liking. See the TIPS AND TRICKS chapter below):"
+.RB "There is a systemd service in " "/usr/lib/systemd/user/arch-update.service " "(or in " "/etc/systemd/user/arch-update.service " "if you installed arch-update from source) that executes the " "\-\-check " "function when launched. To start it automatically " "at boot and then once every hour " "enable the associated systemd timer (the auto-check cycle can be modified to your liking. See the TIPS AND TRICKS chapter below):"
 .br
 .B systemctl \-\-user enable \-\-now arch-update.timer
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -95,15 +95,15 @@ Display the help message.
 .TP
 .B The systray applet
 .RB "To start the systray applet, launch the " "Arch-Update Systray Applet " "application from your app menu."
-.br
+
 To start it automatically at boot, you can either:
-.br
+
 .RB "- Run the following command (preferred method for most Desktop Environments, uses XDG Autostart): " "arch-update \-\-tray \-\-enable"
 .br
 .RB "- Enable the associated systemd service (in case your Desktop Environment doesn't support XDG Autostart): " "systemctl \-\-user enable \-\-now arch-update-tray.service"
-.br
+
 .RB "If you use a Window Manager or a Wayland Compositor, you can add the " "arch-update \-\-tray " "command to your configuration file instead."
-.br
+
 .RB "The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches " "arch-update " "via the " "arch-update.desktop " file.
 
 .RB "The systray applet attempts to read the " "arch-update.desktop " "file at the below paths and in the following order:"

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -95,15 +95,15 @@ Afficher le message d'aide.
 .TP
 .B L'applet systray
 .RB "Pour démarrer l'applet systray, lancez l'application " "Arch-Update Systray Applet " "depuis votre menu d'application."
-.br
+
 Pour la démarrer automatiquement au démarrage du système, utilisez l'une des options suivantes :
-.br
+
 .RB "- Lancer la commande suivante (méthode recommandée pour la plupart des environnements de bureau, utilise XDG Autostart) : " "arch-update \-\-tray \-\-enable"
 .br
 .RB "- Activer le service systemd associé (dans le cas où votre environnement de bureau ne supporte pas XDG Autostart) : " "systemctl \-\-user enable \-\-now arch-update-tray.service"
-.br
+
 .RB "Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update \-\-tray " "à vôtre fichier de configuration."
-.br
+
 .RB "L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance " "arch-update " "via le fichier " "arch-update.desktop".
 
 .RB "L'applet systray essaie de lire le fichier " "arch-update.desktop " "dans les chemins ci-dessous avec l'ordre suivant :"

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -104,7 +104,7 @@ Pour la démarrer automatiquement au démarrage du système, utilisez l'une des 
 
 .RB "Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update \-\-tray " "à vôtre fichier de configuration."
 
-.RB "L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance " "arch-update " "via le fichier " "arch-update.desktop".
+.RB "L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, elle lance " "arch-update " "via le fichier " "arch-update.desktop".
 
 .RB "L'applet systray essaie de lire le fichier " "arch-update.desktop " "dans les chemins ci-dessous avec l'ordre suivant :"
 

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -94,7 +94,15 @@ Afficher le message d'aide.
 .SH UTILISATION
 .TP
 .B L'applet systray
-.RB "Pour démarrer l'applet systray automatiquement au démarrage du système, ajouter la commande " "arch-update --tray " "à vos commandes 'auto-start'/configuration de votre WM ou démarrez/activez le service systemd associé comme ceci : " "systemctl \-\-user enable \-\-now arch-update-tray.service"
+.RB "Pour démarrer l'applet systray, lancez l'application " "Arch-Update Systray Applet " "depuis votre menu d'application."
+.br
+Pour la démarrer automatiquement au démarrage du système, utilisez l'une des options suivantes :
+.br
+.RB "- Lancer la commande suivante (méthode recommandée pour la plupart des environnements de bureau, utilise XDG Autostart) : " "arch-update \-\-tray \-\-enable"
+.br
+.RB "- Activer le service systemd associé (dans le cas où votre environnement de bureau ne supporte pas XDG Autostart) : " "systemctl \-\-user enable \-\-now arch-update-tray.service"
+.br
+.RB "Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update \-\-tray " "à vôtre fichier de configuration."
 .br
 .RB "L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, il lance " "arch-update " "via le fichier " "arch-update.desktop".
 


### PR DESCRIPTION
### Description

Oversight of this commit: https://github.com/Antiz96/arch-update/commit/1349ad5a70962f5106980abf730d4c618fa825ff