### PR TITLE
fix: Skip kernel upgrade check if the mkmm package is installed

### DIFF
--- a/src/lib/full_upgrade.sh
+++ b/src/lib/full_upgrade.sh
@@ -55,8 +55,8 @@ source "${libdir}/packages_cache.sh"
 # shellcheck source=src/lib/pacnew_files.sh
 source "${libdir}/pacnew_files.sh"
 
-# Source the "kernel_reboot" library which checks if there's a pending kernel update requiring a reboot to be applied (unless the "kernel-modules-hook" package is installed or we're running from a container)
-if ! pacman -Q kernel-modules-hook &> /dev/null && ! systemd-detect-virt --container --quiet; then
+# Source the "kernel_reboot" library which checks if there's a pending kernel update requiring a reboot to be applied (unless the "kernel-modules-hook" or "mkmm" package is installed, or we're running from a container)
+if ! pacman -Q kernel-modules-hook &> /dev/null && ! pacman -Q mkmm &> /dev/null && ! systemd-detect-virt --container --quiet; then
 	# shellcheck source=src/lib/kernel_reboot.sh
 	source "${libdir}/kernel_reboot.sh"
 fi


### PR DESCRIPTION
### Description

The `[mkmm](https://aur.archlinux.org/packages/mkmm)` package allows to keep the previous kernel modules loaded after a kernel upgrade. This avoids requiring a reboot after a kernel upgrade to load related modules.

As such, running the "kernel upgrade check" function for users of the `mkmm` package is not so relevant (as a reboot is not *strictly* required for them) and it results in a confusing output (as it says that no pending kernel upgrade is detected while there actually might be one).

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/635