### PR TITLE
fix(systray): Fix crash when the 'updates' state file does not exist

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -626,12 +626,8 @@ msgstr ""
 msgid "Flatpak ({updates})"
 msgstr ""
 
-#: src/lib/tray.py:290
+#: src/lib/tray.py:290 src/lib/tray.py:295
 msgid "Arch-Update"
-msgstr ""
-
-#: src/lib/tray.py:295
-msgid "Checking for updates..."
 msgstr ""
 
 #: src/lib/tray.py:296
@@ -681,7 +677,7 @@ msgid ""
 "from your app menu"
 msgstr ""
 
-#: src/lib/tray.sh:42
+#: src/lib/tray.sh:47
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -697,13 +697,9 @@ msgstr "AUR ({updates})"
 msgid "Flatpak ({updates})"
 msgstr "Flatpak ({updates})"
 
-#: src/lib/tray.py:290
+#: src/lib/tray.py:290 src/lib/tray.py:295
 msgid "Arch-Update"
 msgstr "Arch-Update"
-
-#: src/lib/tray.py:295
-msgid "Checking for updates..."
-msgstr "Suche nach Updates..."
 
 #: src/lib/tray.py:296
 msgid "Run Arch-Update"
@@ -756,7 +752,7 @@ msgstr ""
 "zu starten, einfach die Anwendung \"Arch-Update Systray Applet\" aus dem "
 "Anwendungsmenü aufrufen"
 
-#: src/lib/tray.sh:42
+#: src/lib/tray.sh:47
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr "Es gibt bereits eine laufende Instanz des Arch-Update Systray-Applets"

--- a/po/fr.po
+++ b/po/fr.po
@@ -697,13 +697,9 @@ msgstr "AUR ({updates})"
 msgid "Flatpak ({updates})"
 msgstr "Flatpak ({updates})"
 
-#: src/lib/tray.py:290
+#: src/lib/tray.py:290 src/lib/tray.py:295
 msgid "Arch-Update"
 msgstr "Arch-Update"
-
-#: src/lib/tray.py:295
-msgid "Checking for updates..."
-msgstr "Vérification des mises à jour..."
 
 #: src/lib/tray.py:296
 msgid "Run Arch-Update"
@@ -756,7 +752,7 @@ msgstr ""
 "immédiatement, vous pouvez lancer l'application \"Arch-Update Systray Applet\" "
 "depuis votre menu d'application"
 
-#: src/lib/tray.sh:42
+#: src/lib/tray.sh:47
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr "Il y a déjà une instance de l'applet systray d'Arch-Update en cours d'exécution"

--- a/po/hu.po
+++ b/po/hu.po
@@ -697,13 +697,9 @@ msgstr "AUR ({updates})"
 msgid "Flatpak ({updates})"
 msgstr "Flatpak ({updates})"
 
-#: src/lib/tray.py:290
+#: src/lib/tray.py:290 src/lib/tray.py:295
 msgid "Arch-Update"
 msgstr "Arch-Update"
-
-#: src/lib/tray.py:295
-msgid "Checking for updates..."
-msgstr "Frissítések keresése..."
 
 #: src/lib/tray.py:296
 msgid "Run Arch-Update"
@@ -756,7 +752,7 @@ msgstr ""
 "most azonnal el szeretné indítani, futtassa az \"Arch-Frissítő Rendszertálca Indító "
 "kisalkalmazást\", a rendszer alkalmazás indító menüjéből"
 
-#: src/lib/tray.sh:42
+#: src/lib/tray.sh:47
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr "Már fut egy példánya az Arch-Frissítő, rendszertálca indító kisalkalmazásnak"

--- a/po/sv.po
+++ b/po/sv.po
@@ -704,13 +704,9 @@ msgstr "AUR ({updates})"
 msgid "Flatpak ({updates})"
 msgstr "Flatpak ({updates})"
 
-#: src/lib/tray.py:290
+#: src/lib/tray.py:290 src/lib/tray.py:295
 msgid "Arch-Update"
 msgstr "Arch-Update"
-
-#: src/lib/tray.py:295
-msgid "Checking for updates..."
-msgstr "Söker efter uppdateringar..."
 
 #: src/lib/tray.py:296
 msgid "Run Arch-Update"
