### PR TITLE
fix(tray): Add basic validation of package URL format

### DIFF
--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -150,7 +150,7 @@ class ArchUpdateQt6:
                     return
                 url = parts[1].strip()
                 # Make sure to only send URLs to xdg-open
-				if url.startswith("http://") or url.startswith("https://"):
+                if url.startswith("http://") or url.startswith("https://"):
                     subprocess.run(["xdg-open", url], check=False)
 
     # Update dropdown menus based on the state files content


### PR DESCRIPTION
### Description

Adds a basic check to verify that the URL field of the package metadata actually starts with http:// or https:// before sending it to xdg-open.