### PR TITLE
feat: Add a description to desktop files

### DIFF
--- a/res/desktop/arch-update-tray.desktop
+++ b/res/desktop/arch-update-tray.desktop
@@ -1,6 +1,8 @@
 [Desktop Entry]
-Type=Application
 Name=Arch-Update Systray Applet
+Comment[fr]=Applet systray pour Arch-Update
+Comment=Systray applet for Arch-Update
 Icon=arch-update_updates-available-light
+Type=Application
 Exec=arch-update --tray
 Categories=Utility

--- a/res/desktop/arch-update.desktop
+++ b/res/desktop/arch-update.desktop
@@ -1,7 +1,9 @@
 [Desktop Entry]
+Name=Arch-Update
+Comment[fr]=Un notificateur & applicateur de mises à jour pour Arch Linux
+Comment=An update notifier & applier for Arch Linux
+Icon=arch-update-light
 Type=Application
 Terminal=true
-Name=Arch-Update
-Icon=arch-update-light
 Exec=arch-update
 Categories=Utility


### PR DESCRIPTION
### Description

Add a comment entry to the `arch-update.service` & `arch-update-tray.service` to serves as a short description in applications menus.

### Screenshots

Before:

![2024-10-02_11-06](https://github.com/user-attachments/assets/f64e7c5a-fb3f-46d1-9a9e-d3efbe398d45)

After:

![2024-10-02_12-52](https://github.com/user-attachments/assets/84d55e03-cf4c-49d2-a632-e8153c1628ec)

