### PR TITLE
feat: Add the `NoAUR` option to `arch-update.conf`

### DIFF
--- a/doc/man/arch-update.conf.5.scd
+++ b/doc/man/arch-update.conf.5.scd
@@ -26,6 +26,9 @@ Options are case sensitive, so capital letters have to be respected.
 *NoVersion*
 	Do not show versions changes for packages when listing pending updates (including when using the `-l / --list` option, see the *arch-update*(1) man page for more details).
 
+*NoAUR*
+	Ignore AUR packages support.
+
 *NoFlatpak*
 	Ignore Flatpak packages support.
 

--- a/doc/man/fr/arch-update.conf.5.scd
+++ b/doc/man/fr/arch-update.conf.5.scd
@@ -26,6 +26,9 @@ Les options sont sensibles à la casse, les majuscules doivent donc être respec
 *NoVersion*
 	Ne pas afficher les modifications de versions des paquets lors du listing des mises à jour en attente (y compris lors de l'utilisation de l'option `-l / --list`, voir la page de manuel *arch-update*(1) pour plus de détails).
 
+*NoAUR*
+	Ignorer la prise en charge des paquets AUR.
+
 *NoFlatpak*
 	Ignorer la prise en charge des paquets Flatpak.
 

--- a/res/config/arch-update.conf.example
+++ b/res/config/arch-update.conf.example
@@ -4,6 +4,7 @@
 
 #NoColor
 #NoVersion
+#NoAUR
 #NoFlatpak
 #NoNotification
 #NewsNum=5

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -109,22 +109,24 @@ quit_msg() {
 }
 
 # Definition of the AUR helper to use (depending on if / which one is installed on the system and if it's not already defined in arch-update.conf) for the optional AUR packages support
-# shellcheck disable=SC2034
-if [ -z "${aur_helper}" ]; then
-	if command -v paru > /dev/null; then
-		# shellcheck disable=SC2034
-		aur_helper="paru"
-	elif command -v yay > /dev/null; then
-		# shellcheck disable=SC2034
-		aur_helper="yay"
-	elif command -v pikaur > /dev/null; then
-		# shellcheck disable=SC2034
-		aur_helper="pikaur"
-	fi
-else
-	if ! command -v "${aur_helper}" > /dev/null; then
-		warning_msg "$(eval_gettext "The \${aur_helper} AUR helper set for AUR packages support in the arch-update.conf configuration file is not found\n")"
-		unset aur_helper
+if [ -z "${no_aur}" ]; then
+	# shellcheck disable=SC2034
+	if [ -z "${aur_helper}" ]; then
+		if command -v paru > /dev/null; then
+			# shellcheck disable=SC2034
+			aur_helper="paru"
+		elif command -v yay > /dev/null; then
+			# shellcheck disable=SC2034
+			aur_helper="yay"
+		elif command -v pikaur > /dev/null; then
+			# shellcheck disable=SC2034
+			aur_helper="pikaur"
+		fi
+	else
+		if ! command -v "${aur_helper}" > /dev/null; then
+			warning_msg "$(eval_gettext "The \${aur_helper} AUR helper set for AUR packages support in the arch-update.conf configuration file is not found\n")"
+			unset aur_helper
+		fi
 	fi
 fi
 

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -18,6 +18,10 @@ if [ -f "${config_file}" ]; then
 	# shellcheck disable=SC2034
 	no_version=$(grep -Eq '^[[:space:]]*NoVersion[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
 
+	# Check the "NoAUR" option in arch-update.conf
+	# shellcheck disable=SC2034
+	no_aur=$(grep -Eq '^[[:space:]]*NoAUR[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")
+
 	# Check the "NoFlatpak" option in arch-update.conf
 	# shellcheck disable=SC2034
 	no_flatpak=$(grep -Eq '^[[:space:]]*NoFlatpak[[:space:]]*$' "${config_file}" 2> /dev/null && echo "true")


### PR DESCRIPTION
### Description

Add the `NoAUR` option in the `arch-update.conf` configuration file to ignore AUR packages support (even if `paru`, `yay` or `pikaur` is installed).