@@ -763,7 +759,7 @@ msgstr ""
 "direkt kan du starta programmet \"Arch-Update Systray Applet\" från din "
 "program meny"
 
-#: src/lib/tray.sh:42
+#: src/lib/tray.sh:47
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr "Det finns redan en körande instans av Arch-Update systemfält-appleten"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -640,13 +640,9 @@ msgstr "AUR ({updates})"
 msgid "Flatpak ({updates})"
 msgstr "Flatpak ({updates})"
 
-#: src/lib/tray.py:290
+#: src/lib/tray.py:290 src/lib/tray.py:295
 msgid "Arch-Update"
 msgstr "Arch-Update"
-
-#: src/lib/tray.py:295
-msgid "Checking for updates..."
-msgstr "正在检查更新..."
 
 #: src/lib/tray.py:296
 msgid "Run Arch-Update"
@@ -697,7 +693,7 @@ msgstr "${tray_desktop_file_autostart} 文件已创建，"
 "Arch-Update 系统托盘应用程序将在下次登录时自动启动\\n"
 "要立即启动它，您可以从应用菜单中运行 \"Arch-Update Systray Applet\" 应用程序"
 
-#: src/lib/tray.sh:42
+#: src/lib/tray.sh:47
 #, sh-format
 msgid "There's already a running instance of the Arch-Update systray applet"
 msgstr "已经有 Arch-Update 系统托盘应用程序的运行实例"

--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -143,7 +143,7 @@ class ArchUpdateQt6:
                 updates_list = f.readlines()
         except FileNotFoundError:
             log.error("State updates file missing")
-            self.menu_count.setTitle(_("'updates' state file isn't found"))
+            self.menu_count.setText(_("'updates' state file isn't found"))
             return
 
         if self.watcher and not self.updatesfilepkg in self.watcher.files():
@@ -292,7 +292,7 @@ class ArchUpdateQt6:
 
         # Definition of menus titles
         self.menu = QMenu()
-        self.menu_count = QAction(_("Checking for updates..."))
+        self.menu_count = QAction(_("Arch-Update"))
         self.menu_launch = QAction(_("Run Arch-Update"))
         self.menu_check = QAction(_("Check for updates"))
         self.menu_exit = QAction(_("Exit"))

--- a/src/lib/tray.sh
+++ b/src/lib/tray.sh
@@ -38,6 +38,11 @@ else
 	fi
 
 	# shellcheck disable=SC2154
+	if [ ! -f "${statedir}/last_updates_check" ]; then
+		touch "${statedir}/last_updates_check"
+	fi
+
+	# shellcheck disable=SC2154
 	if pgrep -f "${libdir}/tray.py" > /dev/null; then
 		error_msg "$(eval_gettext "There's already a running instance of the Arch-Update systray applet")"
 		exit 3


### PR DESCRIPTION
### Description

Fix the systray applet crash occuring when the 'updates' state file does not exists on the system by correcting the `QAction` attribute for the main menu entry ("classic" menu entries use `setText` rather than `setTitle`).

Also, create the 'updates' state file if it doesn't exists when starting the systray applet (to prevent unnecessary error logs).

Finally, update the initial menu entry text to "Arch-Update" ("Checking for updates..." is actually wrong and misleading).

### Logs

```text
$ arch-update --tray
State updates file does not exist: /home/antiz/.local/state/arch-update/last_updates_check
State updates file missing
Traceback (most recent call last):
  File "/usr/share/arch-update/lib/tray.py", line 142, in update_dropdown_menus
    with open(self.updatesfile, encoding="utf-8") as f:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/antiz/.local/state/arch-update/last_updates_check'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/arch-update/lib/tray.py", line 330, in <module>
    ArchUpdateQt6(ICON_STATEFILE)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/usr/share/arch-update/lib/tray.py", line 325, in __init__
    self.file_changed()
    ~~~~~~~~~~~~~~~~~^^
  File "/usr/share/arch-update/lib/tray.py", line 115, in file_changed
    self.update_dropdown_menus()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/share/arch-update/lib/tray.py", line 146, in update_dropdown_menus
    self.menu_count.setTitle(_("'updates' state file isn't found"))
    ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'QAction' object has no attribute 'setTitle'
```