### PR TITLE
fix: Update the "updates" state file on package listing

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,12 +16,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/check.sh:38 src/lib/check.sh:41
+#: src/lib/check.sh:39 src/lib/check.sh:42
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/lib/check.sh:46 src/lib/check.sh:48
+#: src/lib/check.sh:47 src/lib/check.sh:49
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""
@@ -242,14 +242,14 @@ msgstr ""
 msgid "Would you like to reboot now? [y/N]"
 msgstr ""
 
-#: src/lib/kernel_reboot.sh:15 src/lib/list_packages.sh:60
+#: src/lib/kernel_reboot.sh:15 src/lib/list_packages.sh:68
 #: src/lib/orphan_packages.sh:25 src/lib/orphan_packages.sh:59
 #: src/lib/packages_cache.sh:30 src/lib/pacnew_files.sh:21
 #, sh-format
 msgid "Y"
 msgstr ""
 
-#: src/lib/kernel_reboot.sh:15 src/lib/list_packages.sh:60
+#: src/lib/kernel_reboot.sh:15 src/lib/list_packages.sh:68
 #: src/lib/orphan_packages.sh:25 src/lib/orphan_packages.sh:59
 #: src/lib/packages_cache.sh:30 src/lib/pacnew_files.sh:21
 #, sh-format
@@ -355,32 +355,32 @@ msgstr ""
 msgid "Looking for updates...\\n"
 msgstr ""
 
-#: src/lib/list_packages.sh:32
+#: src/lib/list_packages.sh:35
 #, sh-format
 msgid "Packages:"
 msgstr ""
 
-#: src/lib/list_packages.sh:37
+#: src/lib/list_packages.sh:41
 #, sh-format
 msgid "AUR Packages:"
 msgstr ""
 
-#: src/lib/list_packages.sh:42
+#: src/lib/list_packages.sh:47
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr ""
 
-#: src/lib/list_packages.sh:48
+#: src/lib/list_packages.sh:56
 #, sh-format
 msgid "No update available\\n"
 msgstr ""
 
-#: src/lib/list_packages.sh:56
+#: src/lib/list_packages.sh:64
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr ""
 
-#: src/lib/list_packages.sh:66
+#: src/lib/list_packages.sh:74
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr ""
@@ -588,15 +588,15 @@ msgstr ""
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr ""
 
-#: src/lib/tray.py:124
+#: src/lib/tray.py:123
 msgid "Arch-Update: 'updates' state file isn't found"
 msgstr ""
 
-#: src/lib/tray.py:141
+#: src/lib/tray.py:137
 msgid "Arch-Update: System is up to date"
 msgstr ""
 
-#: src/lib/tray.py:144
+#: src/lib/tray.py:140
 #, python-brace-format
 msgid ""
 "Arch-Update: 1 update available\n"
@@ -604,7 +604,7 @@ msgid ""
 "{update_list}"
 msgstr ""
 
-#: src/lib/tray.py:149
+#: src/lib/tray.py:145
 #, python-brace-format
 msgid ""
 "Arch-Update: {updates} updates available\n"
@@ -612,15 +612,15 @@ msgid ""
 "{update_list}"
 msgstr ""
 
-#: src/lib/tray.py:186
+#: src/lib/tray.py:182
 msgid "Run Arch-Update"
 msgstr ""
 
-#: src/lib/tray.py:187
+#: src/lib/tray.py:183
 msgid "Check for updates"
 msgstr ""
 
-#: src/lib/tray.py:188
+#: src/lib/tray.py:184
 msgid "Exit"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,12 +16,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/check.sh:38 src/lib/check.sh:41
+#: src/lib/check.sh:39 src/lib/check.sh:42
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} mise à jour disponible"
 
-#: src/lib/check.sh:46 src/lib/check.sh:48
+#: src/lib/check.sh:47 src/lib/check.sh:49
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"
@@ -283,14 +283,14 @@ msgstr ""
 msgid "Would you like to reboot now? [y/N]"
 msgstr "Voulez-vous redémarrer votre système maintenant ? [o/N]"
 
