### PR TITLE
fix(check): Ensure state files exist before being processed

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,12 +16,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/check.sh:51 src/lib/check.sh:54
+#: src/lib/check.sh:54 src/lib/check.sh:57
 #, sh-format
 msgid "${update_number} update available"
 msgstr ""
 
-#: src/lib/check.sh:59 src/lib/check.sh:61
+#: src/lib/check.sh:62 src/lib/check.sh:64
 #, sh-format
 msgid "${update_number} updates available"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -16,12 +16,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/check.sh:51 src/lib/check.sh:54
+#: src/lib/check.sh:54 src/lib/check.sh:57
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} Update verfügbar"
 
-#: src/lib/check.sh:59 src/lib/check.sh:61
+#: src/lib/check.sh:62 src/lib/check.sh:64
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} Updates verfügbar"

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,12 +16,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/check.sh:51 src/lib/check.sh:54
+#: src/lib/check.sh:54 src/lib/check.sh:57
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} mise à jour disponible"
 
-#: src/lib/check.sh:59 src/lib/check.sh:61
+#: src/lib/check.sh:62 src/lib/check.sh:64
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} mises à jour disponibles"

--- a/po/hu.po
+++ b/po/hu.po
@@ -17,12 +17,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/check.sh:51 src/lib/check.sh:54
+#: src/lib/check.sh:54 src/lib/check.sh:57
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} frissítés érhető el"
 
-#: src/lib/check.sh:59 src/lib/check.sh:61
+#: src/lib/check.sh:62 src/lib/check.sh:64
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} frissítés érhető el"

--- a/po/sv.po
+++ b/po/sv.po
@@ -16,12 +16,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/check.sh:51 src/lib/check.sh:54
+#: src/lib/check.sh:54 src/lib/check.sh:57
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} uppdatering är tillgänglig"
 
-#: src/lib/check.sh:59 src/lib/check.sh:61
+#: src/lib/check.sh:62 src/lib/check.sh:64
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} uppdateringar är tillgängliga"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -16,12 +16,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/check.sh:51 src/lib/check.sh:54
+#: src/lib/check.sh:54 src/lib/check.sh:57
 #, sh-format
 msgid "${update_number} update available"
 msgstr "${update_number} 个更新可用"
 
-#: src/lib/check.sh:59 src/lib/check.sh:61
+#: src/lib/check.sh:62 src/lib/check.sh:64
 #, sh-format
 msgid "${update_number} updates available"
 msgstr "${update_number} 个更新可用"

--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # shellcheck disable=SC2154
+touch "${statedir}"/last_updates_check_{packages,aur,flatpak}
+
+# shellcheck disable=SC2154
 checkupdates_db_tmpdir=$(mktemp -d "${checkupdates_db_tmpdir_prefix}XXXXX")
 
 # shellcheck disable=SC2154


### PR DESCRIPTION
### Description

Initialize state files during update checks to ensure they exists before being processed, in order to avoid (harmless but noisy) errors in journal.

### Logs

```text
May 20 14:52:31 meterpeter systemd[1153]: Starting Run arch-update auto check...
May 20 14:52:33 meterpeter arch-update[1150460]: sed: can't read /home/chris/.local/state/arch-update/last_updates_check_flatpak: No such file or directory
May 20 14:52:33 meterpeter arch-update[1150461]: sed: can't read /home/chris/.local/state/arch-update/last_updates_check_flatpak: No such file or directory
May 20 14:52:33 meterpeter arch-update[1150462]: cat: /home/chris/.local/state/arch-update/last_updates_check_flatpak: No such file or directory
```

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/384