### PR TITLE
feat(i18n): Fix Spanish translation formality

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -10,19 +10,19 @@ msgstr ""
 "Project-Id-Version: Arch-Update 3.19.5\n"
 "Report-Msgid-Bugs-To: https://github.com/Antiz96/arch-update/issues\n"
 "POT-Creation-Date: 2024-03-17 16:22+0100\n"
-"PO-Revision-Date: 2026-03-28 19:47-0300\n"
-"Last-Translator: Diego N.S <degons490@gmail.com>\n"
+"PO-Revision-Date: 2026-05-26 17:22+0200\n"
+"Last-Translator: Diego Jesús <diego.u7ozo@addy.io>\n"
 "Language-Team: Spanish\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.8\n"
+"X-Generator: Poedit 3.9\n"
 
 #: src/lib/alhp_check.sh:14
 #, sh-format
 msgid "Your primary ALHP mirror is out of date!\\n"
-msgstr "¡Tu espejo principal de ALHP está desactualizado!\\n"
+msgstr "¡Su espejo principal de ALHP está desactualizado!\\n"
 
 #: src/lib/alhp_check.sh:20
 #, sh-format
@@ -200,7 +200,7 @@ msgid ""
 "with important pre / post update tasks."
 msgstr ""
 "Un notificador y aplicador de actualizaciones interactivo para Arch Linux "
-"que te ayuda con tareas importantes antes y después de las actualizaciones."
+"que le ayuda con tareas importantes antes y después de las actualizaciones."
 
 #: src/lib/help.sh:10
 #, sh-format
@@ -358,7 +358,7 @@ msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information"
 msgstr ""
-"${name}: opción no válida -- «${option}»\\nPrueba «${name} --help» para "
+"${name}: opción no válida -- «${option}»\\nPruebe «${name} --help» para "
 "obtener más información"
 
 #: src/lib/kernel_reboot.sh:10


### PR DESCRIPTION
### Description

Change the Spanish translation from informal (“tú”) to formal (“usted”) to maintain consistency with the rest of the Spanish translations.

The following msgstr entries were updated:
- Line 25: "Tu espejo principal..." → "Su espejo principal..."
- Line 203: "que te ayuda..." → "que le ayuda..."
- Line 361: "Prueba" → "Pruebe"

This ensures that all Spanish strings consistently use formal second-person pronouns throughout the application.