### PR TITLE
Skip reboot check if kernel-modules-hook is installed

### DIFF
--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -49,8 +49,8 @@ source "${libdir}/packages_cache.sh"
 # shellcheck source=src/lib/pacnew_files.sh
 source "${libdir}/pacnew_files.sh"
 
-# Source the "kernel_reboot" library which checks if there's a pending kernel update requiring a reboot to be applied (unless running from a container)
-if ! systemd-detect-virt --container --quiet; then
+# Source the "kernel_reboot" library which checks if there's a pending kernel update requiring a reboot to be applied (unless the "kernel-modules-hook" package is installed or we're running from a container)
+if ! pacman -Q kernel-modules-hook &> /dev/null && ! systemd-detect-virt --container --quiet; then
 	# shellcheck source=src/lib/kernel_reboot.sh
 	source "${libdir}/kernel_reboot.sh"
 fi


### PR DESCRIPTION
If `kernel-modules-hook` is installed, the reboot detection is not useful and will at the moment always show that there's no pending kernel update, even if there is. This skips the detection if that package is installed to prevent user confusion.

Fixes: #396