-#: src/lib/kernel_reboot.sh:15 src/lib/list_packages.sh:60
+#: src/lib/kernel_reboot.sh:15 src/lib/list_packages.sh:68
 #: src/lib/orphan_packages.sh:25 src/lib/orphan_packages.sh:59
 #: src/lib/packages_cache.sh:30 src/lib/pacnew_files.sh:21
 #, sh-format
 msgid "Y"
 msgstr "O"
 
-#: src/lib/kernel_reboot.sh:15 src/lib/list_packages.sh:60
+#: src/lib/kernel_reboot.sh:15 src/lib/list_packages.sh:68
 #: src/lib/orphan_packages.sh:25 src/lib/orphan_packages.sh:59
 #: src/lib/packages_cache.sh:30 src/lib/pacnew_files.sh:21
 #, sh-format
@@ -410,32 +410,32 @@ msgstr "URL :"
 msgid "Looking for updates...\\n"
 msgstr "Recherche de mises à jour...\\n"
 
-#: src/lib/list_packages.sh:32
+#: src/lib/list_packages.sh:35
 #, sh-format
 msgid "Packages:"
 msgstr "Paquets :"
 
-#: src/lib/list_packages.sh:37
+#: src/lib/list_packages.sh:41
 #, sh-format
 msgid "AUR Packages:"
 msgstr "Paquets AUR :"
 
-#: src/lib/list_packages.sh:42
+#: src/lib/list_packages.sh:47
 #, sh-format
 msgid "Flatpak Packages:"
 msgstr "Paquets Flatpak :"
 
-#: src/lib/list_packages.sh:48
+#: src/lib/list_packages.sh:56
 #, sh-format
 msgid "No update available\\n"
 msgstr "Aucune mise à jour disponible\\n"
 
-#: src/lib/list_packages.sh:56
+#: src/lib/list_packages.sh:64
 #, sh-format
 msgid "Proceed with update? [Y/n]"
 msgstr "Procéder à la mise à jour ? [O/n]"
 
-#: src/lib/list_packages.sh:66
+#: src/lib/list_packages.sh:74
 #, sh-format
 msgid "The update has been aborted\\n"
 msgstr "La mise à jour a été abandonnée\\n"
@@ -658,15 +658,15 @@ msgstr ""
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Aucun service nécessitant un redémarrage suite à la mise à jour n'a été trouvé\\n"
 
-#: src/lib/tray.py:124
+#: src/lib/tray.py:123
 msgid "Arch-Update: 'updates' state file isn't found"
 msgstr "Arch-Update : fichier d'état 'updates' non trouvé"
 
-#: src/lib/tray.py:141
+#: src/lib/tray.py:137
 msgid "Arch-Update: System is up to date"
 msgstr "Arch-Update : Le système est à jour"
 
-#: src/lib/tray.py:144
+#: src/lib/tray.py:140
 #, python-brace-format
 msgid ""
 "Arch-Update: 1 update available\n"
@@ -677,7 +677,7 @@ msgstr ""
 "\n"
 "{update_list}"
 
-#: src/lib/tray.py:149
+#: src/lib/tray.py:145
 #, python-brace-format
 msgid ""
 "Arch-Update: {updates} updates available\n"
@@ -688,15 +688,15 @@ msgstr ""
 "\n"
 "{update_list}"
 
-#: src/lib/tray.py:186
+#: src/lib/tray.py:182
 msgid "Run Arch-Update"
 msgstr "Lancer Arch-Update"
 
-#: src/lib/tray.py:187
+#: src/lib/tray.py:183
 msgid "Check for updates"
 msgstr "Vérifier les mises à jour"
 
-#: src/lib/tray.py:188
+#: src/lib/tray.py:184
 msgid "Exit"
 msgstr "Quitter"
 

--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -22,6 +22,7 @@ if [ -n "${notif}" ]; then
 	# shellcheck disable=SC2154
 	echo "${update_available}" > "${statedir}/current_updates_check"
 	sed -i '/^\s*$/d' "${statedir}/current_updates_check"
