### PR TITLE
feat: Add a lock file to avoid multiple parallel runs

### DIFF
--- a/doc/man/arch-update.1.scd
+++ b/doc/man/arch-update.1.scd
@@ -240,6 +240,9 @@ See https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#configu
 *16*
 	Error when creating the `statedir` and / or the `tmpdir` directories.
 
+*17*
+	Another instance of Arch-Update is already running.
+
 # SEE ALSO
 
 *checkupdates*(8),

--- a/doc/man/fr/arch-update.1.scd
+++ b/doc/man/fr/arch-update.1.scd
@@ -240,6 +240,9 @@ Voir https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#config
 *16*
 	Erreur lors de la création des répertoires `statedir` et / ou `tmpdir`.
 
+*17*
+	Une autre instance d'Arch-Update est en cours d'exécution.
+
 # VOIR AUSSI
 
 *checkupdates*(8),

--- a/doc/man/fr/arch-update.1.scd
+++ b/doc/man/fr/arch-update.1.scd
@@ -241,7 +241,7 @@ Voir https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#config
 	Erreur lors de la création des répertoires `statedir` et / ou `tmpdir`.
 
 *17*
-	Une autre instance d'Arch-Update est en cours d'exécution.
+	Une autre instance d'Arch-Update est déjà en cours d'exécution.
 
 # VOIR AUSSI
 

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -88,7 +88,7 @@ msgstr ""
 
 #: src/lib/full_upgrade.sh:12
 #, sh-format
-msgid "There's already a running instance of Arch-Update"
+msgid "There's already a running instance of Arch-Update\\n"
 msgstr ""
 
 #: src/lib/gen-config.sh:19

--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -86,6 +86,11 @@ msgid ""
 "is not set and \"nano\" (fallback option) is not installed"
 msgstr ""
 
+#: src/lib/full_upgrade.sh:12
+#, sh-format
+msgid "There's already a running instance of Arch-Update"
+msgstr ""
+
 #: src/lib/gen-config.sh:19
 #, sh-format
 msgid "Example configuration file not found"

--- a/po/de.po
+++ b/po/de.po
@@ -98,8 +98,8 @@ msgstr ""
 
 #: src/lib/full_upgrade.sh:12
 #, sh-format
-msgid "There's already a running instance of Arch-Update"
-msgstr "Es gibt bereits eine laufende Instanz von Arch-Update"
+msgid "There's already a running instance of Arch-Update\\n"
+msgstr "Es gibt bereits eine laufende Instanz von Arch-Update\\n"
 
 #: src/lib/gen-config.sh:19
 #, sh-format

--- a/po/de.po
+++ b/po/de.po
@@ -96,6 +96,11 @@ msgstr ""
 "Zu verwendender Editor kann nicht ermittel werden\\nDie \"EDITOR\" Umgebungsvariable "
 "ist nicht gesetzt und \"nano\" (Fallback-Option) ist nicht installiert"
 
+#: src/lib/full_upgrade.sh:12
+#, sh-format
+msgid "There's already a running instance of Arch-Update"
+msgstr "Es gibt bereits eine laufende Instanz von Arch-Update"
+
 #: src/lib/gen-config.sh:19
 #, sh-format
 msgid "Example configuration file not found"

--- a/po/fr.po
+++ b/po/fr.po
@@ -96,6 +96,11 @@ msgstr ""
 "Impossible de déterminer l'éditeur à utiliser\\n La variable d'environnement \"EDITOR\" "
 "n'est pas paramétrée et \"nano\" (option de secours) n'est pas installé"
 
+#: src/lib/full_upgrade.sh:12
+#, sh-format
+msgid "There's already a running instance of Arch-Update"
+msgstr "Il y a déjà une instance d'Arch-Update en cours d'exécution"
+
 #: src/lib/gen-config.sh:19
 #, sh-format
 msgid "Example configuration file not found"

--- a/po/fr.po
+++ b/po/fr.po
@@ -98,8 +98,8 @@ msgstr ""
 
 #: src/lib/full_upgrade.sh:12
 #, sh-format
-msgid "There's already a running instance of Arch-Update"
-msgstr "Il y a déjà une instance d'Arch-Update en cours d'exécution"
+msgid "There's already a running instance of Arch-Update\\n"
+msgstr "Il y a déjà une instance d'Arch-Update en cours d'exécution\\n"
 
 #: src/lib/gen-config.sh:19
 #, sh-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -99,8 +99,8 @@ msgstr ""
 
 #: src/lib/full_upgrade.sh:12
 #, sh-format
