### PR TITLE
feat: Add version diff highlighting and columns to the update list

### DIFF
--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -90,25 +90,25 @@ true > "${statedir}/last_updates_check_flatpak"
 
 # Display a package list with aligned columns and version diff highlighting.
 display_update_list() {
-	local line name old new i seg
-	local -a old_parts new_parts
+	local line pkgname oldver newver counter seg
+	local -a old_vers new_vers
 
 	while IFS= read -r line; do
 		[ -z "${line}" ] && continue
-		read -r name old _ new <<< "${line}"
+		read -r pkgname oldver _ newver <<< "${line}"
 		# shellcheck disable=SC2154
-		if [ -z "${old}" ]; then
-			echo "${name}"
+		if [ -z "${oldver}" ]; then
+			echo "${pkgname}"
 		elif [ -z "${no_color}" ]; then
-			IFS='.-' read -ra old_parts <<< "${old}"
-			IFS='.-' read -ra new_parts <<< "${new}"
-			i=0
+			IFS='.-' read -ra old_vers <<< "${oldver}"
+			IFS='.-' read -ra new_vers <<< "${newver}"
+			counter=0
 			seg=0
-			while [ "${seg}" -lt "${#old_parts[@]}" ] && [ "${seg}" -lt "${#new_parts[@]}" ] && [ "${old_parts[${seg}]}" = "${new_parts[${seg}]}" ]; do
-				i=$(( i + ${#old_parts[${seg}]} + 1 ))
+			while [ "${seg}" -lt "${#old_vers[@]}" ] && [ "${seg}" -lt "${#new_vers[@]}" ] && [ "${old_vers[${seg}]}" = "${new_vers[${seg}]}" ]; do
+				counter=$(( counter + ${#old_vers[${seg}]} + 1 ))
 				seg=$(( seg + 1 ))
 			done
-			printf "%b %b -> %b\n" "${bold}${name}${color_off}" "${old:0:${i}}${red}${bold}${old:${i}}${color_off}" "${new:0:${i}}${green}${bold}${new:${i}}${color_off}"
+			printf "%b %b -> %b\n" "${bold}${pkgname}${color_off}" "${oldver:0:${counter}}${red}${bold}${oldver:${counter}}${color_off}" "${newver:0:${counter}}${green}${bold}${newver:${counter}}${color_off}"
 		else
 			echo "${line}"
 		fi

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -9,7 +9,7 @@ info_msg "$(eval_gettext "Looking for updates...\n")"
 # shellcheck disable=SC2154
 checkupdates_db_tmpdir=$(mktemp -d "${checkupdates_db_tmpdir_prefix}XXXXX")
 # shellcheck disable=SC2154
-packages=$(CHECKUPDATES_DB="${checkupdates_db_tmpdir}" timeout "${update_check_timeout}" checkupdates "${contrib_color_opt[@]}")
+packages=$(CHECKUPDATES_DB="${checkupdates_db_tmpdir}" timeout "${update_check_timeout}" checkupdates --nocolor)
 packages_exit_code=$?
 
 if [ "${packages_exit_code}" -eq 124 ]; then
@@ -82,22 +82,55 @@ if [ -n "${flatpak_support}" ]; then
 	fi
 fi
 
+# Strip ANSI color codes from AUR helper output
+# shellcheck disable=SC2001
+[ -n "${aur_packages}" ] && aur_packages=$(echo "${aur_packages}" | sed 's/\x1B\[[0-9;]*m//g')
+
 # shellcheck disable=SC2154
 true > "${statedir}/last_updates_check"
 true > "${statedir}/last_updates_check_packages"
 true > "${statedir}/last_updates_check_aur"
 true > "${statedir}/last_updates_check_flatpak"
 
+# Display a package list with aligned columns and version diff highlighting.
+display_update_list() {
+	local line name old new i seg
+	local -a old_parts new_parts
+
+	while IFS= read -r line; do
+		[ -z "${line}" ] && continue
+		read -r name old _ new <<< "${line}"
+		# shellcheck disable=SC2154
+		if [ -z "${old}" ]; then
+			echo "${name}"
+		elif [ -z "${no_color}" ]; then
+			IFS='.-' read -ra old_parts <<< "${old}"
+			IFS='.-' read -ra new_parts <<< "${new}"
+			i=0
+			seg=0
+			while [ "${seg}" -lt "${#old_parts[@]}" ] && [ "${seg}" -lt "${#new_parts[@]}" ] && [ "${old_parts[${seg}]}" = "${new_parts[${seg}]}" ]; do
+				i=$(( i + ${#old_parts[${seg}]} + 1 ))
+				seg=$(( seg + 1 ))
+			done
+			printf "%b %b -> %b\n" "${bold}${name}${color_off}" "${old:0:${i}}${red}${bold}${old:${i}}${color_off}" "${new:0:${i}}${green}${bold}${new:${i}}${color_off}"
+		else
+			echo "${line}"
+		fi
+	done | column -t
+}
+
 if [ -n "${packages}" ]; then
 	main_msg "$(eval_gettext "Packages:")"
-	echo -e "${packages}\n"
+	echo "${packages}" | display_update_list
+	echo
 	echo "${packages}" >> "${statedir}/last_updates_check"
 	echo "${packages}" > "${statedir}/last_updates_check_packages"
 fi
 
 if [ -n "${aur_packages}" ]; then
 	main_msg "$(eval_gettext "AUR Packages:")"
-	echo -e "${aur_packages}\n"
+	echo "${aur_packages}" | display_update_list
+	echo
 	echo "${aur_packages}" >> "${statedir}/last_updates_check"
 	echo "${aur_packages}" > "${statedir}/last_updates_check_aur"
 fi
@@ -108,8 +141,6 @@ if [ "${#flatpak_packages[@]}" -gt 0 ]; then
 	printf "%s\n" "${flatpak_packages[@]}" >> "${statedir}/last_updates_check"
 	printf "%s\n" "${flatpak_packages[@]}" > "${statedir}/last_updates_check_flatpak"
 fi
-
-sed -ri 's/\x1B\[[0-9;]*m//g' "${statedir}"/last_updates_check{,_packages,_aur,_flatpak}
 
 if [ -z "${packages}" ] && [ -z "${aur_packages}" ] && [ "${#flatpak_packages[@]}" -eq 0 ]; then
 	icon_up-to-date

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -89,7 +89,7 @@ true > "${statedir}/last_updates_check_aur"
 true > "${statedir}/last_updates_check_flatpak"
 
 # Display a package list with aligned columns and version diff highlighting.
-display_update_list() {
+color_update_list() {
 	local line pkgname oldver newver counter seg
 	local -a old_vers new_vers
 
@@ -113,12 +113,12 @@ display_update_list() {
 		else
 			echo "${line}"
 		fi
-	done | column -t
+	done
 }
 
 if [ -n "${packages}" ]; then
 	main_msg "$(eval_gettext "Packages:")"
-	echo "${packages}" | display_update_list
+	echo "${packages}" | color_update_list | column -t
 	echo
 	echo "${packages}" >> "${statedir}/last_updates_check"
 	echo "${packages}" > "${statedir}/last_updates_check_packages"
@@ -126,7 +126,7 @@ fi
 
 if [ -n "${aur_packages}" ]; then
 	main_msg "$(eval_gettext "AUR Packages:")"
-	echo "${aur_packages}" | display_update_list
+	echo "${aur_packages}" | color_update_list | column -t
 	echo
 	echo "${aur_packages}" >> "${statedir}/last_updates_check"
 	echo "${aur_packages}" > "${statedir}/last_updates_check_aur"
@@ -134,7 +134,8 @@ fi
 
 if [ "${#flatpak_packages[@]}" -gt 0 ]; then
 	main_msg "$(eval_gettext "Flatpak Packages:")"
-	printf "%s\n" "${flatpak_packages[@]}" ""
+	printf "%s\n" "${flatpak_packages[@]}" | column -t
+	echo
 	printf "%s\n" "${flatpak_packages[@]}" >> "${statedir}/last_updates_check"
 	printf "%s\n" "${flatpak_packages[@]}" > "${statedir}/last_updates_check_flatpak"
 fi

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -24,7 +24,7 @@ if [ -n "${aur_helper}" ]; then
 	# The former because it assumes an interactive TTY environment (causing `timeout` to behave unexpectedly) 
 	# The latter because it outputs some descriptive string in stderr when looking for updates with -Qua
 	# shellcheck disable=SC2154
-	unformatted_aur_packages=$(timeout "${update_check_timeout}" "${aur_helper}" --color "${pacman_color_opt}" "${devel_flag[@]}" -Qua < /dev/null 2> /dev/null)
+	unformatted_aur_packages=$(timeout "${update_check_timeout}" "${aur_helper}" --color never "${devel_flag[@]}" -Qua < /dev/null 2> /dev/null)
 	unformatted_aur_packages_exit_code=$?
 	aur_packages=$(echo "${unformatted_aur_packages}" | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$")
 
@@ -81,10 +81,6 @@ if [ -n "${flatpak_support}" ]; then
 		fi
 	fi
 fi
-
-# Strip ANSI color codes from AUR helper output
-# shellcheck disable=SC2001
-[ -n "${aur_packages}" ] && aur_packages=$(echo "${aur_packages}" | sed 's/\x1B\[[0-9;]*m//g')
 
 # shellcheck disable=SC2154
 true > "${statedir}/last_updates_check"

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -104,6 +104,7 @@ color_update_list() {
 			counter=$(( counter + ${#old_vers[${seg}]} + 1 ))
 			seg=$(( seg + 1 ))
 		done
+		# shellcheck disable=SC2154
 		printf "%b %b -> %b\n" "${bold}${pkgname}${color_off}" "${oldver:0:${counter}}${red}${bold}${oldver:${counter}}${color_off}" "${newver:0:${counter}}${green}${bold}${newver:${counter}}${color_off}"
 	done
 }

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -96,6 +96,7 @@ display_update_list() {
 	while IFS= read -r line; do
 		[ -z "${line}" ] && continue
 		read -r pkgname oldver _ newver <<< "${line}"
+		# If running with the "NoVersion" option
 		# shellcheck disable=SC2154
 		if [ -z "${oldver}" ]; then
 			echo "${pkgname}"

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -88,7 +88,7 @@ true > "${statedir}/last_updates_check_packages"
 true > "${statedir}/last_updates_check_aur"
 true > "${statedir}/last_updates_check_flatpak"
 
-# Display a package list with aligned columns and version diff highlighting.
+# Re-color update list output with version diff highlighting
 color_update_list() {
 	local line pkgname oldver newver counter seg
 	local -a old_vers new_vers
@@ -96,29 +96,25 @@ color_update_list() {
 	while IFS= read -r line; do
 		[ -z "${line}" ] && continue
 		read -r pkgname oldver _ newver <<< "${line}"
-		# If running with the "NoVersion" option
-		# shellcheck disable=SC2154
-		if [ -z "${oldver}" ]; then
-			echo "${pkgname}"
-		elif [ -z "${no_color}" ]; then
-			IFS='.-' read -ra old_vers <<< "${oldver}"
-			IFS='.-' read -ra new_vers <<< "${newver}"
-			counter=0
-			seg=0
-			while [ "${seg}" -lt "${#old_vers[@]}" ] && [ "${seg}" -lt "${#new_vers[@]}" ] && [ "${old_vers[${seg}]}" = "${new_vers[${seg}]}" ]; do
-				counter=$(( counter + ${#old_vers[${seg}]} + 1 ))
-				seg=$(( seg + 1 ))
-			done
-			printf "%b %b -> %b\n" "${bold}${pkgname}${color_off}" "${oldver:0:${counter}}${red}${bold}${oldver:${counter}}${color_off}" "${newver:0:${counter}}${green}${bold}${newver:${counter}}${color_off}"
-		else
-			echo "${line}"
-		fi
+		IFS='.-' read -ra old_vers <<< "${oldver}"
+		IFS='.-' read -ra new_vers <<< "${newver}"
+		counter=0
+		seg=0
+		while [ "${seg}" -lt "${#old_vers[@]}" ] && [ "${seg}" -lt "${#new_vers[@]}" ] && [ "${old_vers[${seg}]}" = "${new_vers[${seg}]}" ]; do
+			counter=$(( counter + ${#old_vers[${seg}]} + 1 ))
+			seg=$(( seg + 1 ))
+		done
+		printf "%b %b -> %b\n" "${bold}${pkgname}${color_off}" "${oldver:0:${counter}}${red}${bold}${oldver:${counter}}${color_off}" "${newver:0:${counter}}${green}${bold}${newver:${counter}}${color_off}"
 	done
 }
 
 if [ -n "${packages}" ]; then
 	main_msg "$(eval_gettext "Packages:")"
-	echo "${packages}" | color_update_list | column -t
+	if [ -n "${no_color}" ] || [ -n "${no_version}" ]; then
+		echo "${packages}" | column -t
+	else
+		echo "${packages}" | color_update_list | column -t
+	fi
 	echo
 	echo "${packages}" >> "${statedir}/last_updates_check"
 	echo "${packages}" > "${statedir}/last_updates_check_packages"
@@ -126,7 +122,11 @@ fi
 
 if [ -n "${aur_packages}" ]; then
 	main_msg "$(eval_gettext "AUR Packages:")"
-	echo "${aur_packages}" | color_update_list | column -t
+	if [ -n "${no_color}" ] || [ -n "${no_version}" ]; then
+		echo "${aur_packages}" | column -t
+	else
+		echo "${aur_packages}" | color_update_list | column -t
+	fi
 	echo
 	echo "${aur_packages}" >> "${statedir}/last_updates_check"
 	echo "${aur_packages}" > "${statedir}/last_updates_check_aur"


### PR DESCRIPTION
<!-- Please, read the contributing guidelines before opening a pull request: https://github.com/Antiz96/arch-update/blob/main/CONTRIBUTING.md -->

### Description

Colorize the changed suffix of version strings when displaying pending updates.
Column alignment is handled by column -t.
Leaves flatpak printing as it was.

### Screenshots / Logs

#### Before
<img width="1131" height="919" alt="image" src="https://github.com/user-attachments/assets/daa95674-b32b-4a80-b895-b92a458ebb5d" />

#### After
<img width="889" height="922" alt="image" src="https://github.com/user-attachments/assets/e034ca9b-63f1-4d79-b427-01d383532b73" />

### Addressed feature request

<!-- If this pull request is addressing an opened feature request, paste the corresponding issue URL below -->

Closes https://github.com/Antiz96/arch-update/issues/600
