### PR TITLE
fix: Update state files updating logic to match changes added in #583

### DIFF
--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -28,12 +28,8 @@ if [ -n "${proceed_with_update}" ]; then
 	# shellcheck source=src/lib/update.sh
 	source "${libdir}/update.sh"
 
-	# Record the date of the last successful update (used by other stages) and empty the 'updates' state files (which contains the list of pending updates)
+	# Record the date of the last successful update (used by the "list_news" library)
 	date +%Y-%m-%d > "${statedir}/last_update_run"
-	true > "${statedir}/last_updates_check"
-	true > "${statedir}/last_updates_check_packages"
-	true > "${statedir}/last_updates_check_aur"
-	true > "${statedir}/last_updates_check_flatpak"
 fi
 
 # Source the "orphan_packages" library which displays orphan packages and offers to remove them

--- a/src/lib/update.sh
+++ b/src/lib/update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# update.sh: Update packages
+# update.sh: Update packages and update state files accordingly
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,6 +15,7 @@ if [ -n "${packages}" ]; then
 		error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
 		exit 5
 	else
+		true > "${statedir}/last_updates_check_packages"
 		packages_updated="true"
 	fi
 fi
@@ -30,6 +31,7 @@ if [ -n "${aur_packages}" ]; then
 		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")"
 		error_during_update="true"
 	else
+		true > "${statedir}/last_updates_check_aur"
 		# shellcheck disable=SC2034
 		packages_updated="true"
 	fi
@@ -43,8 +45,12 @@ if [ -n "${flatpak_packages}" ]; then
 		icon_updates-available
 		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")"
 		error_during_update="true"
+	else
+		true > "${statedir}/last_updates_check_flatpak"
 	fi
 fi
+
+cat "${statedir}"/last_updates_check_{packages,aur,flatpak} > "${statedir}/last_updates_check"
 
 if [ -z "${error_during_update}" ]; then
 	icon_up-to-date


### PR DESCRIPTION
### Description

Logic fixes to ensure that state files are properly being updated when an error occur during an update process

Relates to https://github.com/Antiz96/arch-update/issues/582 & https://github.com/Antiz96/arch-update/pull/583