### PR TITLE
chore: Rename LIBDIR env var

### DIFF
--- a/src/arch-update.sh
+++ b/src/arch-update.sh
@@ -11,8 +11,8 @@ version="3.4.2"
 option="${1}"
 
 # Define the directory containing libraries
-if [ -n "${TEST_LIBDIR}" ]; then # Used in bats test cases for `make test`
-	libdir="${TEST_LIBDIR}"
+if [ -n "${ARCH_UPDATE_LIBDIR}" ]; then
+	libdir="${ARCH_UPDATE_LIBDIR}"
 elif [ -d "${XDG_DATA_HOME}/${name}/lib" ]; then
         libdir="${XDG_DATA_HOME}/${name}/lib"
 elif [ -d "${HOME}/.local/share/${name}/lib" ]; then

--- a/test/case/basic_functions.bats
+++ b/test/case/basic_functions.bats
@@ -1,4 +1,4 @@
-export TEST_LIBDIR="${PWD}/src/lib"
+export ARCH_UPDATE_LIBDIR="${PWD}/src/lib"
 
 @test "version" {
 	src/arch-update.sh --version


### PR DESCRIPTION
### Description

Rename the `TEST_LIBDIR` environment variable to `ARCH_UPDATE_LIBDIR`, which is more specific name wise (to avoid eventual conflicts) and is more generic usage wise (as it could be useful outside of `make test`, e.g. for people that want to use a custom library directory).