### PR TITLE
fix: Fix icons name in desktop files

### DIFF
--- a/res/desktop/arch-update-tray.desktop
+++ b/res/desktop/arch-update-tray.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
 Name=Arch-Update Systray Applet
-Icon=arch-update_updates-available
+Icon=arch-update_updates-available-light
 Exec=arch-update --tray
 Categories=Utility

--- a/res/desktop/arch-update.desktop
+++ b/res/desktop/arch-update.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Terminal=true
 Name=Arch-Update
-Icon=arch-update
+Icon=arch-update-light
 Exec=arch-update
 Categories=Utility


### PR DESCRIPTION
### Description

Fix icons name in the `arch-update.desktop` and `arch-update-tray.desktop` files to get the icons back in application menus.

### Screenshots

Before:

![2024-10-02_10-58](https://github.com/user-attachments/assets/a356aa3b-d94f-4af5-8dd3-ef03b474edbb)

After:

![2024-10-02_11-06](https://github.com/user-attachments/assets/f64e7c5a-fb3f-46d1-9a9e-d3efbe398d45)

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/261