### PR TITLE
chore: Add security concerns reporting guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Security concerns
+    url: https://github.com/Antiz96/arch-update/blob/main/SECURITY.md
+    about: To report security concerns, please follow the instructions in the SECURITY.md document
   - name: Contributing guidelines
     url: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md
     about: Please, read the contributing guidelines before opening an issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,8 @@ Arch-Update is developed and tested specifically with *vanilla* Arch Linux in mi
 
 ## Open an issue
 
+**Note:** To report security concerns, please follow the instructions in the [SECURITY.md](https://github.com/Antiz96/arch-update/blob/main/SECURITY.md) document.
+
 Before [opening an issue](https://github.com/Antiz96/arch-update/issues/new/choose), verify that there isn't one already open on the same (or a similar) subject.
 
 Make sure to use the correct type for your issue (`Bug Report` or `Feature Request`) and to provide the requested information. If you have a doubt about which one is the most appropriate for your issue (or if you think that none of these types apply to your issue), feel free to use the general `Other` type.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security
+
+To report security concerns, please send a mail to robincandau@protonmail.com instead of opening a public issue.


### PR DESCRIPTION
### Description

Add security concerns reporting guidelines via SECURITY.md and link it to issue templates and CONTRIBUTING.md