### PR TITLE
chore: Use more specific names for 'notif' and 'flatpak' variables

### DIFF
--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -4,11 +4,11 @@
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-if [ -n "${aur_helper}" ] && [ -n "${flatpak}" ]; then
+if [ -n "${aur_helper}" ] && [ -n "${flatpak_support}" ]; then
 	update_available=$(checkupdates ; "${aur_helper}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' ; flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
-elif [ -n "${aur_helper}" ] && [ -z "${flatpak}" ]; then
+elif [ -n "${aur_helper}" ] && [ -z "${flatpak_support}" ]; then
 	update_available=$(checkupdates ; "${aur_helper}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g')
-elif [ -z "${aur_helper}" ] && [ -n "${flatpak}" ]; then
+elif [ -z "${aur_helper}" ] && [ -n "${flatpak_support}" ]; then
 	update_available=$(checkupdates ; flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 else
 	update_available=$(checkupdates)
@@ -26,7 +26,7 @@ sed -ri 's/\x1B\[[0-9;]*m//g' "${statedir}/current_updates_check"
 if [ -n "${update_available}" ]; then
 	icon_updates-available
 
-	if [ -n "${notif}" ] && [ -z "${no_notification}" ]; then
+	if [ -n "${notification_support}" ] && [ -z "${no_notification}" ]; then
 		if ! diff "${statedir}/current_updates_check" "${statedir}/last_updates_check" &> /dev/null; then
 			update_number=$(wc -l "${statedir}/current_updates_check" | awk '{print $1}')
 			# shellcheck disable=SC2154

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -130,11 +130,11 @@ fi
 
 # Check if flatpak is installed for the optional Flatpak support
 # shellcheck disable=SC2034
-flatpak=$(command -v flatpak)
+flatpak_support=$(command -v flatpak)
 
 # Check if notify-send is installed for the optional desktop notification support
 # shellcheck disable=SC2034
-notif=$(command -v notify-send)
+notification_support=$(command -v notify-send)
 
 # Definition of the elevation command to use (depending on which one is installed on the system and if it's not already defined in arch-update.conf)
 if [ -z "${su_cmd}" ]; then

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -24,7 +24,7 @@ if [ -n "${aur_helper}" ]; then
 	fi
 fi
 
-if [ -n "${flatpak}" ]; then
+if [ -n "${flatpak_support}" ]; then
 	flatpak_packages=$(flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 fi
 

--- a/src/lib/orphan_packages.sh
+++ b/src/lib/orphan_packages.sh
@@ -6,7 +6,7 @@
 
 orphan_packages=$(pacman -Qtdq)
 
-if [ -n "${flatpak}" ]; then
+if [ -n "${flatpak_support}" ]; then
 	flatpak_unused=$(flatpak uninstall --unused | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 fi
 
@@ -44,7 +44,7 @@ else
 	info_msg "$(eval_gettext "No orphan package found\n")"
 fi
 
-if [ -n "${flatpak}" ]; then
+if [ -n "${flatpak_support}" ]; then
 	if [ -n "${flatpak_unused}" ]; then
 		main_msg "$(eval_gettext "Flatpak Unused Packages:")"
 		echo -e "${flatpak_unused}\n"


### PR DESCRIPTION
### Description

Rename 'notif' and 'flatpak' variables to 'notification_support' and 'flatpak_support' respectively for a better clarity / to avoid confusions.