### PR TITLE
style: Refine output for info msg about potentially long tasks

### DIFF
--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -74,7 +74,8 @@ main_msg() {
 # Definition of the info_msg function: Display a message as an information message
 info_msg() {
 	msg="${1}"
-	echo -e "${green}==>${color_off}${bold} ${msg}${color_off}"
+	[ -n "${2}" ] && opt="${2}"
+	echo -e "${opt}" "${green}==>${color_off}${bold} ${msg}${color_off}"
 }
 
 # Definition of the ask_msg function: Display a message as an interactive question

--- a/src/lib/list_news.sh
+++ b/src/lib/list_news.sh
@@ -4,12 +4,12 @@
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-info_msg "$(eval_gettext "Looking for recent Arch News...")"
+info_msg "$(eval_gettext "Looking for recent Arch News... ")" "-n"
 # shellcheck disable=SC2154
 news=$(curl -m "${news_timeout}" -Lfs https://www.archlinux.org/news || echo "error")
+echo -en "\r$(tput el)"
 
 if [ "${news}" == "error" ]; then
-	echo
 	warning_msg "$(eval_gettext "Unable to retrieve recent Arch News (HTTP error response or request timeout)\nPlease, look for any recent news at https://archlinux.org before updating your system")"
 else
 	if [ -z "${show_news}" ]; then
@@ -19,8 +19,7 @@ else
 		if ! diff "${statedir}/current_news_check" "${statedir}/last_news_check" &> /dev/null; then
 			show_news="true"
 		else
-			echo
-			info_msg "$(eval_gettext "No recent Arch News found")"
+			info_msg "$(eval_gettext "No recent Arch News found\n")"
 		fi
 
 		if [ -f "${statedir}/current_news_check" ]; then
@@ -33,7 +32,6 @@ else
 		news_titles=$(echo "${news}" | htmlq -a title a | grep ^"View:" | sed "s/View:\ //g" | head -"${news_num}")
 		mapfile -t news_dates < <(echo "${news}" | htmlq td | grep -v "class" | grep "[0-9]" | sed "s/<[^>]*>//g" | head -"${news_num}" | xargs -I{} date -d "{}" "+%s")
 
-		echo
 		main_msg "$(eval_gettext "Arch News:")"
 
 		i=1

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -4,7 +4,7 @@
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-info_msg "$(eval_gettext "Looking for updates...\n")"
+info_msg "$(eval_gettext "Looking for updates... ")" "-n"
 
 # shellcheck disable=SC2154
 checkupdates_db_tmpdir=$(mktemp -d "${checkupdates_db_tmpdir_prefix}XXXXX")
@@ -36,6 +36,7 @@ true > "${statedir}/last_updates_check"
 true > "${statedir}/last_updates_check_packages"
 true > "${statedir}/last_updates_check_aur"
 true > "${statedir}/last_updates_check_flatpak"
+echo -en "\r$(tput el)"
 
 if [ -n "${packages}" ]; then
 	main_msg "$(eval_gettext "Packages:")"


### PR DESCRIPTION
### Description

Refine output for potentially long tasks (e.g. looking for pending updates or looking for recent Arch News) by removing the related info msg for a clearer / improved readability