### PR TITLE
fix(news): Remove the preliminary curl request

### DIFF
--- a/src/lib/list_news.sh
+++ b/src/lib/list_news.sh
@@ -6,7 +6,7 @@
 
 info_msg "$(eval_gettext "Looking for recent Arch News...")"
 # shellcheck disable=SC2154
-news=$(curl -m "${news_timeout}" -s https://archlinux.org &> /dev/null ; curl -m "${news_timeout}" -Lfs https://www.archlinux.org/news || echo "error")
+news=$(curl -m "${news_timeout}" -Lfs https://www.archlinux.org/news || echo "error")
 
 if [ "${news}" == "error" ]; then
 	echo


### PR DESCRIPTION
### Description

The preliminary curl request (added in https://github.com/Antiz96/arch-update/pull/414) was required to workaroud service outages that Arch Linux suffered from. Fortunately, it should not be necessary anymore so we can get rid of it.