### PR TITLE
Fix: incorrect paths in uninstall target of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,9 @@ uninstall:
 	rm -f "${DESTDIR}${PREFIX}/lib/systemd/user/${pkgname}-tray.service"
 
 	# Delete .mo files
-	rm -f "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${_pkgname}.mo"
-	rm -f "${DESTDIR}${PREFIX}/usr/share/locale/zh_CN/LC_MESSAGES/${_pkgname}.mo"
+	rm -f "${DESTDIR}${PREFIX}/share/locale/fr/LC_MESSAGES/${_pkgname}.mo"
+	rm -f "${DESTDIR}${PREFIX}/share/locale/sv/LC_MESSAGES/${_pkgname}.mo"
+	rm -f "${DESTDIR}${PREFIX}/share/locale/zh_CN/LC_MESSAGES/${_pkgname}.mo"
 
 	# Delete shell completions
 	rm -f "${DESTDIR}${PREFIX}/share/bash-completion/completions/${pkgname}"


### PR DESCRIPTION
Description:
Fixes incorrect paths in the uninstall target of the Makefile for arch-update. Additionally, the Swedish translation file was missing from the removal list.

Changes:

Corrected the path for .mo files.

Added Swedish (sv) translation file to the uninstall target.

Before:

# Delete .mo files
rm -f "${DESTDIR}${PREFIX}/usr/share/locale/fr/LC_MESSAGES/${_pkgname}.mo" rm -f "${DESTDIR}${PREFIX}/usr/share/locale/zh_CN/LC_MESSAGES/${_pkgname}.mo"

After:

# Delete .mo files
rm -f "${DESTDIR}${PREFIX}/share/locale/fr/LC_MESSAGES/${_pkgname}.mo" rm -f "${DESTDIR}${PREFIX}/share/locale/sv/LC_MESSAGES/${_pkgname}.mo" rm -f "${DESTDIR}${PREFIX}/share/locale/zh_CN/LC_MESSAGES/${_pkgname}.mo"

Testing:

Ran make uninstall and confirmed that all translation files are properly removed.