### PR TITLE
fix(news): Make URL path parsing more robust

### DIFF
--- a/src/lib/list_news.sh
+++ b/src/lib/list_news.sh
@@ -70,8 +70,8 @@ else
 			if [ "${num}" -le "${news_num}" ] 2> /dev/null && [ "${num}" -gt "0" ]; then
 				printed_news="true"
 				news_selected=$(sed -n "${num}"p <<< "${news_titles}")
-				news_path=$(echo "${news_selected}" | sed -e s/\ -//g -e s/\ /-/g -e s/[.]//g -e s/=//g -e s/\>//g -e s/\<//g -e s/\`//g -e s/://g -e s/+//g -e s/[[]//g -e s/]//g -e s/,//g -e s/\(//g -e s/\)//g -e s/[/]//g -e s/@//g -e s/\'//g -e s/--/-/g | awk '{print tolower($0)}')
-				news_url="https://www.archlinux.org/news/${news_path}"
+				news_path=$(echo "${news}" | htmlq -a href a | grep ^"/news/" | sed -n "${num}"p)
+				news_url="https://www.archlinux.org${news_path}"
 				# shellcheck disable=SC2154
 				news_content=$(curl -m "${news_timeout}" -Lfs "${news_url}" || echo "error")
 


### PR DESCRIPTION
### Description

The current logic for parsing news URL assumed that the URL path would always match the title of the news entry, which turned out to not necessarily be the case, resulting in eventual wrongly parsed URL paths.

This commit makes the logic to parse URL paths more robust by relying on the actual path as defined as `href` in the https://archlinux.org/news source code (and, as a bonus, it also allows to *finally* get rid of that `sed` monstrosity).

### Logs

```text
$ arch-update --news
==> Looking for recent Arch News...

==> Arch News:
1 - zabbix >= 7.4.1-2 may require manual intervention
2 - linux-firmware >= 20250613.12fe085f-5 upgrade requires manual intervention
3 - Plasma 6.4.0 will need manual intervention if you are on X11
4 - Transition to the new WoW64 wine and wine-staging
5 - Valkey to replace Redis in the [extra] Repository

-> Select the news to read (e.g. 1 3 5), select 0 to read them all or press "enter" to quit: 1

==> WARNING: Unable to retrieve the selected Arch News (HTTP error response or request timeout)
Please, read the selected Arch News at https://www.archlinux.org/news/zabbix-741-2-may-require-manual-intervention before updating your system
```

While the correct URL path is "news/zabbix-741-2-may-require**s**-manual-intervention/" *(yes, this is a typo I didn't spot when publishing the news* :pleading_face::point_right::point_left:*... But at least it helped identifying this bug* :grin:*).*