### PR TITLE
i18n: Update Basque translation with request timeout messages

### DIFF
--- a/po/eu.po
+++ b/po/eu.po
@@ -15,6 +15,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Language: eu_ES\n"
+"X-Source-Language: C\n"
 
 #: src/lib/alhp_check.sh:14
 #, sh-format
@@ -436,16 +439,22 @@ msgstr "Eguneraketak bilatzen...\\n"
 #, sh-format
 msgid "Unable to retrieve Packages updates (request timeout)\\n"
 msgstr ""
+"Ezin izan dira paketeen eguneraketak eskuratu (eskaeraren denbora-muga "
+"gainditu da)\\n"
 
 #: src/lib/list_packages.sh:32
 #, sh-format
 msgid "Unable to retrieve AUR Packages updates (request timeout)\\n"
 msgstr ""
+"Ezin izan dira AUR paketeen eguneraketak eskuratu (eskaeraren denbora-muga "
+"gainditu da)\\n"
 
 #: src/lib/list_packages.sh:44
 #, sh-format
 msgid "Unable to retrieve Flatpak packages updates (request timeout)\\n"
 msgstr ""
+"Ezin izan dira Flatpak paketeen eguneraketak eskuratu (eskaeraren denbora-"
+"muga gainditu da)\\n"
 
 #: src/lib/list_packages.sh:91
 #, sh-format


### PR DESCRIPTION
Hi Antiz! 

I've followed your advice and started fresh from a clean fork to avoid the previous merge issues. 

In this PR:
- Fixed all previous merge conflicts.
- Added the 3 new translation strings regarding request timeouts.
- The `po/eu.po` file is now clean and up to date.

Ready for review. Thanks!
