### PR TITLE
Modify orphan package removal to use --noconfirm

### DIFF
--- a/src/lib/orphan_packages.sh
+++ b/src/lib/orphan_packages.sh
@@ -27,7 +27,7 @@ if [ -n "${orphan_packages}" ]; then
 			main_msg "$(eval_gettext "Removing Orphan Packages...\n")"
 
 			# shellcheck disable=SC2154
-			if ! pacman -Qtdq | "${su_cmd}" pacman --color "${pacman_color_opt}" -Rns -; then
+			if ! pacman -Qtdq | "${su_cmd}" pacman --color "${pacman_color_opt}" -Rns --noconfirm -; then
 				echo
 				error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
 			else


### PR DESCRIPTION
Add --noconfirm option to pacman removal command.

<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

<!-- Describe your changes -->
pacman -Rns expects a confirmation normally, which results in an error when running this script. Updated to use --noconfirm, as the user on our end has already "confirmed" the removal of these items.


### Screenshots / Logs
Screenshot of the bug before the change
<img width="1155" height="470" alt="image" src="https://github.com/user-attachments/assets/d312efba-51b4-4dc5-8ef8-0c776029cfe6" />

Screenshot of the fix
<img width="1244" height="630" alt="image" src="https://github.com/user-attachments/assets/ebadc45d-46ed-4804-8dbe-0a9f6068e6b6" />
