### PR TITLE
feat: Disable flatpak support if no flatpak package is installed

### DIFF
--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -142,6 +142,10 @@ check_aur_helper() {
 if [ -z "${no_flatpak}" ]; then
 	# shellcheck disable=SC2034
 	flatpak_support=$(command -v flatpak)
+	# Disable flatpak support if flatpak is available but no Flatpak package is installed
+	if [ -n "${flatpak_support}" ] && [ -z "$(flatpak list --user ; flatpak list --system)" ]; then
+		unset flatpak_support
+	fi
 fi
 
 # Check if notify-send is installed for the optional desktop notification support


### PR DESCRIPTION
### Description

Currently, we only check if the `flatpak` command is available to enable the flatpak support. However, there are edge cases where the `flatpak` command is available but no flatpak package is (intentionally) installed (for instance if `flatpak` is pulled as a dependency of another package, yet the user has no intent to install flatpak packages).

The `NoFlatpak` option in the `arch-update.conf` configuration file could cover this, but it probably make sense to handle such a case automatically / dynamically as it doesn't make sense to check for flatpak updates if there are no flatpak package installed anyway.

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/551