### PR TITLE
feat(edit-config): Add vim as an additional fallback option

### DIFF
--- a/src/lib/edit-config.sh
+++ b/src/lib/edit-config.sh
@@ -9,7 +9,7 @@ if [ ! -f "${config_file}" ]; then
 	error_msg "$(eval_gettext "No configuration file found\nYou can generate one with \"\${name} --gen-config\"")"
 	exit 13
 else
-	if ! "${EDITOR:-nano}" "${config_file}" 2> /dev/null; then
+	if ! "${EDITOR:-vim:-nano}" "${config_file}" 2> /dev/null; then
 		error_msg "$(eval_gettext "Unable to determine the editor to use\nThe \"EDITOR\" environment variable is not set and \"nano\" (fallback option) is not installed")"
 		exit 13
 	fi


### PR DESCRIPTION
### Description

Add `vim` as a fallback option (in addition of `nano`) for the `--edit-config` option.