### PR TITLE
feat: Add a right click menu entry to trigger a check for updates in the systray applet

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -588,11 +588,15 @@ msgstr ""
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr ""
 
-#: src/lib/tray.py:123
+#: src/lib/tray.py:127
 msgid "Run Arch-Update"
 msgstr ""
 
-#: src/lib/tray.py:124
+#: src/lib/tray.py:128
+msgid "Check for updates"
+msgstr ""
+
+#: src/lib/tray.py:129
 msgid "Exit"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -658,11 +658,15 @@ msgstr ""
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Aucun service nécessitant un redémarrage suite à la mise à jour n'a été trouvé\\n"
 
-#: src/lib/tray.py:123
+#: src/lib/tray.py:127
 msgid "Run Arch-Update"
 msgstr "Lancer Arch-Update"
 
-#: src/lib/tray.py:124
+#: src/lib/tray.py:128
+msgid "Check for updates"
+msgstr "Vérifier les mises à jour"
+
+#: src/lib/tray.py:129
 msgid "Exit"
 msgstr "Quitter"
 

--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -98,6 +98,10 @@ class ArchUpdateQt6:
         """ Start arch-update """
         arch_update()
 
+    def check(self):
+        """ Check for updates """
+        subprocess.run(["arch-update", "--check"])
+
     def exit(self):
         """ Close systray process """
         sys.exit(0)
@@ -121,11 +125,13 @@ class ArchUpdateQt6:
         # Menu
         menu = QMenu()
         menu_launch = QAction(_("Run Arch-Update"))
+        menu_check = QAction(_("Check for updates"))
         menu_exit = QAction(_("Exit"))
         menu.addAction(menu_launch)
         menu.addAction(menu_exit)
 
         menu_launch.triggered.connect(self.run)
+        menu_check.triggered.connect(self.check)
         menu_exit.triggered.connect(self.exit)
 
         self.tray.setContextMenu(menu)

--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -128,6 +128,7 @@ class ArchUpdateQt6:
         menu_check = QAction(_("Check for updates"))
         menu_exit = QAction(_("Exit"))
         menu.addAction(menu_launch)
+        menu.addAction(menu_check)
         menu.addAction(menu_exit)
 
         menu_launch.triggered.connect(self.run)

--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -100,7 +100,7 @@ class ArchUpdateQt6:
 
     def check(self):
         """ Check for updates """
-        subprocess.run(["arch-update", "--check"])
+        subprocess.run(["arch-update", "--check"], check=False)
 
     def exit(self):
         """ Close systray process """


### PR DESCRIPTION
### Description

Add a right click menu entry to check for updates in the systray applet (runs `arch-update --check`), allowing to easily trigger a check for new pending updates without having to actually run `arch-update` by cliking systray or waiting for the systemd timer to run (or without having to run `arch-update --check` manually via the terminal)

### Screenshots

![2024-10-01_09-05](https://github.com/user-attachments/assets/c7d9d4b9-031f-4191-8f3b-4007bb2b6955)

