### PR TITLE
fix(flatpak): Make masked patterns detection logic more robust

### DIFF
--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -30,26 +30,40 @@ fi
 if [ -n "${flatpak_support}" ]; then
 	flatpak update --appstream > /dev/null
 
-	mapfile -t flatpak_packages < <(flatpak remote-ls --updates --columns=name,version,application | tr -s '\t' ' ')
 	mapfile -t flatpak_mask < <(flatpak mask | tr -d ' ')
 
 	if [ "${#flatpak_mask[@]}" -gt 0 ]; then
-		mapfile -t flatpak_packages < <(
-			for application in "${flatpak_packages[@]}"; do
-				app_id=$(awk '{print $3}' <<< "${application}")
+		mapfile -t flatpak_packages < <(flatpak remote-ls --updates --columns=application,version | tr -s '\t' ' ')
+
+		declare -A app_names
+		while read -r flatpak_id flatpak_name; do
+			app_names["${flatpak_id}"]="${flatpak_name}"
+		done < <(flatpak list --columns=application,name)
+
+	        mapfile -t flatpak_packages < <(
+			for packages in "${flatpak_packages[@]}"; do
+				read -r app_id app_version <<< "${packages}"
+
 				for pattern in "${flatpak_mask[@]}"; do
 					# shellcheck disable=SC2053
 					[[ "${app_id}" == ${pattern} ]] && continue 2
 				done
-				echo "${application}"
+
+				app_name="${app_names[${app_id}]:-${app_id}}"
+
+				if [ -z "${no_version}" ]; then
+					echo "${app_name} ${app_version}"
+				else
+					echo "${app_name}"
+				fi
 			done
 		)
-	fi
-
-	if [ -z "${no_version}" ]; then
-		mapfile -t flatpak_packages < <(printf "%s\n" "${flatpak_packages[@]}" | awk '{print $1,$2}' | sed '/^[[:space:]]*$/d')
 	else
-		mapfile -t flatpak_packages < <(printf "%s\n" "${flatpak_packages[@]}" | awk '{print $1}' | sed '/^[[:space:]]*$/d')
+		if [ -z "${no_version}" ]; then
+			mapfile -t flatpak_packages < <(flatpak remote-ls --updates --columns=name,version | tr -s '\t' ' ')
+		else
+			mapfile -t flatpak_packages < <(flatpak remote-ls --updates --columns=name)
+		fi
 	fi
 fi
 


### PR DESCRIPTION
### Description

Flatpak application names may have spaces, so assuming that the flatpak application ID is the third column of `flatpak remote-ls --updates --columns=name,version,application` (as the previous logic to honor flatpak masked patterns introduced in https://github.com/Antiz96/arch-update/pull/466 was doing) is fragile and may result in wrong & confusing behaviors (see e.g. https://github.com/Antiz96/arch-update/issues/489).

As such, if flatpak masked patterns are detected, we are now relying on the application & version fields only (which *should* not contain spaces and are therefore *hopefully* guaranteed to respectively match column 1 & 2) and we then perform some string substitution between the application id and the application *human-readable* name later on (with a fallback to the app id for *eventual(?)* edge cases).

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/489