### PR TITLE
chore(i18n): Restore French translation for `.desktop` files

### DIFF
--- a/res/desktop/arch-update-tray.desktop
+++ b/res/desktop/arch-update-tray.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=Arch-Update Systray Applet
 Comment=Systray applet for Arch-Update
+Comment[fr]=Applet systray pour Arch-Update
 Icon=arch-update_updates-available-blue
 Type=Application
 Exec=arch-update --tray

--- a/res/desktop/arch-update.desktop
+++ b/res/desktop/arch-update.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=Arch-Update
 Comment=An interactive update notifier & applier for Arch Linux
+Comment[fr]=Un notificateur & applicateur de mises à jour interactif pour Arch Linux
 Icon=arch-update-blue
 Type=Application
 Terminal=true


### PR DESCRIPTION
### Description

The translation for `.desktop` files was dropped as part of https://github.com/Antiz96/arch-update/pull/531.

However, some users / translators might find this one still relevant to keep (see e.g. https://github.com/Antiz96/arch-update/discussions/436?sort=new#discussioncomment-16083518). As opposed to the translation for other resources dropped in https://github.com/Antiz96/arch-update/pull/531, translations for `.desktop` files should hopefully be cheap to maintain (as `.desktop` file will likely never change, this should be a one line / one time effort). So let's restore those :)