### PR TITLE
fix(systray): Drop sub-menus for update sources in favor of "top level" dropdown menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 - *(i18n)* Add German translation ([#346](https://github.com/Antiz96/arch-update/pull/346)) - ([5224d8a](https://github.com/Antiz96/arch-update/commit/5224d8a3c76811dd44bcec3bbbf84c2f958d66c5)) by @DeN-AlB
-- *(systray)* Add dropdown sub-menus for earch sources of available updates ([#348](https://github.com/Antiz96/arch-update/pull/348)) - ([75e2239](https://github.com/Antiz96/arch-update/commit/75e2239216a12dc2032831e15152653642bbc0d6)) by @Antiz96
+- *(systray)* Add dropdown sub-menus for each sources of available updates ([#348](https://github.com/Antiz96/arch-update/pull/348)) - ([75e2239](https://github.com/Antiz96/arch-update/commit/75e2239216a12dc2032831e15152653642bbc0d6)) by @Antiz96
 
 ### Fixes
 

--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -108,11 +108,11 @@ def arch_update():
 class ArchUpdateQt6:
     """System Tray using QT6 library"""
 
-    # Definition of functions to update the icon and the dropdown menu when their respective state files content change
+    # Definition of functions to update the icon and dropdown menus when their respective state files content change
     def file_changed(self):
-        """Update icon and dropdown menu"""
+        """Update icon and dropdown menus"""
         self.update_icon()
-        self.update_dropdown_menu()
+        self.update_dropdown_menus()
 
     # Update the icon based on the 'tray_icon' statefile content
     def update_icon(self):
@@ -131,9 +131,9 @@ class ArchUpdateQt6:
             icon = QIcon.fromTheme(contents)
             self.tray.setIcon(icon)
 
-    # Update the dropdown menu based on the state files content
-    def update_dropdown_menu(self):
-        """Update dropdown menu"""
+    # Update dropdown menus based on the state files content
+    def update_dropdown_menus(self):
+        """Update dropdown menus"""
     # Check presence of state files
         if self.watcher and not self.updatesfile in self.watcher.files():
             self.watcher.addPath(self.updatesfile)
@@ -143,8 +143,7 @@ class ArchUpdateQt6:
                 updates_list = f.readlines()
         except FileNotFoundError:
             log.error("State updates file missing")
-            self.dropdown_menu.setTitle(_("'updates' state file isn't found"))
-            self.dropdown_menu.setEnabled(False)
+            self.menu_count.setTitle(_("'updates' state file isn't found"))
             return
 
         if self.watcher and not self.updatesfilepkg in self.watcher.files():
@@ -183,63 +182,73 @@ class ArchUpdateQt6:
         updates_list_aur = [update.strip() for update in updates_list_aur if update.strip()]
         updates_list_flatpak = [update.strip() for update in updates_list_flatpak if update.strip()]
 
-	# Count the number of pending updates (according to the number of lines of statefiles)
+        # Count the number of pending updates (according to the number of lines of statefiles)
         updates_count = len(updates_list)
         updates_count_pkg = len(updates_list_pkg)
         updates_count_aur = len(updates_list_aur)
         updates_count_flatpak = len(updates_list_flatpak)
 
-        # Update the main dropdown menu title accordingly
+        # Update the update main menu title accordingly
         if updates_count == 0:
-            self.dropdown_menu.setTitle(_("System is up to date"))
-            self.dropdown_menu.setEnabled(False)
+            self.menu_count.setText(_("System is up to date"))
+            self.menu_count.setEnabled(False)
         elif updates_count == 1:
-            self.dropdown_menu.setTitle(_("1 update available"))
-            self.dropdown_menu.setEnabled(True)
+            self.menu_count.setText(_("1 update available"))
+            self.menu_count.setEnabled(True)
         else:
-            self.dropdown_menu.setTitle(_("{updates} updates available").format(updates=updates_count))
-            self.dropdown_menu.setEnabled(True)
+            self.menu_count.setText(_("{updates} updates available").format(updates=updates_count))
+            self.menu_count.setEnabled(True)
 
-        # Add / update submenus if at least one available update, remove it otherwise
+        # Clear the menu (to update entries)
+        self.menu.clear()
+        self.menu.addAction(self.menu_count)
+
+        # Add / update dropdown menus if there's at least one available update, remove it otherwise
         if (updates_count_pkg >= 1) + (updates_count_aur >=1) + (updates_count_flatpak >=1) >= 2:
-            self.dropdown_menu.addMenu(self.submenu_all)
-            self.submenu_all.setTitle(_("All ({updates})").format(updates=updates_count))
-            self.submenu_all.setEnabled(True)
-            self.submenu_all.clear()
+            self.dropdown_menu_all.setTitle(_("All ({updates})").format(updates=updates_count))
+            self.dropdown_menu_all.setEnabled(True)
+            self.dropdown_menu_all.clear()
             for update in updates_list:
-                self.submenu_all.addAction(update)
+                self.dropdown_menu_all.addAction(update)
+            self.menu.addMenu(self.dropdown_menu_all)
         else:
-            self.dropdown_menu.removeAction(self.submenu_all.menuAction())
+            self.menu.removeAction(self.dropdown_menu_all.menuAction())
 
         if updates_count_pkg >= 1:
-            self.dropdown_menu.addMenu(self.submenu_pkg)
-            self.submenu_pkg.setTitle(_("Packages ({updates})").format(updates=updates_count_pkg))
-            self.submenu_pkg.setEnabled(True)
-            self.submenu_pkg.clear()
+            self.dropdown_menu_pkg.setTitle(_("Packages ({updates})").format(updates=updates_count_pkg))
+            self.dropdown_menu_pkg.setEnabled(True)
+            self.dropdown_menu_pkg.clear()
             for update in updates_list_pkg:
-                self.submenu_pkg.addAction(update)
+                self.dropdown_menu_pkg.addAction(update)
+            self.menu.addMenu(self.dropdown_menu_pkg)
         else:
-            self.dropdown_menu.removeAction(self.submenu_pkg.menuAction())
+            self.menu.removeAction(self.dropdown_menu_pkg.menuAction())
 
         if updates_count_aur >= 1:
-            self.dropdown_menu.addMenu(self.submenu_aur)
-            self.submenu_aur.setTitle(_("AUR ({updates})").format(updates=updates_count_aur))
-            self.submenu_aur.setEnabled(True)
-            self.submenu_aur.clear()
+            self.dropdown_menu_aur.setTitle(_("AUR ({updates})").format(updates=updates_count_aur))
+            self.dropdown_menu_aur.setEnabled(True)
+            self.dropdown_menu_aur.clear()
             for update in updates_list_aur:
-                self.submenu_aur.addAction(update)
+                self.dropdown_menu_aur.addAction(update)
+            self.menu.addMenu(self.dropdown_menu_aur)
         else:
-            self.dropdown_menu.removeAction(self.submenu_aur.menuAction())
+            self.menu.removeAction(self.dropdown_menu_aur.menuAction())
 
         if updates_count_flatpak >= 1:
-            self.dropdown_menu.addMenu(self.submenu_flatpak)
-            self.submenu_flatpak.setTitle(_("Flatpak ({updates})").format(updates=updates_count_flatpak))
-            self.submenu_flatpak.setEnabled(True)
-            self.submenu_flatpak.clear()
+            self.dropdown_menu_flatpak.setTitle(_("Flatpak ({updates})").format(updates=updates_count_flatpak))
+            self.dropdown_menu_flatpak.setEnabled(True)
+            self.dropdown_menu_flatpak.clear()
             for update in updates_list_flatpak:
-                self.submenu_flatpak.addAction(update)
+                self.dropdown_menu_flatpak.addAction(update)
+            self.menu.addMenu(self.dropdown_menu_flatpak)
         else:
-            self.dropdown_menu.removeAction(self.submenu_flatpak.menuAction())
+            self.menu.removeAction(self.dropdown_menu_flatpak.menuAction())
+
+        # Restore static menu entries (after clearing the menu)
+        self.menu.addSeparator()
+        self.menu.addAction(self.menu_launch)
+        self.menu.addAction(self.menu_check)
+        self.menu.addAction(self.menu_exit)
 
     # Action to run the arch_update function
     def run(self):
@@ -282,36 +291,35 @@ class ArchUpdateQt6:
         self.tray.setToolTip(tooltip)
 
         # Definition of menus titles
-        menu = QMenu()
-        menu_launch = QAction(_("Run Arch-Update"))
-        menu_check = QAction(_("Check for updates"))
-        menu_exit = QAction(_("Exit"))
+        self.menu = QMenu()
+        self.menu_count = QAction(_("Checking for updates..."))
+        self.menu_launch = QAction(_("Run Arch-Update"))
+        self.menu_check = QAction(_("Check for updates"))
+        self.menu_exit = QAction(_("Exit"))
 
-        # Initialisation of the dynamic dropdown menu
-        self.dropdown_menu = QMenu(_("Checking for updates..."))
-        self.submenu_all = QMenu(_("All"))
-        self.submenu_pkg = QMenu(_("Packages"))
-        self.submenu_aur = QMenu(_("AUR"))
-        self.submenu_flatpak = QMenu(_("Flatpak"))
+        # Initialisation of the dynamic dropdown menus
+        self.dropdown_menu_all = QMenu(_("All"))
+        self.dropdown_menu_pkg = QMenu(_("Packages"))
+        self.dropdown_menu_aur = QMenu(_("AUR"))
+        self.dropdown_menu_flatpak = QMenu(_("Flatpak"))
 
         # Link actions to the menu
-        menu.addMenu(self.dropdown_menu)
-        menu.addSeparator()
-        menu.addAction(menu_launch)
-        menu.addAction(menu_check)
-        menu.addAction(menu_exit)
+        self.menu.addSeparator()
+        self.menu.addAction(self.menu_launch)
+        self.menu.addAction(self.menu_check)
+        self.menu.addAction(self.menu_exit)
 
-        menu_launch.triggered.connect(self.run)
-        menu_check.triggered.connect(self.check)
-        menu_exit.triggered.connect(self.exit)
+        self.menu_launch.triggered.connect(self.run)
+        self.menu_check.triggered.connect(self.check)
+        self.menu_exit.triggered.connect(self.exit)
 
-        self.tray.setContextMenu(menu)
+        self.tray.setContextMenu(self.menu)
 
         # File Watcher (watches for statefiles content changes)
         self.watcher = QFileSystemWatcher([self.iconfile, self.updatesfile, self.updatesfilepkg, self.updatesfileaur, self.updatesfileflatpak])
         self.watcher.fileChanged.connect(self.file_changed)
 
-        # Initial file check to set the right icon and dropdown menu text
+        # Initial file check to set the right icon and dynamic menu text
         self.file_changed()
 
         app.exec()


### PR DESCRIPTION
### Description

Some panels open dropdown menus in an arbitrary direction depending on different parameters such as the position of the applet in the tray area, the content length, the screen size, etc.. With dropdown sub-menus, this can result in overlaps on the main menu, preventing the main menu from being seen / used (see screenshot below).

To prevent that, the dropdown sub-menus for each update sources are dropped in favor of "top level" dropdown menus (which cannot overlap with the main menu), right under the "update count" menu entry (see screenshot below).

They work the same way as the previous sub-menus:

- Dropdown menus for sources with 0 pending update are not shown.
- The "All" dropdown menu is only shown when relevant (meaning when at least two sources have pending updates).
- The "NoVersion" configuration file option is honored in dropdown menus.

Aside from the potential overlapping issue, this is arguably a better design as it requires less actions / mouse movements to get the number / list of pending updates.

### Screenshots

Potential overlapping issue with the current design:

![2025-03-31_15-16](https://github.com/user-attachments/assets/124b1377-3e8b-489a-8611-5e8cd4ae3403)

![Image](https://github.com/user-attachments/assets/7763daa3-1717-47c7-97e3-86409d8d9750)

New design:

![2025-03-31_15-11](https://github.com/user-attachments/assets/b516902c-fe7b-47e1-a536-799bd2d5365b)

![2025-03-31_15-12](https://github.com/user-attachments/assets/cdb1b45f-ae2f-4ab2-b506-0d971283b5f0)

![2025-03-31_15-12_1](https://github.com/user-attachments/assets/21d9ab97-664e-4c90-a554-55073a2fc0a9)

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/354