### PR TITLE
fix(notification): set app icon with the new notify-send `-n / --app-name` option

### DIFF
--- a/src/lib/notification.sh
+++ b/src/lib/notification.sh
@@ -13,16 +13,16 @@
 if [ "${update_number}" -eq 1 ]; then
 	if [ -z "${last_notif_id}" ]; then
 		# shellcheck disable=SC2154
-		notify-send -p -a "${_name}" -i "${name}_updates-available-${tray_icon_style}" "${_name}" "$(eval_gettext "\${update_number} update available")" -A "run=$(eval_gettext "Run \${_name}")" -A "close=$(eval_gettext "Close")" > "${tmpdir}/notif_param"
+		notify-send -p -a "${_name}" -n "${name}_updates-available-${tray_icon_style}" "${_name}" "$(eval_gettext "\${update_number} update available")" -A "run=$(eval_gettext "Run \${_name}")" -A "close=$(eval_gettext "Close")" > "${tmpdir}/notif_param"
 	else
 		# shellcheck disable=SC2154
-		notify-send -p -r "${last_notif_id}" -a "${_name}" -i "${name}_updates-available-${tray_icon_style}" "${_name}" "$(eval_gettext "\${update_number} update available")" -A "run=$(eval_gettext "Run \${_name}")" -A "close=$(eval_gettext "Close")" > "${tmpdir}/notif_param"
+		notify-send -p -r "${last_notif_id}" -a "${_name}" -n "${name}_updates-available-${tray_icon_style}" "${_name}" "$(eval_gettext "\${update_number} update available")" -A "run=$(eval_gettext "Run \${_name}")" -A "close=$(eval_gettext "Close")" > "${tmpdir}/notif_param"
 	fi
 else
 	if [ -z "${last_notif_id}" ]; then
-		notify-send -p -a "${_name}" -i "${name}_updates-available-${tray_icon_style}" "${_name}" "$(eval_gettext "\${update_number} updates available")" -A "run=$(eval_gettext "Run \${_name}")" -A "close=$(eval_gettext "Close")" > "${tmpdir}/notif_param"
+		notify-send -p -a "${_name}" -n "${name}_updates-available-${tray_icon_style}" "${_name}" "$(eval_gettext "\${update_number} updates available")" -A "run=$(eval_gettext "Run \${_name}")" -A "close=$(eval_gettext "Close")" > "${tmpdir}/notif_param"
 	else
-		notify-send -p -r "${last_notif_id}" -a "${_name}" -i "${name}_updates-available-${tray_icon_style}" "${_name}" "$(eval_gettext "\${update_number} updates available")" -A "run=$(eval_gettext "Run \${_name}")" -A "close=$(eval_gettext "Close")" > "${tmpdir}/notif_param"
+		notify-send -p -r "${last_notif_id}" -a "${_name}" -n "${name}_updates-available-${tray_icon_style}" "${_name}" "$(eval_gettext "\${update_number} updates available")" -A "run=$(eval_gettext "Run \${_name}")" -A "close=$(eval_gettext "Close")" > "${tmpdir}/notif_param"
 	fi
 fi
 


### PR DESCRIPTION
### Description

Since `libnotify` 0.8.8, `notify-send` now differentiates App icons and notification icons with the former overlapping the later in the bottom right corner (depending on the underlying notification server implementation). This looks cool in most cases but looks weird for Arch-Update (see screenshot below).

Fortunately, `libnotify` 0.8.8 introduced [a new `-n / --app-icon` option](https://gitlab.gnome.org/GNOME/libnotify/-/commit/1f3fdd1e4490cb9b9b10b2cdb1a2472212bc67e5) for `notify-send` that allows to overwrite the App icon (basically what the `-i / --icon` option used to do before App icons and notification icons got "separated").

We are therefore switching from the `-i` option to `-n` option with `notify-send` to preserve the current behavior with latest `libnotify`.

### Screenshot

<img width="494" height="145" alt="2026-01-11_23-59" src="https://github.com/user-attachments/assets/9158f13c-c315-4c93-ba44-2cd85d7db98a" />

