### PR TITLE
fix(news): Add default timeout to the initial connection request

### DIFF
--- a/src/lib/list_news.sh
+++ b/src/lib/list_news.sh
@@ -6,7 +6,7 @@
 
 info_msg "$(eval_gettext "Looking for recent Arch News...")"
 # shellcheck disable=SC2154
-news=$(curl -s https://archlinux.org &> /dev/null ; curl -m "${news_timeout}" -Lfs https://www.archlinux.org/news || echo "error")
+news=$(curl -m "${news_timeout}" -s https://archlinux.org &> /dev/null ; curl -m "${news_timeout}" -Lfs https://www.archlinux.org/news || echo "error")
 
 if [ "${news}" == "error" ]; then
 	echo


### PR DESCRIPTION
### Description

We now initiate a connection before checking the news to avoid being hit by the initial connection reset implied by the protection implementation to mitigate the [service outages](https://archlinux.org/news/recent-services-outages/) that Arch Linux is currently suffering from.

This commit adds default timeout to said request.