### PR TITLE
fix(i18n): Fix string format for "Next check" report in tray

### DIFF
--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -268,7 +268,7 @@ class ArchUpdateQt6:
         next_check_output = get_next_check_duration_human_readable(timer_left.stdout.strip())
 
         if next_check_output:
-            self.menu_next_check = QAction("Next check in " + next_check_output)
+            self.menu_next_check = QAction(_("Next check in {time}").format(time=next_check_output))
             self.menu_next_check.setEnabled(False)
         else:
             self.menu_next_check = None


### PR DESCRIPTION
### Description

Fix string format for "Next check" report in the systray applet script so it gets parsed by `xgettext`.