### PR TITLE
feat(flatpak): Improve overall support & integration

### DIFF
--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -33,7 +33,7 @@ if [ -n "${flatpak_support}" ]; then
 	flatpak update --appstream > /dev/null
 
 	if [ -z "${no_version}" ]; then
-		flatpak remote-ls --updates --columns=name,version > "${statedir}/last_updates_check_flatpak"
+		flatpak remote-ls --updates --columns=name,version | tr -s '\t' ' ' > "${statedir}/last_updates_check_flatpak"
 	else
 		flatpak remote-ls --updates --columns=name > "${statedir}/last_updates_check_flatpak"
 	fi

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -31,7 +31,7 @@ if [ -n "${flatpak_support}" ]; then
 	flatpak update --appstream > /dev/null
 
 	if [ -z "${no_version}" ]; then
-		flatpak_packages=$(flatpak remote-ls --updates --columns=name,version)
+		flatpak_packages=$(flatpak remote-ls --updates --columns=name,version | tr -s '\t' ' ')
 	else
 		flatpak_packages=$(flatpak remote-ls --updates --columns=name)
 	fi


### PR DESCRIPTION
### Description

Improve overall flatpak support & integration:

- Switch to the built-in `flatpak remote-ls` listing mechanism to extract the list of flatpak packages that are available for update (which is less hacky / more elegant, more robust and not prone to eventual false positives as compared to the previous method).

- Rely on the "name" field to produce a more meaningful flatpak package list for users (e.g. `Discord`, `Spotify`, `Firefox` rather than `com.discordapp.Discord`, `com.spotify.Client`, `org.mozilla.firefox`).

- Add support for versions report for flatpak updates (e.g. `Discord 0.0.115`, `Spotify 1.2.74.477.g3be53afe`, `Firefox 145.0.1`). As opposed to packages and AUR packages, it doesn't include the actual version changes (e.g. `Discord 0.0.114 -> 0.0.115`) and colored output, but we're limited by flatpak CLI output here. Of course, the `NoVersion` option in `arch-update.conf` applies here as well.

### Screenshots

<img width="439" height="272" alt="2025-11-21_16-09" src="https://github.com/user-attachments/assets/c599c176-f510-48e9-ae7c-cf28b74e1025" />

<img width="414" height="271" alt="2025-11-21_16-10" src="https://github.com/user-attachments/assets/e49febfc-5e08-4361-9eee-bf68560bfa09" />

<img width="744" height="451" alt="2025-11-21_16-11" src="https://github.com/user-attachments/assets/4e17d728-d30e-460c-8d72-484bfe6361bb" />