### PR TITLE
fix(DiffProg): Fix value parsing

### DIFF
--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -56,7 +56,7 @@ if [ -f "${config_file}" ]; then
 
 	# Check the "DiffProg" option in arch-update.conf
 	# shellcheck disable=SC2034
-	diff_prog=$(grep -E '^[[:space:]]*DiffProg[[:space:]]*=[[:space:]]*[^[:space:]].*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
+	diff_prog=$(grep -E '^[[:space:]]*DiffProg[[:space:]]*=[[:space:]]*[^[:space:]].*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
 	# Check the "TrayIconStyle" option in arch-update.conf
 	# shellcheck disable=SC2034


### PR DESCRIPTION
### Description

Fix parsing for the DiffProg option's value to avoid trimming spaces unexpectedly. Spaces within the value may be expected (e.g. `nvim -d`), so we only remove leading and trailing spaces.

### Screenshots

![2025-07-04_18-27](https://github.com/user-attachments/assets/ce444674-8ed0-433d-b2a4-a273650aa0fe)

