### PR TITLE
chore(icon): Remove useless update calls

### DIFF
--- a/src/lib/update.sh
+++ b/src/lib/update.sh
@@ -10,7 +10,6 @@ if [ -n "${packages}" ]; then
 
 	# shellcheck disable=SC2154
 	if ! "${su_cmd}" pacman --color "${pacman_color_opt}" -Syu; then
-		icon_updates-available
 		echo
 		error_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")" && quit_msg
 		exit 5
@@ -26,7 +25,6 @@ if [ -n "${aur_packages}" ]; then
 
 	# shellcheck disable=SC2154
 	if ! "${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Syu; then
-		icon_updates-available
 		echo
 		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")"
 		error_during_update="true"
@@ -42,7 +40,6 @@ if [ -n "${flatpak_packages}" ]; then
 	main_msg "$(eval_gettext "Updating Flatpak Packages...\n")"
 
 	if ! flatpak update; then
-		icon_updates-available
 		warning_msg "$(eval_gettext "An error has occurred during the update process\nThe update has been aborted\n")"
 		error_during_update="true"
 	else


### PR DESCRIPTION
### Description

Those icon update calls where initially added as some sort of "safety measure / fallback" to ensure the proper icon state is used in case of error. However, this shouldn't be needed as, at that stage, the icon is already set to the proper state and there's no reason for it to be changed in between, so let's drop it.