### PR TITLE
fix(news): Add a workaround for the current Arch Linux service outages

### DIFF
--- a/src/lib/list_news.sh
+++ b/src/lib/list_news.sh
@@ -6,7 +6,7 @@
 
 info_msg "$(eval_gettext "Looking for recent Arch News...")"
 # shellcheck disable=SC2154
-news=$(curl -m "${news_timeout}" -Lfs https://www.archlinux.org/news || echo "error")
+news=$(curl -s https://archlinux.org &> /dev/null ; curl -m "${news_timeout}" -Lfs https://www.archlinux.org/news || echo "error")
 
 if [ "${news}" == "error" ]; then
 	echo


### PR DESCRIPTION
### Description

Arch Linux currently suffers from [service outages](https://archlinux.org/news/recent-services-outages/) due to some DoS attacks...

One of the implemented protection to mitigate the impact may send an initial connection reset, but ssubsequent requests should work as expected (the last paragraph of the linked news entry). As such, we initiate a connection before checking the news to avoid being hit by said connection reset.

This is (hopefully) a temporary fix.