### PR TITLE
chore(release): Fix substitution pattern in release script

### DIFF
--- a/scripts/mkrelease.sh
+++ b/scripts/mkrelease.sh
@@ -41,7 +41,8 @@ case "${answer}" in
 esac
 
 # Bump version where necessary
-sed -i "s/${latest_tag#v}/${release_tag}/g" doc/man/arch-update.* doc/man/fr/arch-update.* po/* src/arch-update.sh
+sed_pattern="${latest_tag//./\\.}" # escape dots
+sed -i "s/${sed_pattern#v}/${release_tag}/g" doc/man/arch-update.* doc/man/fr/arch-update.* po/* src/arch-update.sh
 
 # Update changelog
 git-cliff -up CHANGELOG.md


### PR DESCRIPTION
### Description

Escape dots in version tag before substitution with `sed`.