### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://github.com/Antiz96/arch-update/issues\n"
 "POT-Creation-Date: 2024-03-17 16:22+0100\n"
 "PO-Revision-Date: 2026-01-03 18:40+0100\n"
-"Last-Translator: mgruberb\n"
+"Last-Translator: DeN-AlB\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,17 +19,17 @@ msgstr ""
 #: src/lib/alhp_check.sh:14
 #, sh-format
 msgid "Your primary ALHP mirror is out of date!"
-msgstr ""
+msgstr "Der primäre ALHP-Mirror ist veraltet!"
 
 #: src/lib/alhp_check.sh:20
 #, sh-format
 msgid "The following packages still have pending ALHP builds:"
-msgstr ""
+msgstr "Für die folgenden Pakete stehen noch ALHP-Builds aus:"
 
 #: src/lib/alhp_check.sh:23
 #, sh-format
 msgid "Error during ALHP check:"
-msgstr ""
+msgstr "Fehler bei der ALHP-Prüfung:"
 
 #: src/lib/common.sh:96
 #, sh-format


### PR DESCRIPTION
German translation for the new sentences added.

```
#: src/lib/alhp_check.sh:14
#, sh-format
msgid "Your primary ALHP mirror is out of date!"
msgstr "Der primäre ALHP-Mirror ist veraltet!"

#: src/lib/alhp_check.sh:20
#, sh-format
msgid "The following packages still have pending ALHP builds:"
msgstr "Für die folgenden Pakete stehen noch ALHP-Builds aus:"

#: src/lib/alhp_check.sh:23
#, sh-format
msgid "Error during ALHP check:"
msgstr "Fehler bei der ALHP-Prüfung:"
```