### PR TITLE
Fix missing '\n' in German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -517,7 +517,7 @@ msgstr "Das Löschen wurde durchgeführt\\n"
 #: src/lib/packages_cache.sh:75
 #, sh-format
 msgid "The removal hasn't been applied\\n"
-msgstr "Das Löschen wurde nicht durchgeführt\\"
+msgstr "Das Löschen wurde nicht durchgeführt\\n"
 
 #: src/lib/orphan_packages.sh:44
 #, sh-format


### PR DESCRIPTION
Fixes this: 
<img width="413" height="32" alt="grafik" src="https://github.com/user-attachments/assets/b60cda49-183a-46e3-8c91-f54199adf5ab" />
