### PR TITLE
feat: apply DiffProg setting when using doas

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -242,7 +242,7 @@ Les options prises en charge sont :
 - PrivilegeElevationCommand=[Cmd] # Commande à utiliser pour l'élévation de privilège. Les valeurs valides sont `sudo`, `doas` ou `run0`. Si cette option n'est pas spécifiée, Arch-Update utilisera la première commande disponible dans l'odre suivant : `sudo`, `doas` puis `run0`.
 - KeepOldPackages=[Num] # Nombre d'anciennes versions de paquets à conserver dans le cache de pacman. La valeur par défaut est 3.
 - KeepUninstalledPackages=[Num] # Nombre de versions de paquets désinstallés à conserver dans le cache de pacman. La valeur par défaut est 0.
-- DiffProg=[Editeur] # Editeur à utiliser pour visualiser / editer les différences durant le traitement des fichiers pacnew. La valeur par défaut est la valeur de la variable d'environnement `$DIFFPROG` (ou `vimdiff` si `$DIFFPROG` n'est pas paramétrée). Notez qu'en raison de l'absence d'option pour préserver les variables d'environnement dans `doas`, cette option sera ignorée lors de l'utilisation de `doas` comme méthode d'élévation de privilèges.
+- DiffProg=[Editeur] # Editeur à utiliser pour visualiser / editer les différences durant le traitement des fichiers pacnew. La valeur par défaut est la valeur de la variable d'environnement `$DIFFPROG` (ou `vimdiff` si `$DIFFPROG` n'est pas paramétrée).
 - TrayIconStyle=[Style / Color] # Style à utiliser pour l'icône de l'applet systray. Les valeurs valides sont les variantes de style / couleur disponibles pour le set d'icône, listées ici : https://github.com/Antiz96/arch-update/tree/main/res/icons. La valeur par défaut est "light".
 
 Les options sont sensibles à la casse, les majuscules doivent donc être respectées.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The supported options are:
 - PrivilegeElevationCommand=[Cmd] # Command to be used for privilege elevation. Valid values are `sudo`, `doas` or `run0`. If this option is not set, Arch-Update will use the first available command in the following order: `sudo`, `doas` then `run0`.
 - KeepOldPackages=[Num] # Number of old packages' versions to keep in pacman's cache. Defaults to 3.
 - KeepUninstalledPackages=[Num] # Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 0.
-- DiffProg=[Editor] # Editor to use to visualize / edit differences during the pacnew files processing. Defaults to the `$DIFFPROG` environment variable's value (or `vimdiff` if `$DIFFPROG` isn't set). Note that, due to the lack of option to preserve environment variable in `doas`, this option will be ignored when using `doas` as the privilege elevation method.
+- DiffProg=[Editor] # Editor to use to visualize / edit differences during the pacnew files processing. Defaults to the `$DIFFPROG` environment variable's value (or `vimdiff` if `$DIFFPROG` isn't set).
 - TrayIconStyle=[Style / Color] # Style to be used for the systray applet icon. Valid values are the available style / color variants for the icon set, listed in https://github.com/Antiz96/arch-update/tree/main/res/icons. Defaults to "light".
 
 Options are case sensitive, so capital letters have to be respected.

--- a/doc/man/arch-update.conf.5
+++ b/doc/man/arch-update.conf.5
@@ -49,7 +49,7 @@ Number of uninstalled packages' versions to keep in pacman's cache. Defaults to 
 
 .TP
 .B DiffProg=[Editor]
-.RB "Editor to use to visualize / edit differences during the pacnew files processing. Defaults to the " "$DIFFPROG " "environment variable's value (or " "vimdiff " "if " "$DIFFPROG " "isn't set). Note that, due to the lack of option to preserve environment variable in " "doas " ", this option will be ignored when using " "doas " " as the privilege elevation method."
+.RB "Editor to use to visualize / edit differences during the pacnew files processing. Defaults to the " "$DIFFPROG " "environment variable's value (or " "vimdiff " "if " "$DIFFPROG " "isn't set)."
 
 .TP
 .B TrayIconStyle=[Style / Color]

--- a/doc/man/fr/arch-update.conf.5
+++ b/doc/man/fr/arch-update.conf.5
@@ -49,7 +49,7 @@ Nombre de versions de paquets désinstallés à conserver dans le cache de pacma
 
 .TP
 .B DiffProg=[Editeur]
-.RB "Editeur à utiliser pour visualiser / editer les différences durant le traitement des fichiers pacnew. La valeur par défaut est la valeur de la variable d'environnement " "$DIFFPROG " "(ou " "vimdiff " "si " "$DIFFPROG " "n'est pas paramétrée). Notez qu'en raison de l'absence d'option pour préserver les variables d'environnement dans " "doas " ", cette option sera ignorée lors de l'utilisation de " "doas " "comme méthode d'élévation de privilèges."
+.RB "Editeur à utiliser pour visualiser / editer les différences durant le traitement des fichiers pacnew. La valeur par défaut est la valeur de la variable d'environnement " "$DIFFPROG " "(ou " "vimdiff " "si " "$DIFFPROG " "n'est pas paramétrée)."
 
 .TP
 .B TrayIconStyle=[Style / Color]

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -163,6 +163,8 @@ if [ -n "${diff_prog}" ]; then
 	else
 		if [ "${su_cmd}" == "sudo" ]; then
 			diff_prog_opt=("DIFFPROG=${diff_prog}")
+		elif [ "${su_cmd}" == "doas" ]; then
+			diff_prog_opt=("env" "DIFFPROG=${diff_prog}")
 		elif [ "${su_cmd}" == "run0" ]; then
 			diff_prog_opt+=("--setenv=DIFFPROG=${diff_prog}")
 		fi


### PR DESCRIPTION
<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

<!-- Describe your changes -->

Use /usr/bin/env to set the DIFFPROG environment variable for the execution of pacdiff. The manpages and READMEs were also changed to remove the note about DiffProg and doas 
