### PR TITLE
chore: Remove the list of pending updates from the systray's tooltip

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -151,11 +151,7 @@ Si de nouvelles mises à jour sont disponibles, l'icône du systray affiche un c
 
 ![notif_fr](https://github.com/user-attachments/assets/56d72147-bde4-492b-8ad1-20caed9f22a9)
 
-Vous pouvez alors voir la liste des mises à jour disponibles dans l'infobulle de l'icône du systray en passant votre souris dessus :
-
-![tooltip_fr](https://github.com/user-attachments/assets/8bc3d339-f7ab-4c8b-aa3f-2b88ea68af42)
-
-Autrement, vous pouvez voir la liste des mises à jour disponible dans le menu déroulant en faisant un clic droit sur l'icône du systray :
+Vous pouvez voir la liste des mises à jour disponible dans le menu déroulant en faisant un clic droit sur l'icône du systray :
 
 ![dropdown_menu_fr](https://github.com/user-attachments/assets/60c3c0d8-8091-4047-b8da-ce8f8bc72476)
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,7 @@ If there are new available updates, the systray icon shows a red circle and a de
 
 ![notif](https://github.com/user-attachments/assets/55301470-fab6-463f-af2e-ebe4e3d65af7)
 
-You can then see the list of available updates in the systray icon's tooltip by hovering your mouse over it:
-
-![tooltip](https://github.com/user-attachments/assets/52ee0608-a8a2-4be9-ba9b-badeb8720ba1)
-
-Alternatively, you can see the list of available updates in the dropdown menu entry by right-clicking the systray icon:
+You can see the list of available updates in the dropdown menu entry by right-clicking the systray icon:
 
 ![dropdown_menu](https://github.com/user-attachments/assets/4621d7d2-a9e4-40c3-851f-ee1687e6cf1e)
 

--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -90,9 +90,9 @@ class ArchUpdateQt6:
     """ System Tray using QT6 library """
 
     def file_changed(self):
-        """ Update icon, tooltip and dropdown menu on state file content changes """
+        """ Update icon and dropdown menu on state file content changes """
         self.update_icon()
-        self.update_tooltip_and_dropdown_menu()
+        self.update_dropdown_menu()
 
     def update_icon(self):
         """ Update the tray icon based on the icon state file content """
@@ -110,8 +110,8 @@ class ArchUpdateQt6:
             icon = QIcon.fromTheme(contents)
             self.tray.setIcon(icon)
 
-    def update_tooltip_and_dropdown_menu(self):
-        """ Update the tooltip with the number / list of pending updates """
+    def update_dropdown_menu(self):
+        """ Update the dropdown with the number / list of pending updates """
         if self.watcher and not self.updatesfile in self.watcher.files():
             self.watcher.addPath(self.updatesfile)
 
@@ -120,8 +120,6 @@ class ArchUpdateQt6:
                 updates_list = f.readlines()
         except FileNotFoundError:
             log.error("State updates file missing")
-            tooltip = _("'updates' state file isn't found")
-            self.tray.setToolTip(tooltip)
             self.dropdown_menu.setTitle(_("'updates' state file isn't found"))
             self.dropdown_menu.setEnabled(False)
             return
@@ -132,22 +130,16 @@ class ArchUpdateQt6:
         updates_count = len(updates_list)
 
         if updates_count == 0:
-            tooltip = _("System is up to date")
             self.dropdown_menu.setTitle(_("System is up to date"))
             self.dropdown_menu.setEnabled(False)
         elif updates_count == 1:
-            update_list = "".join(updates_list)
-            tooltip = _("1 update available\n\n{update_list}").format(update_list=update_list)
             self.dropdown_menu.setTitle(_("1 update available"))
             self.dropdown_menu.setEnabled(True)
         else:
-            update_list = "\n".join(updates_list)
-            tooltip = _("{updates} updates available\n\n{update_list}").format(updates=updates_count, update_list=update_list)
             self.dropdown_menu.setTitle(_("{updates} updates available").format(updates=updates_count))
             self.dropdown_menu.setEnabled(True)
 
-        # Update tooltip and dropdown menu accordingly
-        self.tray.setToolTip(tooltip)
+        # Update dropdown menu accordingly
         self.dropdown_menu.clear()
         if updates_list:
             for update in updates_list:
@@ -181,6 +173,10 @@ class ArchUpdateQt6:
         self.tray.setVisible(True)
         self.tray.activated.connect(self.run)
 
+        # Tooltip
+        tooltip = _("Arch-Update")
+        self.tray.setToolTip(tooltip)
+
         # Menu
         menu = QMenu()
         menu_launch = QAction(_("Run Arch-Update"))
@@ -207,7 +203,7 @@ class ArchUpdateQt6:
         self.watcher = QFileSystemWatcher([self.iconfile, self.updatesfile])
         self.watcher.fileChanged.connect(self.file_changed)
 
-        # Initial file check to set the right icon, tooltip and dropdown menu text
+        # Initial file check to set the right icon and dropdown menu text
         self.file_changed()
 
         app.exec()


### PR DESCRIPTION
### Description

Having the list of pending updates in the tooltip is kinda a bad design and creates more issues than it solves.  
See https://github.com/Antiz96/arch-update/issues/319 for full rational.

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/319
