### PR TITLE
doc: Document the usage of `xdg-terminal-exec` to run Arch-Update in a specific terminal emulator

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -117,20 +117,9 @@ Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pou
 
 **Si l'applet systray ne démarre pas au démarrage du système malgré tout**, veuillez lire [ce chapitre](#lapplet-systray-ne-démarre-pas-au-démarrage-du-système).
 
-L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, elle lance `arch-update` via le fichier [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
+L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ('à jour' ou 'mises à jour disponibles'). Lorsque vous cliquez dessus, elle lance `arch-update` dans une fenêtre de terminal via le fichier [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop).
 
-L'applet systray essaie de lire le fichier `arch-update.desktop` dans les chemins ci-dessous avec l'ordre suivant :
-
-- `$XDG_DATA_HOME/applications/arch-update.desktop`
-- `$HOME/.local/share/applications/arch-update.desktop`
-- `$XDG_DATA_DIRS/applications/arch-update.desktop`
-- `/usr/local/share/applications/arch-update.desktop` <-- Chemin d'installation par défaut lorsque vous installez Arch-Update [depuis la source](#depuis-la-source)
-- `/usr/share/applications/arch-update.desktop` <-- Chemin d'installation par défaut lorsque vous installez Arch-Update [depuis le AUR](#AUR)
-
-Dans le cas où vous avez envie (ou besoin) de personnaliser le fichier `arch-update.desktop`, copiez le dans un chemin qui a une priorité plus élevée que le chemin d'installation par défaut et modifier le ici (afin d'assurer que votre ficher `arch-update.desktop` personnalisé remplace celui par défaut et que vos modifications ne soient pas écrasées à chaque mise à jour).
-
-Cela peut être utile pour forcer `Arch-Update` à se lancer avec un émulateur de terminal spécifique lorsque l'on clique sur l'applet systray.  
-**Si cliquer sur l'applet systray ne fait rien**, veuillez lire [ce chapitre](#forcer-le-fichier-desktop-à-se-lancer-avec-un-émulateur-de-terminal-spécifique).
+**Si cliquer sur l'applet systray ne fait rien**, veuillez lire [ce chapitre](#lancer-arch-update-dans-un-émulateur-de-terminal-spécifique).
 
 ### Le timer systemd
 
@@ -318,20 +307,13 @@ Voir <https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#
 
 Dans le cas où vous voulez qu'`Arch-Update` ne vérifie les nouvelles mises à jour qu'une fois au démarrage du système, vous pouvez simplement supprimer la ligne `OnUnitActiveSec` complètement.
 
-### Forcer le fichier desktop à se lancer avec un émulateur de terminal spécifique
+### Lancer Arch-Update dans un émulateur de terminal spécifique
 
