### PR TITLE
fix(notification): Fix updates count

### DIFF
--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -44,13 +44,13 @@ if [ -n "${update_available}" ]; then
 	icon_updates-available
 
 	if [ -n "${notification_support}" ]; then
-		(
 		if ! diff "${statedir}/current_updates_check" "${statedir}/last_updates_check" &> /dev/null; then
 			update_number=$(wc -l "${statedir}/current_updates_check" | awk '{print $1}')
 
 			# shellcheck disable=SC2154
 			last_notif_id=$(sed -n '1p' "${tmpdir}/notif_param" 2> /dev/null)
 
+			(
 			if [ "${update_number}" -eq 1 ]; then
 				if [ -z "${last_notif_id}" ]; then
 					# shellcheck disable=SC2154
@@ -90,8 +90,8 @@ if [ -n "${update_available}" ]; then
 					gio launch "${desktop_file}" || exit 18
 				fi
 			fi
+			) & disown
 		fi
-		) & disown
 	fi
 else
 	icon_up-to-date


### PR DESCRIPTION
### Description

Fix updates count in desktop notifications.
The disown logic was happening too soon for the count logic to be handled properly.

### Screenshots / Logs

Missing count in desktop notification:

<img width="515" height="160" alt="2025-07-17_16-59" src="https://github.com/user-attachments/assets/d9407925-6922-4dff-8aa4-e7acb14beec2" />

Error when running `arch-update --check`

```
$ arch-update --check
wc: /home/antiz/.local/state/arch-update/current_updates_check: No such file or directory
/usr/share/arch-update/lib/check.sh: line 54: [: : integer expected
```