+	sed -ri 's/\x1B\[[0-9;]*m//g' "${statedir}/current_updates_check"
 fi
 
 if [ -n "${update_available}" ]; then
@@ -57,5 +58,3 @@ fi
 if [ -f "${statedir}/current_updates_check" ]; then
 	mv -f "${statedir}/current_updates_check" "${statedir}/last_updates_check"
 fi
-
-

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -28,6 +28,7 @@ if [ -n "${flatpak}" ]; then
 	flatpak_packages=$(flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 fi
 
+# shellcheck disable=SC2154
 true > "${statedir}/last_updates_check"
 
 if [ -n "${packages}" ]; then

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -28,19 +28,24 @@ if [ -n "${flatpak}" ]; then
 	flatpak_packages=$(flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 fi
 
+true > "${statedir}/last_updates_check"
+
 if [ -n "${packages}" ]; then
 	main_msg "$(eval_gettext "Packages:")"
 	echo -e "${packages}\n"
+	echo "${packages}" >> "${statedir}/last_updates_check"
 fi
 
 if [ -n "${aur_packages}" ]; then
 	main_msg "$(eval_gettext "AUR Packages:")"
 	echo -e "${aur_packages}\n"
+	echo "${aur_packages}" >> "${statedir}/last_updates_check"
 fi
 
 if [ -n "${flatpak_packages}" ]; then
 	main_msg "$(eval_gettext "Flatpak Packages:")"
 	echo -e "${flatpak_packages}\n"
+	echo "${flatpak_packages}" >> "${statedir}/last_updates_check"
 fi
 
 if [ -z "${packages}" ] && [ -z "${aur_packages}" ] && [ -z "${flatpak_packages}" ]; then

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -49,6 +49,8 @@ if [ -n "${flatpak_packages}" ]; then
 	echo "${flatpak_packages}" >> "${statedir}/last_updates_check"
 fi
 
+sed -ri 's/\x1B\[[0-9;]*m//g' "${statedir}/last_updates_check"
+
 if [ -z "${packages}" ] && [ -z "${aur_packages}" ] && [ -z "${flatpak_packages}" ]; then
 	icon_up-to-date
 	info_msg "$(eval_gettext "No update available\n")"

--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -125,16 +125,6 @@ class ArchUpdateQt6:
             self.tray.setToolTip(tooltip)
             return
 
-        # Define a regex pattern to match ANSI escape / color codes
-        ansi_escape_pattern = re.compile(r'\x1B\[[0-?9;]*[mK]')
-
-        # Remove ANSI escape / color codes and any empty lines, then strip whitespaces
-        updates_list = [
-            ansi_escape_pattern.sub('', update).strip()
-            for update in updates_list
-            if update.strip()
-        ]
-
         updates_count = len(updates_list)
 
         if updates_count == 0:

--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -124,6 +124,13 @@ class ArchUpdateQt6:
             self.tray.setToolTip(tooltip)
             return
 
+        # Remove empty lines
+        updates_list = [
+            update.strip()
+            for update in updates_list
+            if update.strip()
+        ]
+
         updates_count = len(updates_list)
 
         if updates_count == 0:

--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -10,7 +10,6 @@ import logging
 import os
 import sys
 import subprocess
-import re
 from PyQt6.QtGui import QIcon, QAction
 from PyQt6.QtWidgets import QApplication, QSystemTrayIcon, QMenu
 from PyQt6.QtCore import QFileSystemWatcher


### PR DESCRIPTION
### Description

Update the "updates" state file on package listing in `arch-update` / `arch-update --list` to avoid having an different & outdated updates list in the systray applet tooltip (compared to the actual refreshed list given by the package listing)

### Screenshot

See the outdated / incomplete list from the tooltip compared to the package listing:

![2024-10-04_22-59](https://github.com/user-attachments/assets/616aaf5c-a275-40f1-ac70-f4e1adff19cb)