### PR TITLE
fix: Avoid collisions during parallel updates checks

### DIFF
--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -5,12 +5,15 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # shellcheck disable=SC2154
+checkupdates_db_tmpdir=$(mktemp -d "${checkupdates_db_tmpdir_prefix}XXXXX")
+
+# shellcheck disable=SC2154
 if [ -z "${no_version}" ]; then
 	# shellcheck disable=SC2154
-	checkupdates > "${statedir}/last_updates_check_packages"
+	CHECKUPDATES_DB="${checkupdates_db_tmpdir}" checkupdates > "${statedir}/last_updates_check_packages"
 else
 	# shellcheck disable=SC2154
-	checkupdates | awk '{print $1}' > "${statedir}/last_updates_check_packages"
+	CHECKUPDATES_DB="${checkupdates_db_tmpdir}" checkupdates | awk '{print $1}' > "${statedir}/last_updates_check_packages"
 fi
 
 if [ -n "${aur_helper}" ]; then

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -27,6 +27,11 @@ statedir="${XDG_STATE_HOME:-${HOME}/.local/state}/${name}"
 tmpdir="${TMPDIR:-/tmp}/${name}-${UID}"
 mkdir -p "${statedir}" "${tmpdir}" || exit 16
 
+# Define checkupdates temporary db dir prefix and lock file (for later use if needed)
+# shellcheck disable=SC2034
+checkupdates_db_tmpdir_prefix="${tmpdir}/checkupdates-"
+lock_file="${TMPDIR:-/tmp}/arch-update.lock"
+
 # Declare necessary parameters for translations
 # shellcheck disable=SC1091
 . gettext.sh
@@ -190,3 +195,13 @@ icon_updates-available() {
 	# shellcheck disable=SC2154
 	echo "${name}_updates-available-${tray_icon_style}" > "${statedir}/tray_icon"
 }
+
+# Definition of commands to always run on exit (e.g. cleanup of files / dirs which have no purpose being kept)
+cleanup() {
+	# shellcheck disable=SC2154
+	[ -d "${checkupdates_db_tmpdir}" ] && rm -rf "${checkupdates_db_tmpdir}"
+	[ -f "${lock_file}" ] && rm -f "${lock_file}"
+	[ -n "${kernel_reboot}" ] && tput cnorm
+}
+
+trap cleanup EXIT

--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -4,24 +4,16 @@
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Lock file definition
-lock_file="${TMPDIR:-/tmp}/arch-update.lock"
-
 # Exit if a lock file already exists (meaning there's already a running instance of Arch-Update)
+# shellcheck disable=SC2154
 if [ -f "${lock_file}" ]; then
 	error_msg "$(eval_gettext "There's already a running instance of Arch-Update\n")" && quit_msg
+	trap - EXIT
 	exit 17
 fi
 
 # Create a lock file to avoid multiple parallel runs
 touch "${lock_file}"
-
-# Delete the lock file on exit
-delete_lock_file() {
-	rm -f "${lock_file}"
-}
-
-trap delete_lock_file EXIT
 
 # Source the "list_packages" library which displays the list of packages available for updates
 # shellcheck source=src/lib/list_packages.sh disable=SC2154

--- a/src/lib/kernel_reboot.sh
+++ b/src/lib/kernel_reboot.sh
@@ -13,13 +13,10 @@ if [ -z "${kernel_compare}" ]; then
 	# shellcheck disable=SC2154
 	case "${answer}" in
 		"$(eval_gettext "Y")"|"$(eval_gettext "y")")
-			echo
+			# shellcheck disable=SC2034
+			kernel_reboot="true"
 
-			# shellcheck disable=SC2317,SC2329
-			restore_cursor() {
-				tput cnorm
-			}
-			trap restore_cursor EXIT
+			echo
 
 			# shellcheck disable=SC2034
 			for sec in {5..1}; do

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -6,12 +6,15 @@
 
 info_msg "$(eval_gettext "Looking for updates...\n")"
 
+# shellcheck disable=SC2154
+checkupdates_db_tmpdir=$(mktemp -d "${checkupdates_db_tmpdir_prefix}XXXXX")
+
 if [ -z "${no_version}" ]; then
 	# shellcheck disable=SC2154
-	packages=$(checkupdates "${contrib_color_opt[@]}")
+	packages=$(CHECKUPDATES_DB="${checkupdates_db_tmpdir}" checkupdates "${contrib_color_opt[@]}")
 else
 	# shellcheck disable=SC2154
-	packages=$(checkupdates "${contrib_color_opt[@]}" | awk '{print $1}')
+	packages=$(CHECKUPDATES_DB="${checkupdates_db_tmpdir}" checkupdates "${contrib_color_opt[@]}" | awk '{print $1}')
 fi
 
 if [ -n "${aur_helper}" ]; then


### PR DESCRIPTION
### Description

The temporary pacman database created by `checkupdates` can only be accessed by one single `checkupdates` run at the time, resulting in the following error when two (or more) updates checks are being run at the same time within Arch-Update (e.g. if you run Arch-Update or trigger a check for updates at the same time as the automatic one executed by the systemd timer):

```
==> ERROR: Cannot fetch updates
```

To prevent that, we are now creating a temporary database directory for each checks, preventing the above issue to occur in the case when multiple check for updates are running at the same time (since they will now all have their own dedicated temporary database directory).

Database directories are deleted once checks are done, as there's no purpose keeping them around.
This involves to merge all "trapped" commands in a single 'top level' trap statement (as trap statements take precedence over the previous ones).

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/380