### PR TITLE
fix(notification): Fix "Run Arch-Update" click action

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -16,47 +16,47 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/common.sh:102
+#: src/lib/common.sh:96
 #, sh-format
 msgid "WARNING"
 msgstr ""
 
-#: src/lib/common.sh:108
+#: src/lib/common.sh:102
 #, sh-format
 msgid "ERROR"
 msgstr ""
 
-#: src/lib/common.sh:113
+#: src/lib/common.sh:107
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr ""
 
-#: src/lib/common.sh:119
+#: src/lib/common.sh:113
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr ""
 
-#: src/lib/common.sh:140
+#: src/lib/common.sh:134
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the "
 "${name}.conf configuration file is not found\\n"
 msgstr ""
 
-#: src/lib/common.sh:171
+#: src/lib/common.sh:165
 #, sh-format
 msgid ""
 "A privilege elevation command is required (sudo, sudo-rs, doas or run0)\\n"
 msgstr ""
 
-#: src/lib/common.sh:176
+#: src/lib/common.sh:170
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the ${name}.conf "
 "configuration file is not found\\n"
 msgstr ""
 
-#: src/lib/common.sh:186
+#: src/lib/common.sh:180
 #, sh-format
 msgid ""
 "The ${diff_prog} editor set for visualizing / editing differences of pacnew "

--- a/po/de.po
+++ b/po/de.po
@@ -16,27 +16,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/common.sh:102
+#: src/lib/common.sh:96
 #, sh-format
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: src/lib/common.sh:108
+#: src/lib/common.sh:102
 #, sh-format
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: src/lib/common.sh:113
+#: src/lib/common.sh:107
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Zum Fortfahren \"ENTER\" drücken "
 
-#: src/lib/common.sh:119
+#: src/lib/common.sh:113
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Zum Beenden \"ENTER\" drücken "
 
-#: src/lib/common.sh:140
+#: src/lib/common.sh:134
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the "
@@ -45,14 +45,14 @@ msgstr ""
 "Der ${aur_helper} AUR-Helper für den Support von AUR-Paketen in der "
 "${name}.conf Konfigurationsdatei wurde nicht gefunden\\n"
 
-#: src/lib/common.sh:171
+#: src/lib/common.sh:165
 #, sh-format
 msgid ""
 "A privilege elevation command is required (sudo, sudo-rs, doas or run0)\\n"
 msgstr ""
 "Ein Befehl zur Erhöhung der Rechte ist erforderlich (sudo, sudo-rs, doas oder run0)\\n"
 
-#: src/lib/common.sh:176
+#: src/lib/common.sh:170
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the ${name}.conf "
@@ -61,7 +61,7 @@ msgstr ""
 "Der ${su_cmd} Befehl für die Rechteerhöhung in der ${name}.conf "
 "Konfigurationsdatei wurde nicht gefunden\\n"
 
-#: src/lib/common.sh:186
+#: src/lib/common.sh:180
 #, sh-format
 msgid ""
 "The ${diff_prog} editor set for visualizing / editing differences of pacnew "

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,27 +16,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/common.sh:102
+#: src/lib/common.sh:96
 #, sh-format
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
-#: src/lib/common.sh:108
+#: src/lib/common.sh:102
 #, sh-format
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: src/lib/common.sh:113
+#: src/lib/common.sh:107
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Appuyez sur \"entrée\" pour continuer "
 
-#: src/lib/common.sh:119
+#: src/lib/common.sh:113
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Appuyez sur \"entrée\" pour quitter "
 
-#: src/lib/common.sh:140
+#: src/lib/common.sh:134
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the "
@@ -45,14 +45,14 @@ msgstr ""
 "Le AUR helper ${aur_helper} défini pour le support des paquets AUR dans le fichier de configuration "
 "${name}.conf n'est pas disponible\\n"
 
-#: src/lib/common.sh:171
+#: src/lib/common.sh:165
 #, sh-format
 msgid ""
 "A privilege elevation command is required (sudo, sudo-rs, doas or run0)\\n"
 msgstr ""
 "Une commande d'élévation de privilège est requise (sudo, sudo-rs, doas ou run0)\\n"
 
