### PR TITLE
feat: Add the `NoFlatpak` option to `arch-update.conf`

### DIFF
--- a/doc/man/arch-update.conf.5.scd
+++ b/doc/man/arch-update.conf.5.scd
@@ -26,6 +26,9 @@ Options are case sensitive, so capital letters have to be respected.
 *NoVersion*
 	Do not show versions changes for packages when listing pending updates (including when using the `-l / --list` option, see the *arch-update*(1) man page for more details).
 
+*NoFlatpak*
+	Ignore Flatpak packages support.
+
 *NoNotification*
 	Do not send desktop notifications.
 

--- a/doc/man/fr/arch-update.conf.5.scd
+++ b/doc/man/fr/arch-update.conf.5.scd
@@ -26,6 +26,9 @@ Les options sont sensibles à la casse, les majuscules doivent donc être respec
 *NoVersion*
 	Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente (y compris lors de l'utilisation de l'option `-l / --list`, voir la page de manuel *arch-update*(1) pour plus de détails).
 
+*NoFlatpak*
+	Ignorer la prise en charge des paquets Flatpak.
+
 *NoNotification*
 	Ne pas envoyer de notifications de bureau.
 

--- a/res/config/arch-update.conf.example
+++ b/res/config/arch-update.conf.example
@@ -4,6 +4,7 @@
 
 #NoColor
 #NoVersion
+#NoFlatpak
 #NoNotification
 #NewsNum=5
 #AURHelper=paru

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -129,8 +129,10 @@ else
 fi
 
 # Check if flatpak is installed for the optional Flatpak support
-# shellcheck disable=SC2034
-flatpak_support=$(command -v flatpak)
+if [ -z "${no_flatpak}" ]; then
+	# shellcheck disable=SC2034
+	flatpak_support=$(command -v flatpak)
+fi
 
 # Check if notify-send is installed for the optional desktop notification support
 if [ -z "${no_notification}" ]; then

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -18,6 +18,10 @@ if [ -f "${config_file}" ]; then
 	# shellcheck disable=SC2034
 	no_version=$(grep -Eq '^[[:space:]]*NoVersion[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
 
+	# Check the "NoFlatpak" option in arch-update.conf
+	# shellcheck disable=SC2034
+	no_flatpak=$(grep -Eq '^[[:space:]]*NoFlatpak[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
+
 	# Check the "NoNotification" option in arch-update.conf
 	# shellcheck disable=SC2034
 	no_notification=$(grep -Eq '^[[:space:]]*NoNotification[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")


### PR DESCRIPTION
### Description

Add the `NoFlatpak` option in the `arch-update.conf` configuration file to ignore Flatpak packages support (even if `flatpak` is installed).