### PR TITLE
doc(optdepends): Remove mentions of qt6-wayland

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -63,7 +63,6 @@ Dépendances optionnelles supplémentaires dont vous pourriez avoir envie ou bes
 - [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/) : Support des notifications de bureau lors de nouvelles mises à jour disponibles (voir <https://wiki.archlinux.org/title/Desktop_notifications>)
 - [vim](https://archlinux.org/packages/extra/x86_64/vim/) : Programme de comparaison par défaut pour pacdiff
 - [neovim](https://archlinux.org/packages/extra/x86_64/neovim/) : Programme de comparaison par défaut pour pacdiff si `EDITOR=nvim`
-- [qt6-wayland](https://archlinux.org/packages/extra/x86_64/qt6-wayland/) : Support de l'applet systray sur Wayland
 - [sudo](https://archlinux.org/packages/core/x86_64/sudo/): Élévation de privilèges
 - [sudo-rs](https://archlinux.org/packages/extra/x86_64/sudo-rs/): Élévation de privilèges
 - [opendoas](https://archlinux.org/packages/extra/x86_64/opendoas/): Élévation de privilèges

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Additional optional dependencies you might want or need:
 - [libnotify](https://archlinux.org/packages/extra/x86_64/libnotify/): Desktop notifications support on new available updates (see <https://wiki.archlinux.org/title/Desktop_notifications>)
 - [vim](https://archlinux.org/packages/extra/x86_64/vim/): Default diff program for pacdiff
 - [neovim](https://archlinux.org/packages/extra/x86_64/neovim/): Default diff program for pacdiff if `EDITOR=nvim`
-- [qt6-wayland](https://archlinux.org/packages/extra/x86_64/qt6-wayland/): Systray applet support on Wayland
 - [sudo](https://archlinux.org/packages/core/x86_64/sudo/): Privilege elevation
 - [sudo-rs](https://archlinux.org/packages/extra/x86_64/sudo-rs/): Privilege elevation
 - [opendoas](https://archlinux.org/packages/extra/x86_64/opendoas/): Privilege elevation


### PR DESCRIPTION
### Description

In Qt 6.10 the Qt Wayland client library and platform plugin have moved to qt6-base.  
The qt6-wayland package contains only the Wayland compositor libraries.

See https://archlinux.org/todo/qt6-wayland-dependency-cleanup/