### PR TITLE
fix(systray): Allow systray applet to run for multiple users

### DIFF
--- a/src/lib/tray.sh
+++ b/src/lib/tray.sh
@@ -43,7 +43,7 @@ else
 	fi
 
 	# shellcheck disable=SC2154
-	if pgrep -f "${libdir}/tray.py" > /dev/null; then
+	if pgrep -U "${USER}" -f "${libdir}/tray.py" > /dev/null; then
 		error_msg "$(eval_gettext "There's already a running instance of the Arch-Update systray applet")"
 		exit 3
 	fi


### PR DESCRIPTION
### Description

Instead of failing if a process for the systray applet is already running, we are now failing if a process for the systray applet is already running for the current user.

This allows multiple users to run the systray applet at the same time without collision.