-`gio` (qui est utilisé pour lancer le fichier `arch-update.desktop` quand l'applet systray est cliquée) ne supporte actuellement qu'une [liste limitée d'émulateurs de terminal](https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gdesktopappinfo.c#L2694).  
-Si vous n'avez aucun de ces émulateurs de terminal installé sur votre système, il se peut que vous soyez confronté à un problème où cliquer sur l'applet systray [ne fait rien](https://github.com/Antiz96/arch-update/issues/162) et rapporte l'erreur suivante : `[...] Unable to find terminal required for application`.
+`gio` (utilisé pour lancer l'application `arch-update` dans un terminal via le fichier `arch-update.desktop` lorsque l'applet systray est cliquée) a actuellement une liste limitée d'émulateurs de terminal connus par défaut.  
+Ainsi, si aucun de ces émulateurs de terminal "connus" n'est installé sur votre système, vous pourriez être confronté à un problème où le fait de cliquer sur l'applet du systray ne fait rien (car `gio` n'a pas pu trouver un émulateur de terminal dans la liste en question). Par ailleurs, vous pouvez avoir plusieurs émulateurs de terminal installés sur votre système. Dans les deux cas, vous pouvez spécifier quel émulateur de terminal utiliser.
 
-En attendant que Gnome implémente une méthode permettant aux utilisateurs d'utiliser l'émulateur de terminal de leur choix avec `gio` (ce qui, espérons-le, [arrivera à un moment ou à un autre](https://gitlab.freedesktop.org/terminal-wg/specifications/-/merge_requests/3)), vous pouvez contourner le problème en copiant le fichier `arch-update.desktop` dans `$HOME/.local/share/applications/arch-update.desktop` (par exemple, voir [ce chapitre](#lapplet-systray) pour plus de détails) et en modifiant la ligne `Exec` pour "forcer" `arch-update` à s'exécuter dans l'émulateur de terminal de votre choix.  
-Par exemple, avec [alacritty](https://alacritty.org/) *(vérifier le manuel de votre émulateur de terminal pour trouver la bonne option à utiliser)* :
-
-```text
-[...]
-Exec=alacritty -e arch-update
-```
-
-Alternativement, vous pouvez créer un lien symbolique de votre émulateur de terminal pointant vers `/usr/bin/xterm`, qui est l'option de "secours" pour `gio` (par exemple, avec [alacritty](https://alacritty.org) : `sudo ln -s /usr/bin/alacritty /usr/bin/xterm`) ou vous pouvez simplement installer un des émulateurs de terminal [supportés](https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gdesktopappinfo.c#L2701) par `gio`.
+Pour ce faire, installez le paquet AUR [xdg-terminal-exec](https://aur.archlinux.org/packages/xdg-terminal-exec), créez le fichier `~/.config/xdg-terminals.list` et ajoutez-y le nom du fichier `.desktop` de l'émulateur de terminal de votre choix (par exemple `Alacritty.desktop`).  
+Voir <https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#configuration> pour plus de détails.
 
 ## Contribuer
 

--- a/README.md
+++ b/README.md
@@ -117,20 +117,9 @@ If you use a Window Manager or a Wayland Compositor, you can add the `arch-updat
 
 **If the systray applet doesn't start at boot regardless**, please read [this chapter](#the-systray-applet-does-not-start-at-boot).
 
-The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches `arch-update` via the [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop) file.
+The systray icon will automatically change depending on the current state of your system ('up to date' or 'updates available'). When clicked, it launches `arch-update` in a terminal window via the [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop) file.
 
-The systray applet attempts to read the `arch-update.desktop` file at the below paths and in the following order:
-
-- `$XDG_DATA_HOME/applications/arch-update.desktop`
-- `$HOME/.local/share/applications/arch-update.desktop`
-- `$XDG_DATA_DIRS/applications/arch-update.desktop`
-- `/usr/local/share/applications/arch-update.desktop` <-- Default installation path when installing Arch-Update [from source](#from-source)
-- `/usr/share/applications/arch-update.desktop` <-- Default installation path when installing Arch-Update [from the AUR](#AUR)
-
-In case you want (or need) to customize the `arch-update.desktop` file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom `arch-update.desktop` file supersedes the default one and that your modifications are not being overwritten on updates).
-
-This can be useful to force `Arch-Update` to launch with a specific terminal emulator when clicking the systray applet for instance.  
-**If clicking the systray applet does nothing**, please read [this chapter](#force-the-desktop-file-to-run-with-a-specific-terminal-emulator).
+**If clicking the systray applet does nothing**, please read [this chapter](#run-arch-update-in-a-specific-terminal-emulator).
 
 ### The systemd timer
 
@@ -318,20 +307,13 @@ See <https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#P
 
 In case you want `Arch-Update` to check for new updates only once at boot, you can simply delete the `OnUnitActiveSec` line completely.
 
-### Force the desktop file to run with a specific terminal emulator
+### Run Arch-Update in a specific terminal emulator
 
-`gio` (which is used to launch the `arch-update.desktop` file when the systray applet is clicked) currently supports a [limited list of terminal emulators](https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gdesktopappinfo.c#L2694).  
-If you don't have any of these terminal emulators installed on your system, you might face an issue where clicking the systray applet [does nothing](https://github.com/Antiz96/arch-update/issues/162) and reports the following error: `[...] Unable to find terminal required for application`.
+`gio` (used to launch the `arch-update` terminal application via the `arch-update.desktop` file when the systray applet is clicked) currently has a default limited list of known terminal emulators.  
+As such, if you don't have any of these "known" terminal emulators installed on your system, you might face an issue where clicking the systray applet does nothing (as `gio` couldn't find a terminal emulator from the said list). Incidentally, you might have multiple terminal emulators installed on your system. In both cases, you can specify which terminal emulator to use.
 
-While waiting for Gnome to implement a way to allow people using their terminal emulator of choice with `gio` (which will hopefully [happen at some point](https://gitlab.freedesktop.org/terminal-wg/specifications/-/merge_requests/3)), you can workaround this issue by copying the `arch-update.desktop` file to `$HOME/.local/share/applications/arch-update.desktop` (for instance, see [this chapter](#the-systray-applet) for more details) and modifying the `Exec` line in it to "force" `arch-update` to run with your terminal emulator of choice.  
-For instance, with [alacritty](https://alacritty.org/) *(check your terminal emulator's manual to find the correct option to use)*:
-
-```text
-[...]
-Exec=alacritty -e arch-update
-```
-
-Alternatively, you can create a symlink for your terminal emulator that points to `/usr/bin/xterm`, which is the fallback option for `gio` (for instance, with [alacritty](https://alacritty.org): `sudo ln -s /usr/bin/alacritty /usr/bin/xterm`) or you can simply install one of the terminal emulators [supported](https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gdesktopappinfo.c#L2701) by `gio`.
+To do so, install the [xdg-terminal-exec AUR package](https://aur.archlinux.org/packages/xdg-terminal-exec), create the `~/.config/xdg-terminals.list` file and add the name of the `.desktop` file of your terminal emulator of choice in it (e.g. `Alacritty.desktop`).  
+See <https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#configuration> for more details.
 
 ## Contributing
 

--- a/doc/man/arch-update.1.scd
+++ b/doc/man/arch-update.1.scd
@@ -85,26 +85,11 @@ To start it automatically at boot, you can either:
 
 If you use a Window Manager or a Wayland Compositor, you can add the `arch-update --tray` command to your auto-start apps in your configuration file instead.
 
-If the systray applet doesn't start at boot regardless, please read the *"The systray applet does not start at boot"* chapter in the *"Tips and Tricks"* section below.
+*If the systray applet doesn't start at boot regardless*, please read the *"The systray applet does not start at boot"* chapter in the *"Tips and Tricks"* section below.
 
-The systray icon will automatically change depending on the current state of your system ("up to date" or "updates available"). When clicked, it launches `arch-update` via the `arch-update.desktop` file.
+The systray icon will automatically change depending on the current state of your system ("up to date" or "updates available"). When clicked, it launches `arch-update` in a terminal window via the `arch-update.desktop` file.
 
-The systray applet attempts to read the `arch-update.desktop` file at the below paths and in the following order:
-
-- `$XDG_DATA_HOME/applications/arch-update.desktop`
-
-- `$HOME/.local/share/applications/arch-update.desktop`
-
-- `$XDG_DATA_DIRS/applications/arch-update.desktop`
-
-- `/usr/local/share/applications/arch-update.desktop` <-- Default installation path when installing Arch-Update from source
-
-- `/usr/share/applications/arch-update.desktop` <-- Default installation path when installing Arch-Update from the AUR
-
-In case you want (or need) to customize the `arch-update.desktop` file, copy it in a path that has a higher priority than the default installation path and modify it there (to ensure that your custom `arch-update.desktop` file supersedes the default one and that your modifications are not being overwritten on updates).
-This can be useful to force the `arch-update.desktop` file to launch `Arch-Update` within a specific terminal emulator for instance.
-
-If clicking the systray applet does nothing, please read the *"Force the desktop file to run with a specific terminal emulator"* chapter in the *"Tips and Tricks"* section below.
+*If clicking the systray applet does nothing*, please read the *"Run Arch-Update in a specific terminal emulator"* chapter in the *"Tips and Tricks"* section below.
 
 ## The systemd timer
 
@@ -182,23 +167,14 @@ See https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#Pa
 
 In case you want `Arch-Update` to check for new updates only once at boot, you can simply delete the `OnUnitActiveSec` line completely.
 
-## Force the desktop file to run with a specific terminal emulator
+## Run Arch-Update in a specific terminal emulator
 
-"gio" (which is used to launch the `arch-update.desktop` file when the systray applet is clicked) currently supports a limited list of terminal emulators (see https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gdesktopappinfo.c#L2701).
+"gio" (used to launch the `arch-update` terminal application via the `arch-update.desktop` file when the systray applet is clicked) currently has a default limited list of known terminal emulators.  
+As such, if you don't have any of these "known" terminal emulators installed on your system, you might face an issue where clicking the systray applet does nothing (as `gio` couldn't find a terminal emulator from the said list). Incidentally, you might have multiple terminal emulators installed on your system. In both cases, you can specify which terminal emulator to use.
 
-If you don't have any of these terminal emulators installed on your system, you might face an issue where clicking the systray applet does nothing and reports the following error: "[...] Unable to find terminal required for application".
+To do so, install the `xdg-terminal-exec` AUR package (https://aur.archlinux.org/packages/xdg-terminal-exec), create the `~/.config/xdg-terminals.list` file and add the name of the `.desktop` file of your terminal emulator of choice in it (e.g. `Alacritty.desktop`).
 
-While waiting for Gnome to implement a way to allow people using their terminal emulator of choice with `gio`, you can workaround this issue by copying the `arch-update.desktop` file to `$HOME/.local/share/applications/arch-update.desktop` (for instance, see *"The systray applet"* chapter for more details) and modifying the `Exec=` line in it to 'force' `arch-update` to run with your terminal emulator of choice.
-
-For instance, with "alacritty" (check your terminal emulator's manual to find the correct option to use):
-
-```
-[...]
-Exec=alacritty -e arch-update
-[...]
-```
-
-Alternatively, you can create a symlink for your terminal emulator that points to `/usr/bin/xterm`, which is the fallback option for `gio` (for instance, with "alacritty": `sudo ln -s /usr/bin/alacritty /usr/bin/xterm`) or you can simply install one of the terminal emulators supported by `gio` (see https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gdesktopappinfo.c#L2701).
+See https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#configuration for more details.
 
 # EXIT STATUS
 

--- a/doc/man/fr/arch-update.1.scd
+++ b/doc/man/fr/arch-update.1.scd
@@ -86,26 +86,11 @@ Pour la démarrer automatiquement au démarrage du système, utilisez l'une des 
 
 Si vous utilisez un gestionnaire de fenêtre ou un compositeur Wayland, vous pouvez plutôt ajouter la commande `arch-update --tray` à vos applications auto-start dans votre fichier de configuration.
 
-Si l'applet systray ne démarre pas au démarrage du système malgré tout, veuillez lire le chapitre *"l'applet systray ne démarre pas au démarrage du système"* dans la section *"Trucs et Astuces"* ci-dessous.
+*Si l'applet systray ne démarre pas au démarrage du système malgré tout*, veuillez lire le chapitre *"l'applet systray ne démarre pas au démarrage du système"* dans la section *"Trucs et Astuces"* ci-dessous.
 
-L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ("à jour" ou "mises à jour disponibles"). Lorsque vous cliquez dessus, elle lance `arch-update` via le fichier `arch-update.desktop`.
+L'icône du systray changera automatiquement en fonction de l'état actuel de votre système ("à jour" ou "mises à jour disponibles"). Lorsque vous cliquez dessus, elle lance `arch-update` dans une fenêtre de terminal via le fichier `arch-update.desktop`.
 
-L'applet systray essaie de lire le fichier `arch-update.desktop` dans les chemins ci-dessous avec l'ordre suivant :
-
-- `$XDG_DATA_HOME/applications/arch-update.desktop`
-
-- `$HOME/.local/share/applications/arch-update.desktop`
-
-- `$XDG_DATA_DIRS/applications/arch-update.desktop`
-
-- `/usr/local/share/applications/arch-update.desktop` <-- Chemin d'installation par défaut lorsque vous installez Arch-Update depuis la source
-
-- `/usr/share/applications/arch-update.desktop` <-- Chemin d'installation par défaut lorsque vous installez Arch-Update depuis le AUR
-
-Dans le cas où vous avez envie (ou besoin) de personnaliser le fichier `arch-update.desktop`, copiez le dans un chemin qui a une priorité plus élevée que le chemin d'installation par défaut et modifiez le ici (afin d'assurer que votre ficher `arch-update.desktop` personnalisé remplace celui par défaut et que vos modifications ne soient pas écrasées à chaque mise à jour).
-Cela peut être utile pour forcer le fichier `arch-update.desktop` à lancer `Arch-Update` dans un émulateur de terminal spécifique par exemple.
-
-Si cliquer sur l'applet systray ne fait rien, veuillez lire le chapitre *"Forcer le fichier desktop à se lancer avec un émulateur de terminal spécifique"* dans la section *"Trucs et Astuces"* ci-dessous.
+*Si cliquer sur l'applet systray ne fait rien*, veuillez lire le chapitre *"Lancer Arch-Update dans un émulateur de terminal spécifique"* dans la section *"Trucs et Astuces"* ci-dessous.
 
 ## Le timer systemd
 
@@ -183,23 +168,14 @@ Voir https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html#P
 
 Dans le cas où vous voulez qu'`Arch-Update` ne vérifie les nouvelles mises à jour qu'une fois au démarrage du système, vous pouvez simplement supprimer la ligne `OnUnitActiveSec` complètement.
 
-## Forcer le fichier desktop à se lancer avec un émulateur de terminal spécifique
+## Lancer Arch-Update dans un émulateur de terminal spécifique
 
-"gio" (qui est utilisé pour lancer le fichier `arch-update.desktop` quand l'applet systray est cliquée) ne supporte actuellement qu'une liste limitée d'émulateurs de terminal (voir https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gdesktopappinfo.c#L2701).
+"gio" (utilisé pour lancer l'application `arch-update` dans un terminal via le fichier `arch-update.desktop` lorsque l'applet systray est cliquée) a actuellement une liste limitée d'émulateurs de terminal connus par défaut.  
+Ainsi, si aucun de ces émulateurs de terminal "connus" n'est installé sur votre système, vous pourriez être confronté à un problème où le fait de cliquer sur l'applet du systray ne fait rien (car `gio` n'a pas pu trouver un émulateur de terminal dans la liste en question). Par ailleurs, vous pouvez avoir plusieurs émulateurs de terminal installés sur votre système. Dans les deux cas, vous pouvez spécifier quel émulateur de terminal utiliser.
 
-Si vous n'avez aucun de ces émulateurs de terminal installé sur votre système, il se peut que vous soyez confronté à un problème où cliquer sur l'applet systray ne fait rien et rapporte l'erreur suivante : "[...] Unable to find terminal required for application".
+Pour ce faire, installez le paquet AUR `xdg-terminal-exec` (https://aur.archlinux.org/packages/xdg-terminal-exec), créez le fichier `~/.config/xdg-terminals.list` et ajoutez-y le nom du fichier `.desktop` de l'émulateur de terminal de votre choix (par exemple `Alacritty.desktop`).
 
-En attendant que Gnome implémente une méthode permettant aux utilisateurs d'utiliser l'émulateur de terminal de leur choix avec `gio`,vous pouvez contourner le problème en copiant le fichier `arch-update.desktop` dans `$HOME/.local/share/applications/arch-update.desktop` (par exemple, voir le chapitre *"L'applet systray"* pour plus de détails) et en modifiant la ligne `Exec=` pour 'forcer' `arch-update` à s'exécuter dans l'émulateur de terminal de votre choix.
-
-Par exemple, avec `alacritty` (vérifier le manuel de votre émulateur de terminal pour trouver la bonne option à utiliser):
-
-```
-[...]
-Exec=alacritty -e arch-update
-[...]
-```
-
-Alternativement, vous pouvez créer un lien symbolique de votre émulateur de terminal pointant vers `/usr/bin/xterm`, qui est l'option de 'secours' pour `gio` (par exemple, avec `alacritty` : `sudo ln -s /usr/bin/alacritty /usr/bin/xterm`) ou vous pouvez simplement installer un des émulateurs de terminal supportés par `gio` (voir https://gitlab.gnome.org/GNOME/glib/-/blob/main/gio/gdesktopappinfo.c#L2701).
+Voir https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#configuration pour plus de détails.
 
 # EXIT STATUS
 


### PR DESCRIPTION
### Description

The previous documentation to force the usage of an alternative terminal emulator was "messy" and mildly accurate.

This commit updates the documentation to recommended the usage of the [xdg-terminal-exec](https://github.com/Vladimir-csp/xdg-terminal-exec) specification instead, which is a way more sane approach.

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/289