### PR TITLE
feat: Make the blue systray icon the default

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -1,7 +1,7 @@
 # Arch-Update
 
 <p align="center">
-  <img width="460" height="300" src="https://github.com/Antiz96/arch-update/assets/53110319/e2374a41-a3e9-43bf-9b12-54f53d18a320">
+  <img width="460" height="300" src="https://github.com/user-attachments/assets/fb5bb20b-dfe5-48c9-8f1b-899f2ea388ff">
 </p>
 
 [![lang-en](https://img.shields.io/badge/lang-en-blue.svg)](https://github.com/Antiz96/arch-update/blob/main/README.md)
@@ -139,36 +139,36 @@ Par défaut, une vérification est effectuée **au démarrage du système puis u
 ### Captures d'écran
 
 Une fois démarrée, l'applet systray apparait dans la zone systray de votre panneau.  
-C'est l'icône à droite de celle du wifi dans la capture d'écran ci-dessous:
+C'est l'icône à droite de celle en forme de tasse de café dans la capture d'écran ci-dessous (notez qu'il y a [plusieurs variantes de couleur disponibles](https://github.com/Antiz96/arch-update/blob/main/res/icons/README.md) pour l'icône):
 
-![systray-icon](https://github.com/Antiz96/arch-update/assets/53110319/fe032e68-3582-470a-9e6d-b51a9ea8c1ba)
+![icon](https://github.com/user-attachments/assets/833569de-1bff-41f5-8c38-61cddb3535cb)
 
 Avec [le timer systemd](#le-timer-systemd) activé, les vérifications des mises à jour sont effectuées automatiqument et périodiquement, mais vous pouvez en déclencher une manuellement depuise l'applet systray en faisant un clic droit dessus puis en cliquant sur l'entrée `Vérifier les mises à jour` depuis le menu :
 
-![check_menu_fr](https://github.com/user-attachments/assets/68fbeb81-2fe3-4167-badd-bec91bab6f5c)
+![check_for_updates-fr](https://github.com/user-attachments/assets/3d20e8df-d1ef-42d3-838b-a3747d17b41a)
 
 Si de nouvelles mises à jour sont disponibles, l'icône du systray affiche un cercle rouge et une notification de bureau indiquant le nombre de mises à jour disponibles est envoyée :
 
-![notif_fr](https://github.com/user-attachments/assets/1ffd0b47-ecc9-462b-aa18-0e88b726da77)
+![notif-fr](https://github.com/user-attachments/assets/fdf7f769-24bf-4dd3-8928-ef4b8df1d6e1)
 
 Vous pouvez voir la liste des mises à jour disponibles depuis le menu en faisant un clic droit sur l'icône du systray.  
 Un menu déroulant contenant le nombre et la liste des mises à jour disponibles est dynamiquement créé pour chaque sources qui en possède (Paquets, AUR, Flatpak).  
 Un menu déroulant "Tous" affichant le nombre et la liste des mises à jour en attente pour toutes les sources est créé dynamiquement si au moins 2 sources différentes ont des mises à jour en attente :
 
-![dropdown_menu_fr1](https://github.com/user-attachments/assets/0eaa56f2-c6f7-4583-8664-cad81ab43205)
+![all-fr](https://github.com/user-attachments/assets/440a19a5-ba10-4b5d-8fd1-72131b983db8)
 
-![dropdown_menu_fr2](https://github.com/user-attachments/assets/192ebd22-6398-498a-b824-9ff71770a62b)
+![packages-fr](https://github.com/user-attachments/assets/d2fe9d34-52b1-464d-9b51-98a4b07b8dfc)
 
-![dropdown_menu_fr3](https://github.com/user-attachments/assets/48875b7a-a11b-4901-ad6a-53bdd8526a22)
+![aur-fr](https://github.com/user-attachments/assets/0125f571-04c6-4fd7-98e3-c44fbe873849)
 
 Quand l'icône du systray est cliquée, `arch-update` est lancé dans une fenêtre de terminal (vous pouvez également cliquer sur l'entrée "*X* mise(s) à jour disponible(s)" ou l'entrée dédiée "Lancer Arch-Update" depuis le menu) :
 
-![listing_packages-FR](https://github.com/Antiz96/arch-update/assets/53110319/60547cde-f327-46f8-907c-61bf9bbee6c5)
+![run-fr](https://github.com/user-attachments/assets/21ce22f7-b03f-4390-acb5-720dd6d54f08)
 
 Si au moins une news Arch Linux a été publiée depuis la dernière exécution, `Arch-Update` vous proposera de lire les dernières news Arch Linux directement depuis la fenêtre de terminal.  
 Les news publiées depuis la dernière exécution sont labellisées comme `[NOUVEAU]` :
 
-![listing_news-FR](https://github.com/Antiz96/arch-update/assets/53110319/72819197-d4f7-4c50-af21-0aac1c60ba41)
+![news-fr](https://github.com/user-attachments/assets/ca7d6b22-f65b-44a7-9a1c-1b46b1e6a16a)
 
 Si aucune news n'a été publiée depuis la dernière exécution, `Arch-Update` demande directement votre confirmation pour procéder à la mise à jour.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arch-Update
 
 <p align="center">
-  <img width="460" height="300" src="https://github.com/Antiz96/arch-update/assets/53110319/e2374a41-a3e9-43bf-9b12-54f53d18a320">
+  <img width="460" height="300" src="https://github.com/user-attachments/assets/fb5bb20b-dfe5-48c9-8f1b-899f2ea388ff">
 </p>
 
 [![lang-fr](https://img.shields.io/badge/lang-fr-blue.svg)](https://github.com/Antiz96/arch-update/blob/main/README-fr.md)
@@ -139,36 +139,36 @@ By default, a check is performed **at boot and then once every hour**. The check
 ### Screenshots
 
 Once started, the systray applet appears in the systray area of your panel.  
-It is the icon at the right of the 'wifi' one in the screenshot below:
+It is the icon at the right of the 'coffee cup' one in the screenshot below (note that there are [different color variants available](https://github.com/Antiz96/arch-update/blob/main/res/icons/README.md) for it):
 
-![systray-icon](https://github.com/Antiz96/arch-update/assets/53110319/fe032e68-3582-470a-9e6d-b51a9ea8c1ba)
+![icon](https://github.com/user-attachments/assets/833569de-1bff-41f5-8c38-61cddb3535cb)
 
 With [the systemd timer](#the-systemd-timer) enabled, checks for updates are automatically and periodically performed, but you can manually trigger one from the systray applet icon by right-clicking it and then clicking on the `Check for updates` menu entry:
 
-![check_for_updates](https://github.com/user-attachments/assets/642db2e4-2e11-47e8-bd2b-6c653d10d02d)
+![check_for_updates](https://github.com/user-attachments/assets/16ef08b1-7feb-4e60-a6a3-a832e112f78f)
 
 If there are new available updates, the systray icon shows a red circle and a desktop notification indicating the number of available updates is sent:
 
-![notif](https://github.com/user-attachments/assets/0df49fe0-2346-424c-b843-081e4ea21b51)
+![notif](https://github.com/user-attachments/assets/58b959f5-d870-41ff-8a8d-0041cb01e0b7)
 
 You can see the list of available updates from the menu by right-clicking the systray icon.  
 A dropdown menu displaying the number and the list of pending updates is dynamically created for each sources that have some (Packages, AUR, Flatpak).  
 A "All" dropdown menu gathering the number and the list of pending updates for all sources is dynamically created if at least 2 different sources have pending updates:
 
-![dropdown_menu1](https://github.com/user-attachments/assets/af671f5d-143a-498f-ab0b-24d6f4fb89f9)
+![all](https://github.com/user-attachments/assets/eea057ac-febc-4f52-a350-02de647fa409)
 
-![dropdown_menu2](https://github.com/user-attachments/assets/a87f5e95-5852-4429-b2ae-947de3ea9a7e)
+![packages](https://github.com/user-attachments/assets/9ea0edd0-b133-471a-b93e-d5be1a180e50)
 
-![dropdown_menu3](https://github.com/user-attachments/assets/a39253c4-b195-4a51-ae53-1fbf875ba8d5)
+![aur](https://github.com/user-attachments/assets/2c7c0fbd-3251-4c1d-9ca3-f346417ee32a)
 
 When the systray icon is left-clicked, `arch-update` is run in a terminal window (alternatively, you can click the "*X* update(s) available" entry or the dedicated "Run Arch-Update" one from the right-click menu):
 
-![listing_packages](https://github.com/Antiz96/arch-update/assets/53110319/ed552414-0dff-4cff-84d2-6ff13340259d)
+![run](https://github.com/user-attachments/assets/bb07412c-5b55-4637-bc57-e6c072c1e578)
 
 If at least one Arch Linux news has been published since the last run, `Arch-Update` will offer you to read the latest Arch Linux news directly from the terminal window.  
 The news published since the last run are tagged as `[NEW]`:
 
-![listing_news](https://github.com/Antiz96/arch-update/assets/53110319/ec4032f3-835e-418c-b19a-b7bd089d6bd9)
+![news](https://github.com/user-attachments/assets/1309b0b9-ad82-41c4-88e3-4eaef397d293)
 
 If no news has been published since the last run, `Arch-Update` directly asks for your confirmation to proceed with update.
 

--- a/doc/man/arch-update.conf.5.scd
+++ b/doc/man/arch-update.conf.5.scd
@@ -57,7 +57,7 @@ Options are case sensitive, so capital letters have to be respected.
 	Editor to use to visualize / edit differences during the pacnew files processing. Defaults to the `$DIFFPROG` environment variable's value (or `vimdiff` if `$DIFFPROG` isn't set).
 
 *TrayIconStyle=[Style / Color]*
-	Style to be used for the systray applet icon. Valid values are the available style / color variants for the icon set, listed in https://github.com/Antiz96/arch-update/blob/main/res/icons/README.md. Defaults to "light".
+	Style to be used for the systray applet icon. Valid values are the available style / color variants for the icon set, listed in https://github.com/Antiz96/arch-update/blob/main/res/icons/README.md. Defaults to "blue".
 
 # SEE ALSO
 

--- a/doc/man/fr/arch-update.conf.5.scd
+++ b/doc/man/fr/arch-update.conf.5.scd
@@ -57,7 +57,7 @@ Les options sont sensibles à la casse, les majuscules doivent donc être respec
 	Editeur à utiliser pour visualiser / editer les différences durant le traitement des fichiers pacnew. La valeur par défaut est la valeur de la variable d'environnement `$DIFFPROG` (ou `vimdiff` si `$DIFFPROG` n'est pas paramétrée).
 
 *TrayIconStyle=[Style / Couleur]*
-	Style à utiliser pour l'icône de l'applet systray. Les valeurs valides sont les variantes de style / couleur disponibles pour le set d'icône, listées ici : https://github.com/Antiz96/arch-update/blob/main/res/icons/README.md. La valeur par défaut est "light".
+	Style à utiliser pour l'icône de l'applet systray. Les valeurs valides sont les variantes de style / couleur disponibles pour le set d'icône, listées ici : https://github.com/Antiz96/arch-update/blob/main/res/icons/README.md. La valeur par défaut est "blue".
 
 # VOIR AUSSI
 

--- a/res/config/arch-update.conf.example
+++ b/res/config/arch-update.conf.example
@@ -14,4 +14,4 @@
 #KeepOldPackages=3
 #KeepUninstalledPackages=0
 #DiffProg=$DIFFPROG
-#TrayIconStyle=light
+#TrayIconStyle=blue

--- a/res/desktop/arch-update-tray.desktop
+++ b/res/desktop/arch-update-tray.desktop
@@ -2,7 +2,7 @@
 Name=Arch-Update Systray Applet
 Comment[fr]=Applet systray pour Arch-Update
 Comment=Systray applet for Arch-Update
-Icon=arch-update_updates-available-light
+Icon=arch-update_updates-available-blue
 Type=Application
 Exec=arch-update --tray
 Categories=Utility

--- a/res/desktop/arch-update.desktop
+++ b/res/desktop/arch-update.desktop
@@ -2,7 +2,7 @@
 Name=Arch-Update
 Comment[fr]=Un notificateur & applicateur de mises à jour pour Arch Linux
 Comment=An update notifier & applier for Arch Linux
-Icon=arch-update-light
+Icon=arch-update-blue
 Type=Application
 Terminal=true
 Exec=arch-update

--- a/res/icons/README.md
+++ b/res/icons/README.md
@@ -3,6 +3,20 @@
 Here is the list of available style / color for the systray icon.  
 You can select which style / color to use with the `TrayIconStyle` option in the `arch-update.conf` configuration file (see the [arch-update.conf(5) man page](https://github.com/Antiz96/arch-update/blob/main/doc/man/arch-update.conf.5.scd) for more details).
 
+## blue (default one)
+
+- Up to date:
+
+<p align="center">
+  <img width="200" height="200" src="arch-update-blue.svg">
+</p>
+
+- Updates available:
+
+<p align="center">
+  <img width="200" height="200" src="arch-update_updates-available-blue.svg">
+</p>
+
 ## light
 
 - Up to date:
@@ -29,18 +43,4 @@ You can select which style / color to use with the `TrayIconStyle` option in the
 
 <p align="center">
   <img width="200" height="200" src="arch-update_updates-available-dark.svg">
-</p>
-
-## blue
-
-- Up to date:
-
-<p align="center">
-  <img width="200" height="200" src="arch-update-blue.svg">
-</p>
-
-- Updates available:
-
-<p align="center">
-  <img width="200" height="200" src="arch-update_updates-available-blue.svg">
 </p>

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -60,7 +60,7 @@ if [ -f "${config_file}" ]; then
 
 	# Check the "TrayIconStyle" option in arch-update.conf
 	# shellcheck disable=SC2034
-	tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(light|dark|blue)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
+	tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(blue|light|dark)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 fi
 
 # Set the default / fallback value for options that require it (if the arch-update.conf configuration file doesn't exists, if the concerned option is commented or if the set value is invalid) 
@@ -68,4 +68,4 @@ fi
 [ -z "${news_timeout}" ] && news_timeout="10"
 [ -z "${old_packages_num}" ] && old_packages_num="3"
 [ -z "${uninstalled_packages_num}" ] && uninstalled_packages_num="0"
-[ -z "${tray_icon_style}" ] && tray_icon_style="light"
+[ -z "${tray_icon_style}" ] && tray_icon_style="blue"


### PR DESCRIPTION
### Description

The "light" and "dark" systray icon are barely visible when using a theme of the same tone. The "blue" one has the advantage of being visible on most theme variants and therefore might be a better default.

Users can still switch to their prefered icon variant via the `TrayIconStyle` option in the `arch-update.conf` configuration file.

### Screenshots

![icon](https://github.com/user-attachments/assets/cf854892-1394-4f21-b36a-589b90b9b61c)

![notif](https://github.com/user-attachments/assets/b932cb21-63ad-4d49-b8e8-24ddc3731e14)

![all](https://github.com/user-attachments/assets/bce07d78-7f14-4113-90e9-7c8033be6319)

