### PR TITLE
doc: Document the workaround for the race condition potentially happening when starting the systray applet at boot

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -106,7 +106,7 @@ systemctl --user enable --now arch-update-tray.service
 
 Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande `arch-update --tray` à vos applications "auto-start" dans votre fichier de configuration.
 
-**Si l'applet systray ne démarre pas au démarrage du système malgré tout**, veuillez lire [ce chapitre](#l-applet-systray-ne-démarre-pas-au-démarrage-du-système).
+**Si l'applet systray ne démarre pas au démarrage du système malgré tout**, veuillez lire [ce chapitre](#lapplet-systray-ne-démarre-pas-au-démarrage-du-système).
 
 L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, elle lance `arch-update` via le fichier [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
 
@@ -266,7 +266,7 @@ Voir <https://wiki.archlinux.org/title/Desktop_notifications>
 
 ### L'applet systray ne démarre pas au démarrage du système
 
-Assurez vous d'avoir suivi les instructions de [ce chapitre](#l-applet-systray).
+Assurez vous d'avoir suivi les instructions de [ce chapitre](#lapplet-systray).
 
 Si l'applet systray ne démarre pas malgré tout, cela peut être le résultat d'une [situation de compétition](https://fr.wikipedia.org/wiki/Situation_de_comp%C3%A9tition).  
 Dans ce cas, il peut être utile de légèrement retarder le démarrage de l'applet systray en utilisant une déclaration `sleep` au préalable:

--- a/README-fr.md
+++ b/README-fr.md
@@ -104,7 +104,9 @@ arch-update --tray --enable
 systemctl --user enable --now arch-update-tray.service
 ```
 
-Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande `arch-update --tray` à vôtre fichier de configuration.
+Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande `arch-update --tray` à vos applications "auto-start" dans votre fichier de configuration.
+
+**Si l'applet systray ne démarre pas au démarrage du système malgré tout**, veuillez lire [ce chapitre](#l-applet-systray-ne-démarre-pas-au-démarrage-du-système).
 
 L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, elle lance `arch-update` via le fichier [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
 
@@ -261,6 +263,27 @@ Voir <https://www.flatpak.org/> et <https://archlinux.org/packages/extra/x86_64/
 
 Arch-Update prend en charge les notifications de bureau lors de l'exécution de la fonction `--check` si **libnotify** est installé (et qu'un serveur de notification est en cours d'exécution) :  
 Voir <https://wiki.archlinux.org/title/Desktop_notifications>
+
+### L'applet systray ne démarre pas au démarrage du système
+
+Assurez vous d'avoir suivi les instructions de [ce chapitre](#l-applet-systray).
+
+Si l'applet systray ne démarre pas malgré tout, cela peut être le résultat d'une [situation de compétition](https://fr.wikipedia.org/wiki/Situation_de_comp%C3%A9tition).  
+Dans ce cas, il peut être utile de légèrement retarder le démarrage de l'applet systray en utilisant une déclaration `sleep` au préalable:
+
+- Si vous avez utilisé `arch-update --tray --enable`, modifiez la ligne `Exec=` dans le fichier `arch-update-tray.desktop` (qui se trouve sous `~/.config/autostart/` par défaut), comme ceci :
+
+> Exec=sh -c "sleep 3 && arch-update --tray"
+
+- Si vous avez utilisé le service systemd `arch-update-tray.service`, exécutez `systemctl --user edit --full arch-update-tray.service` et modifiez la ligne `ExecStart=`, comme ceci :
+
+> ExecStart=sh -c "sleep 3 && arch-update --tray"
+
+- Si vous utilisez un gestionnaire de fenêtres ou un compositeur Wayland, ajoutez une déclaration `sleep` avant la commande `arch-update --tray` à vos applications "auto-start" dans votre fichier de configuration, comme ceci :
+
+> `sleep 3 && arch-update --tray`
+
+Si l'applet systray ne démarre toujours au démarrage du système, essayez de graduellement augmenter la valeur du `sleep`.
 
 ### Modifier le cycle de vérification automatique
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -269,7 +269,7 @@ Voir <https://wiki.archlinux.org/title/Desktop_notifications>
 Assurez vous d'avoir suivi les instructions de [ce chapitre](#lapplet-systray).
 
 Si l'applet systray ne démarre pas malgré tout, cela peut être le résultat d'une [situation de compétition](https://fr.wikipedia.org/wiki/Situation_de_comp%C3%A9tition).  
-Dans ce cas, il peut être utile de légèrement retarder le démarrage de l'applet systray en utilisant une déclaration `sleep` au préalable:
+Dans ce cas, il peut être utile de légèrement retarder le démarrage de l'applet systray en utilisant une déclaration `sleep` au préalable :
 
 - Si vous avez utilisé `arch-update --tray --enable`, modifiez la ligne `Exec=` dans le fichier `arch-update-tray.desktop` (qui se trouve sous `~/.config/autostart/` par défaut), comme ceci :
 
@@ -279,7 +279,7 @@ Dans ce cas, il peut être utile de légèrement retarder le démarrage de l'app
 
 > ExecStart=sh -c "sleep 3 && arch-update --tray"
 
-- Si vous utilisez un gestionnaire de fenêtres ou un compositeur Wayland, ajoutez une déclaration `sleep` avant la commande `arch-update --tray` à vos applications "auto-start" dans votre fichier de configuration, comme ceci :
+- Si vous utilisez un gestionnaire de fenêtres ou un compositeur Wayland, ajoutez une déclaration `sleep` avant la commande `arch-update --tray` dans vos applications "auto-start" dans votre fichier de configuration, comme ceci :
 
 > `sleep 3 && arch-update --tray`
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Make sure you followed instructions of [this chapter](#the-systray-applet).
 If the systray applet doesn't start regardless, this could be the result of a [race condition](https://en.wikipedia.org/wiki/Race_condition#In_software).  
 In such case, it might be useful to slightly delay the startup of the systray applet by using a `sleep` statement beforehand:
 
-- If you used `arch-update --tray --enable`, modify the `Exec=` line in the `arch-update-tray.desktop` (which is under `~/.config/autostart/` by default), like so:
+- If you used `arch-update --tray --enable`, modify the `Exec=` line in the `arch-update-tray.desktop` file (which is under `~/.config/autostart/` by default), like so:
 
 > Exec=sh -c "sleep 3 && arch-update --tray"
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ arch-update --tray --enable
 systemctl --user enable --now arch-update-tray.service
 ```
 
-If you use a Window Manager or a Wayland Compositor, you can add the `arch-update --tray` command to your configuration file instead.
+If you use a Window Manager or a Wayland Compositor, you can add the `arch-update --tray` command to your "auto-start" apps in your configuration file instead.
+
+**If the systray applet doesn't start at boot regardless**, please read [this chapter](#the-systray-applet-does-not-start-at-boot).
 
 The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches `arch-update` via the [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop) file.
 
@@ -261,6 +263,27 @@ See <https://www.flatpak.org/> and <https://archlinux.org/packages/extra/x86_64/
 
 Arch-Update supports desktop notifications when performing the `--check` function if **libnotify** is installed (and a notification server is running):  
 See <https://wiki.archlinux.org/title/Desktop_notifications>
+
+### The systray applet does not start at boot
+
+Make sure you followed instructions of [this chapter](#the-systray-applet).
+
+If the systray applet doesn't start regardless, this could be the result of a [race condition](https://en.wikipedia.org/wiki/Race_condition#In_software).  
+In such case, it might be useful to slightly delay the startup of the systray applet by using a `sleep` statement beforehand:
+
+- If you used `arch-update --tray --enable`, modify the `Exec=` line in the `arch-update-tray.desktop` (which is under `~/.config/autostart/` by default), like so:
+
+> Exec=sh -c "sleep 3 && arch-update --tray"
+
+- If you used the `arch-update-tray.service` systemd service, run `systemctl --user edit --full arch-update-tray.service` and modify the `ExecStart=` line, like so:
+
+> ExecStart=sh -c "sleep 3 && arch-update --tray"
+
+- If you're using a standalone Window Manager or a Wayland Compositor, add a `sleep` statement before the `arch-update --tray` command in your "auto-start" apps in your configuration file, like so:
+
+> `sleep 3 && arch-update --tray`
+
+If the systray applet still does not start at boot, try to gradually increase the value of the `sleep`.
 
 ### Modify the auto-check cycle
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -161,15 +161,15 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 .RB "If the systray applet doesn't start regardless, this could be the result of a " "race condition".
 .RB "In such case, it might be useful to slightly delay the startup of the systray applet by using a " "sleep " "statement beforehand:"
 
-.RB \- "If you used " "arch-update --tray --enable" ", modify the " "Exec= " "line in the " "arch-update-tray.desktop " "file (which is under " "~/.config/autostart/ " "by default), like so::"
+.RB "\- If you used " "arch-update --tray --enable" ", modify the " "Exec= " "line in the " "arch-update-tray.desktop " "file (which is under " "~/.config/autostart/ " "by default), like so::"
 .br
 Exec=sh -c "sleep 3 && arch-update --tray"
 
-.RB \- "If you used the " "arch-update-tray.service " "systemd service, run " "systemctl --user edit --full arch-update-tray.service " "and modify the " "ExecStart= " "line, like so:"
+.RB "\- If you used the " "arch-update-tray.service " "systemd service, run " "systemctl --user edit --full arch-update-tray.service " "and modify the " "ExecStart= " "line, like so:"
 .br
 ExecStart=sh -c "sleep 3 && arch-update --tray"
 
-.RB \- "If you're using a standalone Window Manager or a Wayland Compositor, add a " "sleep " "statement before the " "arch-update --tray " "command in your auto-start apps in your configuration file, like so:"
+.RB "\- If you're using a standalone Window Manager or a Wayland Compositor, add a " "sleep " "statement before the " "arch-update --tray " "command in your auto-start apps in your configuration file, like so:"
 .br
 sleep 3 && arch-update --tray
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "September 2024" "Arch-Update 3.2.3" "Arch-Update Manual"
+.TH "ARCH-UPDATE" "1" "October 2024" "Arch-Update 3.2.3" "Arch-Update Manual"
 
 .SH NAME
 arch-update \- An update notifier & applier for Arch Linux that assists you with important pre / post update tasks.
@@ -78,7 +78,7 @@ Start the Arch-Update systray applet.
 .br
 .RB "To start it automatically at boot, you can either run the " "arch-update --tray --enable " "command (preferred method for most Desktop Environments, uses XDG Autostart) or enable the associated systemd service (in case your Desktop Environment doesn't support XDG Autostart) by running " "systemctl \-\-user enable \-\-now arch-update-tray.service".
 .br
-.RB "If you use a window manager or a Wayland compositor, you can add the " "arch-update --tray " "command to your configuration file instead."
+.RB "If you use a window manager or a Wayland compositor, you can add the " "arch-update --tray " "command to your auto-start apps in your configuration file instead."
 
 .TP
 .B \-v, \-\-version
@@ -102,7 +102,9 @@ To start it automatically at boot, you can either:
 .br
 .RB "- Enable the associated systemd service (in case your Desktop Environment doesn't support XDG Autostart): " "systemctl \-\-user enable \-\-now arch-update-tray.service"
 
-.RB "If you use a Window Manager or a Wayland Compositor, you can add the " "arch-update \-\-tray " "command to your configuration file instead."
+.RB "If you use a Window Manager or a Wayland Compositor, you can add the " "arch-update \-\-tray " "command to your auto-start apps in your configuration file instead."
+
+.RB "If the systray applet doesn't start at boot regardless" ", please read the " "'The systray applet does not start at boot' " "chapter in the " "Tips and Tricks " "section below."
 
 .RB "The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches " "arch-update " "via the " "arch-update.desktop " file.
 
@@ -151,6 +153,27 @@ See https://www.flatpak.org/ and https://archlinux.org/packages/extra/x86_64/fla
 .RB "Arch-Update supports desktop notifications when performing the " "--check " "function if " "libnotify (notify-send) " "is installed."
 .br
 See https://wiki.archlinux.org/title/Desktop_notifications
+
+.TP
+.B The systray applet does not start at boot
+.RB "Make sure you followed instructions of the " "'The systray applet' " "chapter in the " "Usage " "section above."
+
+.RB "If the systray applet doesn't start regardless, this could be the result of a " "race condition".
+.RB "In such case, it might be useful to slightly delay the startup of the systray applet by using a " "sleep " "statement beforehand:"
+
+.RB \- "If you used " "arch-update --tray --enable" ", modify the " "Exec= " "line in the " "arch-update-tray.desktop " "(which is under " "~/.config/autostart/ " "by default), like so::"
+.br
+Exec=sh -c "sleep 3 && arch-update --tray"
+
+.RB \- "If you used the " "arch-update-tray.service " "systemd service, run " "systemctl --user edit --full arch-update-tray.service " "and modify the " "ExecStart= " "line, like so:"
+.br
+ExecStart=sh -c "sleep 3 && arch-update --tray"
+
+.RB \- "If you're using a standalone Window Manager or a Wayland Compositor, add a " "sleep " "statement before the " "arch-update --tray " "command in your auto-start apps in your configuration file, like so:"
+.br
+sleep 3 && arch-update --tray
+
+.RB "If the systray applet still does not start at boot, try to gradually increase the value of the " "sleep".
 
 .TP
 .B Modify the auto-check cycle

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -161,7 +161,7 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 .RB "If the systray applet doesn't start regardless, this could be the result of a " "race condition".
 .RB "In such case, it might be useful to slightly delay the startup of the systray applet by using a " "sleep " "statement beforehand:"
 
-.RB \- "If you used " "arch-update --tray --enable" ", modify the " "Exec= " "line in the " "arch-update-tray.desktop " "(which is under " "~/.config/autostart/ " "by default), like so::"
+.RB \- "If you used " "arch-update --tray --enable" ", modify the " "Exec= " "line in the " "arch-update-tray.desktop " "file (which is under " "~/.config/autostart/ " "by default), like so::"
 .br
 Exec=sh -c "sleep 3 && arch-update --tray"
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -161,7 +161,7 @@ See https://wiki.archlinux.org/title/Desktop_notifications
 .RB "If the systray applet doesn't start regardless, this could be the result of a " "race condition".
 .RB "In such case, it might be useful to slightly delay the startup of the systray applet by using a " "sleep " "statement beforehand:"
 
-.RB "\- If you used " "arch-update --tray --enable" ", modify the " "Exec= " "line in the " "arch-update-tray.desktop " "file (which is under " "~/.config/autostart/ " "by default), like so::"
+.RB "\- If you used " "arch-update --tray --enable" ", modify the " "Exec= " "line in the " "arch-update-tray.desktop " "file (which is under " "~/.config/autostart/ " "by default), like so:"
 .br
 Exec=sh -c "sleep 3 && arch-update --tray"
 

--- a/doc/man/arch-update.1
+++ b/doc/man/arch-update.1
@@ -104,7 +104,7 @@ To start it automatically at boot, you can either:
 
 .RB "If you use a Window Manager or a Wayland Compositor, you can add the " "arch-update \-\-tray " "command to your auto-start apps in your configuration file instead."
 
-.RB "If the systray applet doesn't start at boot regardless" ", please read the " "'The systray applet does not start at boot' " "chapter in the " "Tips and Tricks " "section below."
+.BR "If the systray applet doesn't start at boot regardless" ", please read the " "'The systray applet does not start at boot' " "chapter in the " "Tips and Tricks " "section below."
 
 .RB "The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches " "arch-update " "via the " "arch-update.desktop " file.
 

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -104,7 +104,7 @@ Pour la démarrer automatiquement au démarrage du système, utilisez l'une des 
 
 .RB "Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update \-\-tray " "à vos applications auto-start dans votre fichier de configuration."
 
-.BR "Si l'applet systray ne démarre pas au démarrage du système malgré tout" ", veuillez lire le chapitre " "'l'applet systray ne démarre pas au démarrage du système' "dans la section " "Trucs et Astuces " "ci-dessous."
+.BR "Si l'applet systray ne démarre pas au démarrage du système malgré tout" ", veuillez lire le chapitre " "'l'applet systray ne démarre pas au démarrage du système' " "dans la section " "Trucs et Astuces " "ci-dessous."
 
 .RB "L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, elle lance " "arch-update " "via le fichier " "arch-update.desktop".
 

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -1,4 +1,4 @@
-.TH "ARCH-UPDATE" "1" "Septembre 2024" "Arch-Update 3.2.3" "Manuel de Arch-Update"
+.TH "ARCH-UPDATE" "1" "Octobre 2024" "Arch-Update 3.2.3" "Manuel de Arch-Update"
 
 .SH NAME
 arch-update \- Un notificateur & applicateur de mises à jour pour Arch Linux qui vous assiste dans les tâches importantes d'avant / après mise à jour.
@@ -78,7 +78,7 @@ Démarrer l'applet systray d'Arch-Update.
 .br
 .RB "Pour la démarrer automatiquement au démarrage du système, vous pouvez soit exécuter la commande " "arch-update --tray --enable " "(méthode recommandée pour la plupart des environnements de bureau, utilise XDG Autostart) ou vous pouvez activer le service systemd associé (dans le cas où vôtre environnement de bureau ne supporte pas XDG Autostart) en exécutant " "systemctl \-\-user enable \-\-now arch-update-tray.service".
 .br
-.RB "Si vous utilisez un gestionnaire de fenêtres ou un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update --tray " "à votre fichier de configuration."
+.RB "Si vous utilisez un gestionnaire de fenêtres ou un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update --tray " "à vos applications auto-start dans votre fichier de configuration."
 
 .TP
 .B \-v, \-\-version
@@ -102,7 +102,9 @@ Pour la démarrer automatiquement au démarrage du système, utilisez l'une des 
 .br
 .RB "- Activer le service systemd associé (dans le cas où votre environnement de bureau ne supporte pas XDG Autostart) : " "systemctl \-\-user enable \-\-now arch-update-tray.service"
 
-.RB "Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update \-\-tray " "à vôtre fichier de configuration."
+.RB "Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update \-\-tray " "à vos applications auto-start dans votre fichier de configuration."
+
+.RB "Si l'applet systray ne démarre pas au démarrage du système malgré tout" ", veuillez lire le chapitre " "'l'applet systray ne démarre pas au démarrage du système' "dans la section " "Trucs et Astuces " "ci-dessous."
 
 .RB "L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, elle lance " "arch-update " "via le fichier " "arch-update.desktop".
 
@@ -151,6 +153,28 @@ Voir https://www.flatpak.org/ et https://archlinux.org/packages/extra/x86_64/fla
 .RB "Arch-Update prend en charge les notifications de bureau lors de l'exécution de la fonction " "--check " "si " "libnotify (notify-send) " "est installé."
 .br
 Voir https://wiki.archlinux.org/title/Desktop_notifications
+
+.TP
+.B L'applet systray ne démarre pas au démarrage du système
+
+.RB "Assurez vous d'avoir suivi les instructions du chapitre " "l'applet systray " "dans la section " "Utilisation " "ci-dessus."
+
+.RB "Si l'applet systray ne démarre pas malgré tout, cela peut être le résultat d'une " "situation de compétition".
+.RB "Dans ce cas, il peut être utile de légèrement retarder le démarrage de l'applet systray en utilisant une déclaration " "sleep " "au préalable:"
+
+.RB \- "Si vous avez utilisé " "arch-update --tray --enable" ", modifiez la ligne " "Exec= " "dans le fichier " "arch-update-tray.desktop " "(qui se trouve sous " "~/.config/autostart/ " "par défaut), comme ceci :"
+.br
+Exec=sh -c "sleep 3 && arch-update --tray"
+
+.RB \- "Si vous avez utilisé le service systemd " "arch-update-tray.service" ", exécutez " "systemctl --user edit --full arch-update-tray.service " "et modifiez la ligne " "ExecStart=" ", comme ceci :"
+.br
+ExecStart=sh -c "sleep 3 && arch-update --tray"
+
+.RB \- "Si vous utilisez un gestionnaire de fenêtres ou un compositeur Wayland, ajoutez une déclaration " "sleep " "avant la commande " "arch-update --tray " "à vos applications auto-start dans votre fichier de configuration, comme ceci :"
+
+"sleep 3 && arch-update --tray"
+
+.RB "Si l'applet systray ne démarre toujours au démarrage du système, essayez de graduellement augmenter la valeur du " "sleep".
 
 .TP
 .B Modifier le cycle de vérification automatique

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -160,7 +160,7 @@ Voir https://wiki.archlinux.org/title/Desktop_notifications
 .RB "Assurez vous d'avoir suivi les instructions du chapitre " "l'applet systray " "dans la section " "Utilisation " "ci-dessus."
 
 .RB "Si l'applet systray ne démarre pas malgré tout, cela peut être le résultat d'une " "situation de compétition".
-.RB "Dans ce cas, il peut être utile de légèrement retarder le démarrage de l'applet systray en utilisant une déclaration " "sleep " "au préalable:"
+.RB "Dans ce cas, il peut être utile de légèrement retarder le démarrage de l'applet systray en utilisant une déclaration " "sleep " "au préalable :"
 
 .RB "\- Si vous avez utilisé " "arch-update --tray --enable" ", modifiez la ligne " "Exec= " "dans le fichier " "arch-update-tray.desktop " "(qui se trouve sous " "~/.config/autostart/ " "par défaut), comme ceci :"
 .br

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -162,16 +162,16 @@ Voir https://wiki.archlinux.org/title/Desktop_notifications
 .RB "Si l'applet systray ne démarre pas malgré tout, cela peut être le résultat d'une " "situation de compétition".
 .RB "Dans ce cas, il peut être utile de légèrement retarder le démarrage de l'applet systray en utilisant une déclaration " "sleep " "au préalable:"
 
-.RB \- "Si vous avez utilisé " "arch-update --tray --enable" ", modifiez la ligne " "Exec= " "dans le fichier " "arch-update-tray.desktop " "(qui se trouve sous " "~/.config/autostart/ " "par défaut), comme ceci :"
+.RB "\- Si vous avez utilisé " "arch-update --tray --enable" ", modifiez la ligne " "Exec= " "dans le fichier " "arch-update-tray.desktop " "(qui se trouve sous " "~/.config/autostart/ " "par défaut), comme ceci :"
 .br
 Exec=sh -c "sleep 3 && arch-update --tray"
 
-.RB \- "Si vous avez utilisé le service systemd " "arch-update-tray.service" ", exécutez " "systemctl --user edit --full arch-update-tray.service " "et modifiez la ligne " "ExecStart=" ", comme ceci :"
+.RB "\- Si vous avez utilisé le service systemd " "arch-update-tray.service" ", exécutez " "systemctl --user edit --full arch-update-tray.service " "et modifiez la ligne " "ExecStart=" ", comme ceci :"
 .br
 ExecStart=sh -c "sleep 3 && arch-update --tray"
 
-.RB \- "Si vous utilisez un gestionnaire de fenêtres ou un compositeur Wayland, ajoutez une déclaration " "sleep " "avant la commande " "arch-update --tray " "à vos applications auto-start dans votre fichier de configuration, comme ceci :"
-
+.RB "\- Si vous utilisez un gestionnaire de fenêtres ou un compositeur Wayland, ajoutez une déclaration " "sleep " "avant la commande " "arch-update --tray " "à vos applications auto-start dans votre fichier de configuration, comme ceci :"
+.br
 "sleep 3 && arch-update --tray"
 
 .RB "Si l'applet systray ne démarre toujours au démarrage du système, essayez de graduellement augmenter la valeur du " "sleep".

--- a/doc/man/fr/arch-update.1
+++ b/doc/man/fr/arch-update.1
@@ -104,7 +104,7 @@ Pour la démarrer automatiquement au démarrage du système, utilisez l'une des 
 
 .RB "Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande " "arch-update \-\-tray " "à vos applications auto-start dans votre fichier de configuration."
 
-.RB "Si l'applet systray ne démarre pas au démarrage du système malgré tout" ", veuillez lire le chapitre " "'l'applet systray ne démarre pas au démarrage du système' "dans la section " "Trucs et Astuces " "ci-dessous."
+.BR "Si l'applet systray ne démarre pas au démarrage du système malgré tout" ", veuillez lire le chapitre " "'l'applet systray ne démarre pas au démarrage du système' "dans la section " "Trucs et Astuces " "ci-dessous."
 
 .RB "L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, elle lance " "arch-update " "via le fichier " "arch-update.desktop".
 


### PR DESCRIPTION
### Description

Document the potential the workaround for the eventual race condition that can potentially happen when starting the systray applet automatically at boot (resulting in the systray applet failing to start).

### Fixed bug

Closes https://github.com/Antiz96/arch-update/issues/269