### PR TITLE
fix: Allow reboot on remote / headless machine (for pending kernel upgrade)

### DIFF
--- a/src/lib/kernel_reboot.sh
+++ b/src/lib/kernel_reboot.sh
@@ -25,7 +25,7 @@ if [ -z "${kernel_compare}" ]; then
 				sleep 1
 			done
 
-			if ! reboot; then
+			if ! systemctl reboot; then
 				echo
 				error_msg "$(eval_gettext "An error has occurred during the reboot process\nThe reboot has been aborted\n")" && quit_msg
 				exit 6


### PR DESCRIPTION
### Description

Switch from `reboot` to `systemctl reboot` to allow reboot on remote / headless machine when there's a pending kernel upgrade.

`reboot` won't run on remote / headless machine without being called with root privileges (e.g. `sudo reboot`), while `systemctl reboot` offers to escalate privileges if needed.