### PR TITLE
fix: Treat issues during AUR and Flatpak packages updates as warning

### DIFF
--- a/src/lib/update.sh
+++ b/src/lib/update.sh
@@ -28,6 +28,7 @@ if [ -n "${aur_packages}" ]; then
 		icon_updates-available
 		echo
 		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted")"
+		error_during_update="true"
 	else
 		# shellcheck disable=SC2034
 		packages_updated="true"
@@ -41,9 +42,12 @@ if [ -n "${flatpak_packages}" ]; then
 	if ! flatpak update; then
 		icon_updates-available
 		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted")"
+		error_during_update="true"
 	fi
 fi
 
-icon_up-to-date
-echo
-info_msg "$(eval_gettext "The update has been applied\n")"
+if [ -z "${error_during_update}" ]; then
+	icon_up-to-date
+	echo
+	info_msg "$(eval_gettext "The update has been applied\n")"
+fi

--- a/src/lib/update.sh
+++ b/src/lib/update.sh
@@ -27,7 +27,7 @@ if [ -n "${aur_packages}" ]; then
 	if ! "${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Syu; then
 		icon_updates-available
 		echo
-		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")"
+		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted")"
 	else
 		# shellcheck disable=SC2034
 		packages_updated="true"
@@ -40,7 +40,7 @@ if [ -n "${flatpak_packages}" ]; then
 
 	if ! flatpak update; then
 		icon_updates-available
-		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")"
+		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted")"
 	fi
 fi
 

--- a/src/lib/update.sh
+++ b/src/lib/update.sh
@@ -27,8 +27,7 @@ if [ -n "${aur_packages}" ]; then
 	if ! "${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Syu; then
 		icon_updates-available
 		echo
-		error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
-		exit 5
+		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")"
 	else
 		# shellcheck disable=SC2034
 		packages_updated="true"
@@ -41,8 +40,7 @@ if [ -n "${flatpak_packages}" ]; then
 
 	if ! flatpak update; then
 		icon_updates-available
-		error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
-		exit 5
+		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")"
 	fi
 fi
 

--- a/src/lib/update.sh
+++ b/src/lib/update.sh
@@ -27,7 +27,7 @@ if [ -n "${aur_packages}" ]; then
 	if ! "${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Syu; then
 		icon_updates-available
 		echo
-		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted")"
+		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")"
 		error_during_update="true"
 	else
 		# shellcheck disable=SC2034
@@ -41,7 +41,7 @@ if [ -n "${flatpak_packages}" ]; then
 
 	if ! flatpak update; then
 		icon_updates-available
-		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted")"
+		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")"
 		error_during_update="true"
 	fi
 fi


### PR DESCRIPTION
### Description

Currently, issues happening during AUR and Flatpak packages updates are treated as errors. This means that the rest of the scripts (orphan cleaning, pacman cache cleaning, post update service restart, etc...) will not be triggered in such case.

This might be a confusing behavior (which may even lead to unexpected issues in rare cases). For instance, choosing not to update AUR or Flatpak packages when being prompted to do so will make Arch-Update exit on error with the rest of the important maintenance steps not being executed (same for an AUR package that fails to build, etc...).

As such, we should probably treat any issues happening during AUR and Flatpak packages updates as (non-blocking) warning rather then actual errors. AUR packages are not officially supported side and their support within Arch-Update is optional. As for Flatpak packages, they do not directly interact with the system and their support within Arch-Update is also optional. It probably makes sense to only treat issues happening during official / repo packages update as actual errors.

### Screenshots

Before:

<img width="803" height="496" alt="image" src="https://github.com/user-attachments/assets/bad02a31-5b19-4f24-95c3-d710ca01e26a" />

After:

<img width="769" height="460" alt="image" src="https://github.com/user-attachments/assets/7da3a716-a6fa-4759-9a08-c9a8dffeb6f4" />

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/582
