### PR TITLE
doc: Update man page link in default / example configuration file

### DIFF
--- a/res/config/arch-update.conf.example
+++ b/res/config/arch-update.conf.example
@@ -1,5 +1,5 @@
 # Arch-Update example configuration file (available at <https://github.com/Antiz96/arch-update/blob/main/res/config/arch-update.conf.example>).
-# Documentation for the configuration file is available in the arch-update.conf(5) man page and at <https://github.com/Antiz96/arch-update?tab=readme-ov-file#arch-update-configuration-file>.
+# Documentation for this configuration file is available in the arch-update.conf(5) man page (see <https://github.com/Antiz96/arch-update/blob/main/doc/man/arch-update.conf.5.scd>).
 # List of available options (with their default value) below, un-comment one to enable it.
 
 #NoColor


### PR DESCRIPTION
### Description

The link to the README currently contained in the default / example configuration file for its documentation is outdated.