### PR TITLE
doc(README): Add a note about the appindicator GNOME extension

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -103,6 +103,8 @@ L'utilisation consiste à démarrer [l'applet systray](#lapplet-systray) et à a
 
 Pour démarrer l'applet systray, lancez l'application "Arch-Update Systray Applet" depuis votre menu d'application.
 
+**Note:** GNOME ne supporte pas les icônes systray nativement, les utilisateurs de GNOME doivent installer [l'extension "AppIndicator and KStatusNotifierItem Support"](https://extensions.gnome.org/extension/615/appindicator-support/) pour que l'applet systray apparaisse.
+
 Pour la démarrer automatiquement au démarrage du système, utilisez l'une des options suivantes :
 
 - Lancer la commande suivante (méthode recommandée pour la plupart des environnements de bureau, utilise [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)) :

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The usage consist of starting [the systray applet](#the-systray-applet) and enab
 
 To start the systray applet, launch the "Arch-Update Systray Applet" application from your app menu.
 
+**Note:** GNOME shell does not support systray icons natively, GNOME users need to install the ["AppIndicator and KStatusNotifierItem Support" extension](https://extensions.gnome.org/extension/615/appindicator-support/) for the systray applet to show.
+
 To start it automatically at boot, you can either:
 
 - Run the following command (preferred method for most Desktop Environments, uses [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)):


### PR DESCRIPTION
### Description

GNOME shell does not support systray icons natively, GNOME users need to install the ["AppIndicator and KStatusNotifierItem Support" extension](https://extensions.gnome.org/extension/615/appindicator-support/) for the systray applet to show.

### Addressed issue

Closes https://github.com/Antiz96/arch-update/issues/464