-msgid "There's already a running instance of Arch-Update"
-msgstr "Már van egy futó példánya az Arch-Update"
+msgid "There's already a running instance of Arch-Update\\n"
+msgstr "Már van egy futó példánya az Arch-Update\\n"
 
 #: src/lib/gen-config.sh:19
 #, sh-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -97,6 +97,11 @@ msgstr ""
 "Nem lehet meghatározni a használni kívánt szerkesztőt\\nAz „EDITOR” "
 "környezeti változó nincs beállítva, és a „nano” (tartalékbeállítás) nincs telepítve"
 
+#: src/lib/full_upgrade.sh:12
+#, sh-format
+msgid "There's already a running instance of Arch-Update"
+msgstr "Már van egy futó példánya az Arch-Update"
+
 #: src/lib/gen-config.sh:19
 #, sh-format
 msgid "Example configuration file not found"

--- a/po/sv.po
+++ b/po/sv.po
@@ -98,6 +98,11 @@ msgstr ""
 "miljövariabeln är inte inställd och \"nano\" (reservalternativ) är inte "
 "installerat"
 
+#: src/lib/full_upgrade.sh:12
+#, sh-format
+msgid "There's already a running instance of Arch-Update"
+msgstr "Det finns redan en pågående instans av Arch-Update"
+
 #: src/lib/gen-config.sh:19
 #, sh-format
 msgid "Example configuration file not found"

--- a/po/sv.po
+++ b/po/sv.po
@@ -100,8 +100,8 @@ msgstr ""
 
 #: src/lib/full_upgrade.sh:12
 #, sh-format
-msgid "There's already a running instance of Arch-Update"
-msgstr "Det finns redan en pågående instans av Arch-Update"
+msgid "There's already a running instance of Arch-Update\\n"
+msgstr "Det finns redan en pågående instans av Arch-Update\\n"
 
 #: src/lib/gen-config.sh:19
 #, sh-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -90,8 +90,8 @@ msgstr "无法确定要使用的编辑器\\n\"EDITOR\" 环境变量未设置"
 
 #: src/lib/full_upgrade.sh:12
 #, sh-format
-msgid "There's already a running instance of Arch-Update"
-msgstr "已经有一个 Arch-Update 实例在运行了"
+msgid "There's already a running instance of Arch-Update\\n"
+msgstr "已经有一个 Arch-Update 实例在运行了\\n"
 
 #: src/lib/gen-config.sh:19
 #, sh-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -88,6 +88,11 @@ msgid ""
 msgstr "无法确定要使用的编辑器\\n\"EDITOR\" 环境变量未设置"
 "且 \"nano\" (备用选项) 未安装"
 
+#: src/lib/full_upgrade.sh:12
+#, sh-format
+msgid "There's already a running instance of Arch-Update"
+msgstr "已经有一个 Arch-Update 实例在运行了"
+
 #: src/lib/gen-config.sh:19
 #, sh-format
 msgid "Example configuration file not found"

--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -9,7 +9,7 @@ lock_file="${TMPDIR:-/tmp}/arch-update.lock"
 
 # Exit if a lock file already exists (meaning there's already a running instance of Arch-Update)
 if [ -f "${lock_file}" ]; then
-	error_msg "$(eval_gettext "There's already a running instance of Arch-Update")" && quit_msg
+	error_msg "$(eval_gettext "There's already a running instance of Arch-Update\n")" && quit_msg
 	exit 17
 fi
 

--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -13,7 +13,7 @@ if [ -f "${lock_file}" ]; then
 	exit 17
 fi
 
-# Create a lock file to avoid multiple parralel runs
+# Create a lock file to avoid multiple parallel runs
 touch "${lock_file}"
 
 # Delete the lock file on exit

--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -4,6 +4,25 @@
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Lock file definition
+lock_file="${TMPDIR:-/tmp}/arch-update.lock"
+
+# Exit if a lock file already exists (meaning there's already a running instance of Arch-Update)
+if [ -f "${lock_file}" ]; then
+	error_msg "$(eval_gettext "There's already a running instance of Arch-Update")" && quit_msg
+	exit 17
+fi
+
+# Create a lock file to avoid multiple parralel runs
+touch "${lock_file}"
+
+# Delete the lock file on exit
+delete_lock_file() {
+	rm -f "${lock_file}"
+}
+
+trap delete_lock_file EXIT
+
 # Source the "list_packages" library which displays the list of packages available for updates
 # shellcheck source=src/lib/list_packages.sh disable=SC2154
 source "${libdir}/list_packages.sh"


### PR DESCRIPTION
### Description

Add a lock file to the main "full_upgrade" function to avoid multiple parallel run of Arch-Update.

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/376