### PR TITLE
fix(pacnew): Honor `$DIFFPROG` properly

### DIFF
--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -175,6 +175,8 @@ check_su_cmd () {
 
 # Definition of the diff program to use (if it is set in the arch-update.conf configuration file)
 check_diff_prog () {
+	[ -n "${DIFFPROG}" ] && diff_prog="${DIFFPROG}"
+
 	if [ -n "${diff_prog}" ]; then
 		if ! command -v "${diff_prog%% *}" > /dev/null; then
 			error_msg "$(eval_gettext "The \${diff_prog} editor set for visualizing / editing differences of pacnew files in the \${name}.conf configuration file is not found\n")" && quit_msg


### PR DESCRIPTION
### Description

Add a fix to properly honor the `$DIFFPROG` environment variable (if defined) as the diff program to use with `pacdiff` when handling pacnew files. Takes priority over the `DiffProg` in the `arch-update.conf` configuration file.

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/479
