### PR TITLE
chore: Increase the default automatic check interval to 6 hours

### DIFF
--- a/res/systemd/arch-update.timer
+++ b/res/systemd/arch-update.timer
@@ -3,7 +3,7 @@ Description=Run arch-update auto check at boot and then every hour
 
 [Timer]
 OnStartupSec=15
-OnUnitActiveSec=1h
+OnUnitActiveSec=6h
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
### Description

Increase the default automatic check interval from 1 hour to 6 hours.

Rationale about this change: https://github.com/Antiz96/arch-update/issues/645

Note that we're still performing a check at boot, that systemd timer monitors active time (and not clock time) and that performing a manual check is just one click (or one command) away.

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/645
