### PR TITLE
Fix False Positive for Unused Runtimes when Flatpak has Runtimes Pinned

### DIFF
--- a/src/lib/orphan_packages.sh
+++ b/src/lib/orphan_packages.sh
@@ -7,7 +7,7 @@
 orphan_packages=$(pacman -Qtdq)
 
 if [ -n "${flatpak}" ]; then
-	flatpak_unused=$(flatpak remove --unused | awk '{print $2}' | grep -v '^$' | sed '$d')
+	flatpak_unused=$(flatpak remove --unused | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 fi
 
 if [ -n "${orphan_packages}" ]; then

--- a/src/lib/orphan_packages.sh
+++ b/src/lib/orphan_packages.sh
@@ -7,7 +7,7 @@
 orphan_packages=$(pacman -Qtdq)
 
 if [ -n "${flatpak}" ]; then
-	flatpak_unused=$(flatpak remove --unused | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
+	flatpak_unused=$(flatpak uninstall --unused | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 fi
 
 if [ -n "${orphan_packages}" ]; then
@@ -60,7 +60,7 @@ if [ -n "${flatpak}" ]; then
 				echo
 				main_msg "$(eval_gettext "Removing Flatpak Unused Packages...")"
 
-				if ! flatpak remove --unused; then
+				if ! flatpak uninstall --unused; then
 					echo
 					error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 				else


### PR DESCRIPTION
### Description

Fixes the parsing for unused runtimes to avoid false positives, as discussed in the issue.

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/285