### PR TITLE
feat: Add the `NoNotification` option to `arch-update.conf`

### DIFF
--- a/doc/man/arch-update.conf.5.scd
+++ b/doc/man/arch-update.conf.5.scd
@@ -26,6 +26,9 @@ Options are case sensitive, so capital letters have to be respected.
 *NoVersion*
 	Do not show versions changes for packages when listing pending updates (including when using the `-l / --list` option, see the *arch-update*(1) man page for more details).
 
+*NoNotification*
+	Do not send desktop notifications.
+
 *NewsNum=[Num]*
 	Number of Arch news to display before updating and with the `-n / --news` option (see the *arch-update*(1) man page for more details). Defaults to 5.
 

--- a/doc/man/fr/arch-update.conf.5.scd
+++ b/doc/man/fr/arch-update.conf.5.scd
@@ -26,6 +26,9 @@ Les options sont sensibles à la casse, les majuscules doivent donc être respec
 *NoVersion*
 	Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente (y compris lors de l'utilisation de l'option `-l / --list`, voir la page de manuel *arch-update*(1) pour plus de détails).
 
+*NoNotification*
+	Ne pas envoyer de notifications de bureau.
+
 *NewsNum=[Num]*
 	Nombre de Arch news à afficher avant la mise à jour et avec l'option `-n / --news` (voir la page de manuel *arch-update*(1) pour plus de détails). La valeur par défaut est 5.
 

--- a/res/config/arch-update.conf.example
+++ b/res/config/arch-update.conf.example
@@ -4,6 +4,7 @@
 
 #NoColor
 #NoVersion
+#NoNotification
 #NewsNum=5
 #AURHelper=paru
 #PrivilegeElevationCommand=sudo

--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -18,17 +18,15 @@ if [ -n "${no_version}" ]; then
 	update_available=$(echo "${update_available}" | awk '{print $1}')
 fi
 
-if [ -n "${notif}" ]; then
-	# shellcheck disable=SC2154
-	echo "${update_available}" > "${statedir}/current_updates_check"
-	sed -i '/^\s*$/d' "${statedir}/current_updates_check"
-	sed -ri 's/\x1B\[[0-9;]*m//g' "${statedir}/current_updates_check"
-fi
+# shellcheck disable=SC2154
+echo "${update_available}" > "${statedir}/current_updates_check"
+sed -i '/^\s*$/d' "${statedir}/current_updates_check"
+sed -ri 's/\x1B\[[0-9;]*m//g' "${statedir}/current_updates_check"
 
 if [ -n "${update_available}" ]; then
 	icon_updates-available
 
-	if [ -n "${notif}" ]; then
+	if [ -n "${notif}" ] && [ -z "${no_notification}" ]; then
 		if ! diff "${statedir}/current_updates_check" "${statedir}/last_updates_check" &> /dev/null; then
 			update_number=$(wc -l "${statedir}/current_updates_check" | awk '{print $1}')
 			# shellcheck disable=SC2154

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -18,6 +18,10 @@ if [ -f "${config_file}" ]; then
 	# shellcheck disable=SC2034
 	no_version=$(grep -Eq '^[[:space:]]*NoVersion[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
 
+	# Check the "NoNotification" option in arch-update.conf
+	# shellcheck disable=SC2034
+	no_notification=$(grep -Eq '^[[:space:]]*NoNotification[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
+
 	# Check the "NewsNum" option in arch-update.conf
 	# shellcheck disable=SC2034
 	news_num=$(grep -E '^[[:space:]]*NewsNum[[:space:]]*=[[:space:]]*[1-9][0-9]*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')


### PR DESCRIPTION
### Description

Add the `NoNotification` option in the `arch-update.conf` configuration file to disable desktop notification (the systray icon still acts as a visual indicator for available updates).

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/297
