### PR TITLE
fix(orphans): Additionally check for orphans packages before AUR package updates

### DIFF
--- a/src/lib/flatpak_unused_packages.sh
+++ b/src/lib/flatpak_unused_packages.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# flatpak_unused_packages.sh: Display flatpak unused packages and offer to remove them
+# https://github.com/Antiz96/arch-update
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+flatpak_unused=$(flatpak uninstall --unused | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
+
+if [ -n "${flatpak_unused}" ]; then
+	main_msg "$(eval_gettext "Flatpak Unused Packages:")"
+	echo -e "${flatpak_unused}\n"
+
+	if [ "$(echo "${flatpak_unused}" | wc -l)" -eq 1 ]; then
+		ask_msg "$(eval_gettext "Would you like to remove this Flatpak unused package now? [y/N]")"
+	else
+		ask_msg "$(eval_gettext "Would you like to remove these Flatpak unused packages now? [y/N]")"
+	fi
+
+	# shellcheck disable=SC2154
+	case "${answer}" in
+		"$(eval_gettext "Y")"|"$(eval_gettext "y")")
+			echo
+			main_msg "$(eval_gettext "Removing Flatpak Unused Packages...")"
+
+			if ! flatpak uninstall --unused; then
+				echo
+				error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
+			else
+				echo
+				info_msg "$(eval_gettext "The removal has been applied\n")"
+			fi
+		;;
+		*)
+			echo
+			info_msg "$(eval_gettext "The removal hasn't been applied\n")"
+		;;
+	esac
+else
+	info_msg "$(eval_gettext "No Flatpak unused package found\n")"
+fi

--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -32,9 +32,20 @@ if [ -n "${proceed_with_update}" ]; then
 	date +%Y-%m-%d > "${statedir}/last_update_run"
 fi
 
-# Source the "orphan_packages" library which displays orphan packages and offers to remove them
-# shellcheck source=src/lib/orphan_packages.sh
-source "${libdir}/orphan_packages.sh"
+# Source the "orphan_packages" library which displays orphan packages and offers to remove them if:
+# - There was no AUR package to update (meaning orphans have not been checked yet)
+# Or
+# - The was AUR package(s) to update but the list of orphans changed after the AUR package(s) update
+if [ -z "${aur_packages}" ] || ! diff <(printf "%s\n" "${orphan_packages[@]}" | sed '/^$/d' | sort) <(pacman -Qtdq | sort) > /dev/null; then
+	# shellcheck source=src/lib/orphan_packages.sh
+	source "${libdir}/orphan_packages.sh"
+fi
+
+# Source the "flatpak_unused_packages" library which displays Flatpak unused packages and offers to remove them (if flatpak support is enabled)
+if [ -n "${flatpak_support}" ]; then
+	# shellcheck source=src/lib/flatpak_unused_packages.sh
+	source "${libdir}/flatpak_unused_packages.sh"
+fi
 
 # Source the "packages_cache" library which searches for old package archives in pacman cache and offers to remove them
 # shellcheck source=src/lib/packages_cache.sh

--- a/src/lib/orphan_packages.sh
+++ b/src/lib/orphan_packages.sh
@@ -6,10 +6,6 @@
 
 mapfile -t orphan_packages < <(pacman -Qtdq)
 
-if [ -n "${flatpak_support}" ]; then
-	flatpak_unused=$(flatpak uninstall --unused | sed -n '/^ 1./,$p' | awk '{print $2}' | grep -v '^$' | sed '$d')
-fi
-
 if [ "${#orphan_packages[@]}" -gt 0 ]; then
 	main_msg "$(eval_gettext "Orphan Packages:")"
 	printf "%s\n" "${orphan_packages[@]}" ""
@@ -33,6 +29,7 @@ if [ "${#orphan_packages[@]}" -gt 0 ]; then
 			else
 				echo
 				info_msg "$(eval_gettext "The removal has been applied\n")"
+				unset orphan_packages
 			fi
 		;;
 		*)
@@ -42,38 +39,4 @@ if [ "${#orphan_packages[@]}" -gt 0 ]; then
 	esac
 else
 	info_msg "$(eval_gettext "No orphan package found\n")"
-fi
-
-if [ -n "${flatpak_support}" ]; then
-	if [ -n "${flatpak_unused}" ]; then
-		main_msg "$(eval_gettext "Flatpak Unused Packages:")"
-		echo -e "${flatpak_unused}\n"
-
-		if [ "$(echo "${flatpak_unused}" | wc -l)" -eq 1 ]; then
-			ask_msg "$(eval_gettext "Would you like to remove this Flatpak unused package now? [y/N]")"
-		else
-			ask_msg "$(eval_gettext "Would you like to remove these Flatpak unused packages now? [y/N]")"
-		fi
-
-		case "${answer}" in
-			"$(eval_gettext "Y")"|"$(eval_gettext "y")")
-				echo
-				main_msg "$(eval_gettext "Removing Flatpak Unused Packages...")"
-
-				if ! flatpak uninstall --unused; then
-					echo
-					error_msg "$(eval_gettext "An error has occurred during the removal process\nThe removal has been aborted\n")"
-				else
-					echo
-					info_msg "$(eval_gettext "The removal has been applied\n")"
-				fi
-			;;
-			*)
-				echo
-				info_msg "$(eval_gettext "The removal hasn't been applied\n")"
-			;;
-		esac
-	else
-		info_msg "$(eval_gettext "No Flatpak unused package found\n")"
-	fi
 fi

--- a/src/lib/update.sh
+++ b/src/lib/update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# update.sh: Update packages and update state files accordingly
+# update.sh: Update packages and state files
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,10 @@ fi
 
 if [ -n "${aur_packages}" ]; then
 	echo
+	# shellcheck disable=SC2154
+	# shellcheck source=src/lib/orphan_packages.sh
+	source "${libdir}/orphan_packages.sh"
+
 	main_msg "$(eval_gettext "Updating AUR Packages...\n")"
 
 	# shellcheck disable=SC2154


### PR DESCRIPTION
### Description

Currently, we only check for orphans packages once every updates has been applied (packages, AUR & Flatpak). In some specific cases, this can lead to undesired behaviors. 

For instance: if a package is dropped from the official repositories to the AUR and is now marked as orphan on users' system but a `pkgrel` (or `pkgver`) bump is made to the AUR package in the mean time, then said package will be picked up by the AUR helper for update; resulting in an unnecessary local (re)build of the package even though we will offer to remove it right after this (as it actually is an orphan package).

As such, when there are AUR updates available, we are now additionally checking for orphans **before** AUR updates (so potential orphans can be removed before eventually being picked up by AUR helpers unnecessarily).

We are still checking for orphans later on if:

- There was no AUR package to update (meaning orphans have not been checked yet)
- There was AUR package(s) to update but the list of orphans changed after the AUR package(s) update

So even if we are technically checking for orphans twice now (when there are AUR package updates), we will only actually prompt it twice to the user if relevant (meaning if the list of orphans changed between the first and the second checks, e.g. if the AUR package updates itself left some orphans behind).

Orphans are still checked once as usual if there's no update available.

For the purpose of this change, the check of unused Flatpak packages is therefore moved to its own library script.