### PR TITLE
chore: Make scripts more robust when using `mkdir`

### DIFF
--- a/doc/man/arch-update.1.scd
+++ b/doc/man/arch-update.1.scd
@@ -233,6 +233,9 @@ See https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#configu
 *15*
 	The "diff prog" editor set in the `arch-update.conf` configuration file isn't found.
 
+*16*
+	Error when creating the `statedir` and / or the `tmpdir` directories.
+
 # SEE ALSO
 
 *checkupdates*(8),

--- a/doc/man/fr/arch-update.1.scd
+++ b/doc/man/fr/arch-update.1.scd
@@ -233,6 +233,9 @@ Voir https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#config
 *15*
 	L'éditeur "diff prog" défini dans le fichier de configuration `arch-update.conf` n'a pas été trouvé.
 
+*16*
+	Erreur lors de la création des répertoires `statedir` et / ou `tmpdir`.
+
 # VOIR AUSSI
 
 *checkupdates*(8),

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -25,7 +25,7 @@ esac
 # shellcheck disable=SC2154
 statedir="${XDG_STATE_HOME:-${HOME}/.local/state}/${name}"
 tmpdir="${TMPDIR:-/tmp}/${name}-${UID}"
-mkdir -p "${statedir}" "${tmpdir}"
+mkdir -p "${statedir}" "${tmpdir}" || exit 16
 
 # Declare necessary parameters for translations
 # shellcheck disable=SC1091

--- a/src/lib/gen-config.sh
+++ b/src/lib/gen-config.sh
@@ -25,7 +25,7 @@ if [ -f "${config_file}" ] && [ -z "${overwrite_config_file}" ]; then
 	error_msg "$(eval_gettext "The '\${config_file}' configuration file already exists\nPlease, remove it before generating a new one (or use --force to overwrite it)")"
 	exit 8
 else
-	mkdir -p "${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/"
+	mkdir -p "${XDG_CONFIG_HOME:-${HOME}/.config}/${name}/" || exit 8
 	cp -f "${example_config_file}" "${config_file}" || exit 8
 	info_msg "$(eval_gettext "The '\${config_file}' configuration file has been generated")"
 fi

--- a/src/lib/tray.sh
+++ b/src/lib/tray.sh
@@ -27,7 +27,7 @@ if [ "${2}" == "--enable" ]; then
 		error_msg "$(eval_gettext "The '\${tray_desktop_file_autostart}' file already exists")"
 		exit 10
 	else
-		mkdir -p "${XDG_CONFIG_HOME:-${HOME}/.config}/autostart/"
+		mkdir -p "${XDG_CONFIG_HOME:-${HOME}/.config}/autostart/" || exit 10
 		cp "${tray_desktop_file}" "${tray_desktop_file_autostart}" || exit 10
 		info_msg "$(eval_gettext "The '\${tray_desktop_file_autostart}' file has been created, the Arch-Update systray applet will be automatically started at your next log on\nTo start it right now, you can launch the \"Arch-Update Systray Applet\" application from your app menu")"
 	fi


### PR DESCRIPTION
### Description

Make scripts exit on `mkdir` failures to avoid running tasks with an non-existent `tmpdir`, `statedir` or `configdir` for instance.