### PR TITLE
fix: Properly handle epoch in version diff coloring

### DIFF
--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -98,8 +98,8 @@ color_update_list() {
 		read -r pkgname oldver _ newver <<< "${line}"
 		IFS='-' read -r old_vers_upstream _old_vers_release <<< "${oldver}"
 		IFS='-' read -r new_vers_upstream _new_vers_release <<< "${newver}"
-		IFS='.' read -ra old_vers <<< "${old_vers_upstream}"
-		IFS='.' read -ra new_vers <<< "${new_vers_upstream}"
+		IFS=':.' read -ra old_vers <<< "${old_vers_upstream}"
+		IFS=':.' read -ra new_vers <<< "${new_vers_upstream}"
 		counter=0
 		seg=0
 		while [ "${seg}" -lt "${#old_vers[@]}" ] && [ "${seg}" -lt "${#new_vers[@]}" ] && [ "${old_vers[${seg}]}" = "${new_vers[${seg}]}" ]; do


### PR DESCRIPTION
### Description

Epochs in `$pkgver` (`:`) where not handled in the version diff coloring, resulting in unexpected coloring for packages updates including an epoch.

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/639