### PR TITLE
fix: Filter out ignored packages when checking for AUR packages update with paru

### DIFF
--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 if [ -n "${aur_helper}" ] && [ -n "${flatpak_support}" ]; then
-	update_available=$(checkupdates ; "${aur_helper}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' ; flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
+	update_available=$(checkupdates ; "${aur_helper}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$" ; flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 elif [ -n "${aur_helper}" ] && [ -z "${flatpak_support}" ]; then
-	update_available=$(checkupdates ; "${aur_helper}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g')
+	update_available=$(checkupdates ; "${aur_helper}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$")
 elif [ -z "${aur_helper}" ] && [ -n "${flatpak_support}" ]; then
 	update_available=$(checkupdates ; flatpak update | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
 else

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -17,10 +17,10 @@ fi
 if [ -n "${aur_helper}" ]; then
 	if [ -z "${no_version}" ]; then
 		# shellcheck disable=SC2154
-		aur_packages=$("${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g')
+		aur_packages=$("${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$")
 	else
 		# shellcheck disable=SC2154
-		aur_packages=$("${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' | awk '{print $1}')
+		aur_packages=$("${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$" | awk '{print $1}')
 	fi
 fi
 


### PR DESCRIPTION
<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

`paru` still shows packages listed in pacman.conf's `IgnorePkg` array when checking for update with `-Qua`, creating false positives when checking for updates with `arch-update`. This commit properly filters out packages tagged as `[ignored]` from the `paru` output to prevent such false positives.

*For information, `pikaur` also shows packages listed in `IgnorePkg` in its output but in `stderr`, which is already filtered out by `arch-update` (so no fix needed for `pikaur`). `yay` completely ignores packages listed in `IgnorePkg` already (just like `checkupdates` does for packages from the repos).*

### Screenshots / Logs

From https://github.com/Antiz96/arch-update/issues/304:

![Image](https://github.com/user-attachments/assets/c7434691-aba5-41ac-8674-88519a8fd594)

```text
$ arch-update
==> Looking for updates...

==> AUR Packages:
bcompare 4.4.7.28397-1 -> 5.0.5.30614-1 [ignored]

-> Proceed with update? [Y/n]
```

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/304