### PR TITLE
fix(flatpak): Honor masked patterns

### DIFF
--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -49,9 +49,9 @@ if [ -n "${flatpak_support}" ]; then
 	fi
 
 	if [ -z "${no_version}" ]; then
-		printf "%s\n" "${flatpak_packages[@]}" | awk '{print $1,$2}' > "${statedir}/last_updates_check_flatpak"
+		printf "%s\n" "${flatpak_packages[@]}" | awk '{print $1,$2}' | sed '/^[[:space:]]*$/d' > "${statedir}/last_updates_check_flatpak"
 	else
-		printf "%s\n" "${flatpak_packages[@]}" | awk '{print $1}' > "${statedir}/last_updates_check_flatpak"
+		printf "%s\n" "${flatpak_packages[@]}" | awk '{print $1}' | sed '/^[[:space:]]*$/d' > "${statedir}/last_updates_check_flatpak"
 	fi
 fi
 

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -47,9 +47,9 @@ if [ -n "${flatpak_support}" ]; then
 	fi
 
 	if [ -z "${no_version}" ]; then
-		mapfile -t flatpak_packages < <(printf "%s\n" "${flatpak_packages[@]}" | awk '{print $1,$2}')
+		mapfile -t flatpak_packages < <(printf "%s\n" "${flatpak_packages[@]}" | awk '{print $1,$2}' | sed '/^[[:space:]]*$/d')
 	else
-		mapfile -t flatpak_packages < <(printf "%s\n" "${flatpak_packages[@]}" | awk '{print $1}')
+		mapfile -t flatpak_packages < <(printf "%s\n" "${flatpak_packages[@]}" | awk '{print $1}' | sed '/^[[:space:]]*$/d')
 	fi
 fi
 


### PR DESCRIPTION
### Description

`flatpak remote-ls` (which is now used to get the list of flatpak packages available for update - https://github.com/Antiz96/arch-update/pull/459) does not take masked patterns (`flatpak mask`) into consideration, resulting in eventual false positives.

There's apparently no built-in / straightforward way from the flatpak CLI to take masked patterns into account with `flatpak remote-ls`, so we have to bake our own solution here:

- Include application IDs into the list of flatpak packages available for update.
- Store the list of flatpak packages available for update and the list of masked patterns into arrays.
- If the list of masked patterns is not empty, itterate over the list of flatpak packages available for update and remove those that matches any masked pattern.
- The match test respects the way it is handled by flatpak:
	- Comparison is done between masked patterns and application IDs.
	- Comparison is case sensitive.
	- Comparison honors wildcards (e.g. the `com.core447.*` masked pattern would exclude `com.core447.StreamController` from the list of pending updates).
- Parse the list of flatpak packages available for update in a meaningful way for users (only show application names and version, unless the `NoVersion` option is enabled in `arch-update.conf`).

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/462