### PR TITLE
feat(systray): Run arch-update when clicking on the "X update(s) available" menu entry

### DIFF
--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -304,11 +304,13 @@ class ArchUpdateQt6:
         self.dropdown_menu_flatpak = QMenu(_("Flatpak"))
 
         # Link actions to the menu
+        self.menu.addAction(self.menu_count)
         self.menu.addSeparator()
         self.menu.addAction(self.menu_launch)
         self.menu.addAction(self.menu_check)
         self.menu.addAction(self.menu_exit)
 
+        self.menu_count.triggered.connect(self.run)
         self.menu_launch.triggered.connect(self.run)
         self.menu_check.triggered.connect(self.check)
         self.menu_exit.triggered.connect(self.exit)


### PR DESCRIPTION
### Description

Add a trigger to run Arch-Update when the "X update(s) available menu entry" is clicked (in addition of the dedicated "Run Arch-Update" menu entry).

This allows users to act on pending updates by being able to run Arch-Update from the first menu entry, without having to move down to the dedicated "Run Arch-Update" one (which, since [this PR](https://github.com/Antiz96/arch-update/pull/355), will be moved lower than it currently is when there's pending updates available).

### Screenshots

