### PR TITLE
Add NoNews option

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The supported options are:
 - NoColor # Do not colorize output.
 - NoVersion # Do not show versions changes for packages when listing pending updates (including when using the `-l / --list` option).
 - AlwaysShowNews # Always display Arch news before updating, regardless of whether there's a new one since the last run or not.
+- NoNews # Never show Arch news before updating, regardless of whether there's a new one since the last run or not.
 - NewsNum=[Num] # Number of Arch news to display before updating and with the `-n / --news` option (see the arch-update(1) man page for more details). Defaults to 5.
 - AURHelper=[AUR Helper] # AUR helper to be used for AUR packages support. Valid values are `paru`, `yay` or `pikaur`. If this option is not set, Arch-Update will use the first available AUR helper in the following order: `paru` then `yay` then `pikaur` (in case none of them is installed, Arch-Update will not take AUR packages into account).
 - PrivilegeElevationCommand=[Cmd] # Command to be used for privilege elevation. Valid values are `sudo`, `doas` or `run0`. If this option is not set, Arch-Update will use the first available command in the following order: `sudo`, `doas` then `run0`.

--- a/res/config/arch-update.conf.example
+++ b/res/config/arch-update.conf.example
@@ -5,6 +5,7 @@
 #NoColor
 #NoVersion
 #AlwaysShowNews
+#NoNews
 #NewsNum=5
 #AURHelper=paru
 #PrivilegeElevationCommand=sudo

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -22,6 +22,10 @@ if [ -f "${config_file}" ]; then
 	# shellcheck disable=SC2034
 	show_news=$(grep -Eq '^[[:space:]]*AlwaysShowNews[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
 
+ 	# Check the "NoNews" option in arch-update.conf
+	# shellcheck disable=SC2034
+	no_news=$(grep -Eq '^[[:space:]]*NoNews[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
+ 
 	# Check the "NewsNum" option in arch-update.conf
 	# shellcheck disable=SC2034
 	news_num=$(grep -E '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')

--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -10,9 +10,12 @@ source "${libdir}/list_packages.sh"
 
 # If the user gave the confirmation to proceed to apply updates
 if [ -n "${proceed_with_update}" ]; then
-	# Source the "list_news" library which displays the latest Arch news and offers to read them
-	# shellcheck source=src/lib/list_news.sh
-	source "${libdir}/list_news.sh"
+	# If the user hasn't disabled news, proceed to show the news
+	if [ -z "${no_news}" ]; then
+		# Source the "list_news" library which displays the latest Arch news and offers to read them
+		# shellcheck source=src/lib/list_news.sh
+		source "${libdir}/list_news.sh"
+  	fi
 
 	# Source the "update" library which updates packages
 	# shellcheck source=src/lib/update.sh


### PR DESCRIPTION
<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

Added NoNews option to disable the display of Arch new on full upgrade

### Addressed feature request

<!-- If this pull request is addressing an opened feature request, paste the corresponding issue URL below -->

Closes "[Option to disable the display of Arch news](https://github.com/Antiz96/arch-update/issues/281)"
