### PR TITLE
fix(kernel_reboot): Don't source the kernel_reboot lib in WSL

### DIFF
--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -35,9 +35,11 @@ source "${libdir}/packages_cache.sh"
 # shellcheck source=src/lib/pacnew_files.sh
 source "${libdir}/pacnew_files.sh"
 
-# Source the "kernel_reboot" library which check if there's a pending kernel update requiring a reboot to be applied
-# shellcheck source=src/lib/kernel_reboot.sh
-source "${libdir}/kernel_reboot.sh"
+# Source the "kernel_reboot" library which check if there's a pending kernel update requiring a reboot to be applied (unless running from WSL)
+if [ -z "${WSL_DISTRO_NAME}" ]; then
+	# shellcheck source=src/lib/kernel_reboot.sh
+	source "${libdir}/kernel_reboot.sh"
+fi
 
 # Source the "restart_services" library which displays services requiring a post update restart and offers to restart them
 # shellcheck source=src/lib/restart_services.sh


### PR DESCRIPTION
### Description

Do not source / load the `kernel_reboot` library when running from WSL. Running this library from WSL makes no sense (as the kernel is managed by WSL itself) and create false positives.