### PR TITLE
fix: polkit password prompts broken via SSH (#574)

### DIFF
--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -37,7 +37,8 @@ if [ -n "${aur_helper}" ]; then
 fi
 
 if [ -n "${flatpak_support}" ]; then
-	timeout "${update_check_timeout}" flatpak update --appstream > /dev/null
+	# `--foreground` because Flatpak requires interactive authentications through Polkit's `pkttyagent` if it is executed from a TTY / SSH environment
+	timeout --foreground "${update_check_timeout}" flatpak update --appstream > /dev/null
 	flatpak_metadata_update_exit_code=$?
 
 	if [ "${flatpak_metadata_update_exit_code}" -eq 124 ]; then


### PR DESCRIPTION
<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

Added `--foreground/-f` flag to `timeout` calls in the list-packages routine to fix polkit password prompts when used via SSH.

### Screenshots / Logs

See #574

### Fixed bug

Fixes #574 

### Notes

Sorry for the delay, I was already off my computer for the day by the time you asked me for a PR.