-#: src/lib/common.sh:176
+#: src/lib/common.sh:170
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the ${name}.conf "
@@ -61,7 +61,7 @@ msgstr ""
 "La commande ${su_cmd} définie pour l'élévation de privilège dans le fichier "
 "de configuration ${name}.conf n'est pas disponible\\n"
 
-#: src/lib/common.sh:186
+#: src/lib/common.sh:180
 #, sh-format
 msgid ""
 "The ${diff_prog} editor set for visualizing / editing differences of pacnew "

--- a/po/hu.po
+++ b/po/hu.po
@@ -17,27 +17,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/common.sh:102
+#: src/lib/common.sh:96
 #, sh-format
 msgid "WARNING"
 msgstr "FIGYELMEZTETÉS"
 
-#: src/lib/common.sh:108
+#: src/lib/common.sh:102
 #, sh-format
 msgid "ERROR"
 msgstr "HIBA"
 
-#: src/lib/common.sh:113
+#: src/lib/common.sh:107
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Nyomja meg az „enter” gombot a folytatáshoz "
 
-#: src/lib/common.sh:119
+#: src/lib/common.sh:113
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Nyomja meg az „enter” gombot a kilépéshez "
 
-#: src/lib/common.sh:140
+#: src/lib/common.sh:134
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the "
@@ -46,14 +46,14 @@ msgstr ""
 "A(z) ${aur_helper} AUR-csomagok AUR-segédkészletének támogatása nem található "
 "az ${name}.conf konfigurációs fájlban\\n"
 
-#: src/lib/common.sh:171
+#: src/lib/common.sh:165
 #, sh-format
 msgid ""
 "A privilege elevation command is required (sudo, sudo-rs, doas or run0)\\n"
 msgstr ""
 "Jogosultságszint-emelési parancs szükséges (sudo, sudo-rs, doas vagy run0)\\n"
 
-#: src/lib/common.sh:176
+#: src/lib/common.sh:170
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the ${name}.conf "
@@ -62,7 +62,7 @@ msgstr ""
 "A(z) ${su_cmd} ${name}.conf konfigurációs fájlban, a jogosultságok "
 "kiterjesztéséhez beállított parancs nem található\\n"
 
-#: src/lib/common.sh:186
+#: src/lib/common.sh:180
 #, sh-format
 msgid ""
 "The ${diff_prog} editor set for visualizing / editing differences of pacnew "

--- a/po/sv.po
+++ b/po/sv.po
@@ -16,27 +16,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/common.sh:102
+#: src/lib/common.sh:96
 #, sh-format
 msgid "WARNING"
 msgstr "VARNING"
 
-#: src/lib/common.sh:108
+#: src/lib/common.sh:102
 #, sh-format
 msgid "ERROR"
 msgstr "FEL"
 
-#: src/lib/common.sh:113
+#: src/lib/common.sh:107
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "Tryck på \"enter\" för att fortsätta "
 
-#: src/lib/common.sh:119
+#: src/lib/common.sh:113
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "Tryck på \"enter\" för att avsluta "
 
-#: src/lib/common.sh:140
+#: src/lib/common.sh:134
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the "
@@ -45,14 +45,14 @@ msgstr ""
 "${aur_helper} Den inställda AUR-hjälparen för stöd för AUR-paket i "
 "konfigurationsfilen ${name}.conf hittades inte\\n"
 
-#: src/lib/common.sh:171
+#: src/lib/common.sh:165
 #, sh-format
 msgid ""
 "A privilege elevation command is required (sudo, sudo-rs, doas or run0)\\n"
 msgstr ""
 "Ett kommando för behörighetshöjning krävs (sudo, sudo-rs, doas eller run0)\\n"
 
-#: src/lib/common.sh:176
+#: src/lib/common.sh:170
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the ${name}.conf "
@@ -61,7 +61,7 @@ msgstr ""
 "${su_cmd}-kommandot inställt för privilegieskalering i ${name}.conf-"
 "konfigurationsfilen hittades inte\\n"
 
-#: src/lib/common.sh:186
+#: src/lib/common.sh:180
 #, sh-format
 msgid ""
 "The ${diff_prog} editor set for visualizing / editing differences of pacnew "

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -16,48 +16,48 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/lib/common.sh:102
+#: src/lib/common.sh:96
 #, sh-format
 msgid "WARNING"
 msgstr "警告"
 
