### PR TITLE
Fix crash if timer_json is invalid

### DIFF
--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -111,7 +111,10 @@ def arch_update():
 def get_next_check_duration_human_readable(input_json):
     """Calculate human-readable duration from systemctl output"""
     result = None
-    timer_json = json.loads(input_json)
+    try:
+        timer_json = json.loads(input_json)
+    except json.decoder.JSONDecodeError:
+        return None
     if timer_json:
         next_microseconds = timer_json[0].get("next")
         if next_microseconds:


### PR DESCRIPTION
### Description
Added a try except block to catch JSONDecodeError in get_next_check_duration_human_readable, as if systemd is not present update_dropdown_menus will pass an invalid output to the function and crash the program
The behavior is if a bad json is passed it simply returns None as it seems the function already expects to not get a json (`if timer_json:`) and returns result if that's the case (which will be None due to the previous check)

### Screenshots / Logs

```text
Traceback (most recent call last):
  File "/usr/share/arch-update/lib/tray.py", line 421, in <module>
    ArchUpdateQt6(ICON_STATEFILE)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/usr/share/arch-update/lib/tray.py", line 416, in __init__
    self.file_changed()
    ~~~~~~~~~~~~~~~~~^^
  File "/usr/share/arch-update/lib/tray.py", line 144, in file_changed
    self.update_dropdown_menus()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/share/arch-update/lib/tray.py", line 268, in update_dropdown_menus
    next_check_output = get_next_check_duration_human_readable(timer_left.stdout.strip())
  File "/usr/share/arch-update/lib/tray.py", line 114, in get_next_check_duration_human_readable
    timer_json = json.loads(input_json)
  File "/usr/lib/python3.14/json/__init__.py", line 352, in loads
    return _default_decoder.decode(s)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/usr/lib/python3.14/json/decoder.py", line 345, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/json/decoder.py", line 363, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```