### PR TITLE
fix: version diff highlighting

### DIFF
--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -96,8 +96,8 @@ color_update_list() {
 	while IFS= read -r line; do
 		[ -z "${line}" ] && continue
 		read -r pkgname oldver _ newver <<< "${line}"
-		IFS='-' read -r old_vers_upstream old_vers_release <<< "${oldver}"
-		IFS='-' read -r new_vers_upstream new_vers_release <<< "${newver}"
+		IFS='-' read -r old_vers_upstream _old_vers_release <<< "${oldver}"
+		IFS='-' read -r new_vers_upstream _new_vers_release <<< "${newver}"
 		IFS='.' read -ra old_vers <<< "${old_vers_upstream}"
 		IFS='.' read -ra new_vers <<< "${new_vers_upstream}"
 		counter=0

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -96,8 +96,10 @@ color_update_list() {
 	while IFS= read -r line; do
 		[ -z "${line}" ] && continue
 		read -r pkgname oldver _ newver <<< "${line}"
-		IFS='.-' read -ra old_vers <<< "${oldver}"
-		IFS='.-' read -ra new_vers <<< "${newver}"
+		IFS='-' read -r old_vers_upstream old_vers_release <<< "${oldver}"
+		IFS='-' read -r new_vers_upstream new_vers_release <<< "${newver}"
+		IFS='.' read -ra old_vers <<< "${old_vers_upstream}"
+		IFS='.' read -ra new_vers <<< "${new_vers_upstream}"
 		counter=0
 		seg=0
 		while [ "${seg}" -lt "${#old_vers[@]}" ] && [ "${seg}" -lt "${#new_vers[@]}" ] && [ "${old_vers[${seg}]}" = "${new_vers[${seg}]}" ]; do


### PR DESCRIPTION
### Description

Fixes version diff highlighting when new revision version number is introduced.
Done by separating upstream and patch versions.

### Screenshots / Logs

Old:

<img width="616" height="69" alt="image" src="https://github.com/user-attachments/assets/ec2ee32a-42e0-451b-a258-e43a2d0c37fe" />

Fix:

<img width="632" height="66" alt="image" src="https://github.com/user-attachments/assets/d233e1e5-bd08-4ef0-ad1b-6309d4da6006" />

### Fixed bug

<!-- If this pull request is fixing an opened bug report, paste the corresponding issue URL below -->

Fixes https://github.com/Antiz96/arch-update/issues/616