-#: src/lib/common.sh:108
+#: src/lib/common.sh:102
 #, sh-format
 msgid "ERROR"
 msgstr "错误"
 
-#: src/lib/common.sh:113
+#: src/lib/common.sh:107
 #, sh-format
 msgid "Press \"enter\" to continue "
 msgstr "按下 \"enter\" 继续"
 
-#: src/lib/common.sh:119
+#: src/lib/common.sh:113
 #, sh-format
 msgid "Press \"enter\" to quit "
 msgstr "按下 \"enter\" 退出"
 
-#: src/lib/common.sh:140
+#: src/lib/common.sh:134
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the "
 "${name}.conf configuration file is not found\\n"
 msgstr "配置在 ${name}.conf 文件中的 AUR 帮助程序 ${aur_helper} 未找到\\n"
 
-#: src/lib/common.sh:171
+#: src/lib/common.sh:165
 #, sh-format
 msgid ""
 "A privilege elevation command is required (sudo, sudo-rs, doas or run0)\\n"
 msgstr ""
 "需要特权提升命令程序（sudo、sudo-rs、doas 或 run0）\\n"
 
-#: src/lib/common.sh:176
+#: src/lib/common.sh:170
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the ${name}.conf "
 "configuration file is not found\\n"
 msgstr "配置在 ${name}.conf 文件中的特权提升命令程序 ${su_cmd} 未找到\\n"
 
-#: src/lib/common.sh:186
+#: src/lib/common.sh:180
 #, sh-format
 msgid ""
 "The ${diff_prog} editor set for visualizing / editing differences of pacnew "

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -27,15 +27,9 @@ statedir="${XDG_STATE_HOME:-${HOME}/.local/state}/${name}"
 tmpdir="${TMPDIR:-/tmp}/${name}-${UID}"
 mkdir -p "${statedir}" "${tmpdir}" || exit 16
 
-# Define checkupdates temporary db dir prefix and lockfiles
+# Define checkupdates temporary db dir prefix
 # shellcheck disable=SC2034
 checkupdates_db_tmpdir_prefix="${tmpdir}/checkupdates-"
-# shellcheck disable=SC2034
-upgrade_lockfile="${TMPDIR:-/tmp}/${name}.lock"
-# shellcheck disable=SC2034
-tray_lockfile="${tmpdir}/tray.lock"
-# shellcheck disable=SC2034
-notif_lockfile="${tmpdir}/notif_action.lock"
 
 # Declare necessary parameters for translations
 # shellcheck disable=SC1091

--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -6,7 +6,7 @@
 
 # Hold the lockfile to avoid multiple parallel runs
 # shellcheck disable=SC2154
-exec {fd_upgrade}> "${upgrade_lockfile}"
+exec {fd_upgrade}> "${TMPDIR:-/tmp}/${name}.lock"
 
 # Exit if the lockfile is already hold
 if ! flock -n "${fd_upgrade}"; then

--- a/src/lib/notification.sh
+++ b/src/lib/notification.sh
@@ -44,7 +44,7 @@ fi
 
 if [ "$(sed -n '2p' "${tmpdir}/notif_param")" == "run" ]; then
 	# shellcheck disable=SC2154
-	exec {fd_notif}>"${notif_lockfile}"
+	exec {fd_notif}>"${tmpdir}/notif_action.lock"
 
 	if flock -n "${fd_notif}"; then
 		systemd-run --user --scope --unit="${name}"-run-"$(date +%Y%m%d-%H%M%S)" --quiet /bin/bash -c "gio launch ${desktop_file}" || exit 18

--- a/src/lib/tray.sh
+++ b/src/lib/tray.sh
@@ -43,7 +43,7 @@ else
 	fi
 
 	# shellcheck disable=SC2154
-	exec {fd_tray}>"${tray_lockfile}"
+	exec {fd_tray}>"${tmpdir}/tray.lock"
 
 	if ! flock -n "${fd_tray}"; then
 		error_msg "$(eval_gettext "There's already a running instance of the \${_name} systray applet")"


### PR DESCRIPTION
### Description

The "Run Arch-Update" click action in the desktop notifications was broken due to the related "lockfile" variable not being passed correctly to the `systemd-run` environment the notification library is executed in.

After a second thought, there's no need for those "lockfiles" to be put in variables in the first place. They can just be called explicitly where needed.