### PR TITLE
feat: Add `--check --enable` to enable automated updates checks and start the systray applet when running `--tray --enable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Features:
 - Check for pending kernel update requiring a reboot (and offers to do so if there's one).
 - Check for services requiring a post upgrade restart (and offers to do so if there are).
 - Support for `sudo`, `sudo-rs`, `doas` & `run0`.
+- Extensive CLI.
 
 Optional support for:
 
@@ -96,15 +97,12 @@ sudo make uninstall
 
 ## Usage
 
-The usage consist of starting [the systray applet](#the-systray-applet) and enabling [the systemd timer](#the-systemd-timer).
+For desktop machines, the usage consist of starting [the systray applet](#the-systray-applet) and enabling [the automated updates checks](#automated-updates-check).  
+For headless machines, `Arch-Update` includes an extensive CLI.
 
 ### The systray applet
 
-To start the systray applet, launch the "Arch-Update Systray Applet" application from your app menu.
-
-**Note:** GNOME shell does not support systray icons natively, GNOME users need to install the ["AppIndicator and KStatusNotifierItem Support" extension](https://extensions.gnome.org/extension/615/appindicator-support/) for the systray applet to show.
-
-To start it automatically at boot, you can either:
+To start the systray applet and enable it automatically at boot, you can either:
 
 - Run the following command (preferred method for most Desktop Environments, uses [XDG Autostart](https://wiki.archlinux.org/title/XDG_Autostart)):
 
@@ -124,21 +122,22 @@ systemctl --user enable --now arch-update-tray.service
 arch-update --tray
 ```
 
-**If the systray applet doesn't start at boot regardless or if it doesn't work as expected** (e.g the icon is missing or the click actions do not act as they should), please read [this chapter](#the-systray-applet-does-not-start-at-boot-or-does-not-work-as-expected).
+**If the systray applet doesn't start at boot regardless or if it doesn't work as expected** (e.g the icon is missing or the click actions do not act as they should), please read [this chapter](#the-systray-applet-does-not-start-at-boot-or-does-not-work-as-expected).  
+**Note:** GNOME shell does not support systray icons natively, GNOME users need to install the ["AppIndicator and KStatusNotifierItem Support" extension](https://extensions.gnome.org/extension/615/appindicator-support/) for the systray applet to show.
 
 The systray icon dynamically changes to indicate the current state of your system ('up to date' or 'updates available'). When clicked, it launches `arch-update` in a terminal window via the [arch-update.desktop](https://github.com/Antiz96/arch-update/blob/main/res/desktop/arch-update.desktop) file.
 
 **If clicking the systray applet does nothing**, please read [this chapter](#run-arch-update-in-a-specific-terminal-emulator).
 
-### The systemd timer
+### Automated updates check
 
-To perform automatic and periodic checks for available updates, enable the associated systemd timer:
+To enable automated and periodic checks for available updates, run the following command:
 
 ```bash
-systemctl --user enable --now arch-update.timer
+arch-update --check --enable
 ```
 
-By default, a check is performed **at boot and then once every hour**. The check cycle can be customized, see [this chapter](#modify-the-check-cycle).
+By default, a check is performed **at boot and then once every 6 hours**. The check cycle can be customized, see [this chapter](#modify-the-check-cycle).
 
 ### Screenshots
 

--- a/doc/man/arch-update.1.scd
+++ b/doc/man/arch-update.1.scd
@@ -25,6 +25,7 @@ Features:
 - Check for pending kernel update requiring a reboot (and offers to do so if there's one).
 - Check for services requiring a post upgrade restart (and offers to do so if there are).
 - Support for `sudo`, `sudo-rs`, `doas` & `run0`.
+- Extensive CLI.
 
 Optional support for:
 
@@ -39,7 +40,7 @@ If no option is passed, launch the relevant series of functions to perform a com
 
 *-c, --check*
 	Check for available updates. If there are, send a desktop notification and update the systray icon.
-	To run the `--check` option automatically and periodically, see the *"The systemd timer"* chapter in the *"USAGE"* section below.
+	To enable automated and periodic checks, use the `--check --enable`.
 
 *-l, --list*
 	Display the list of pending updates.
@@ -81,13 +82,12 @@ Certain options can be enabled, disabled or modified via the `arch-update.conf` 
 
 # USAGE
 
-The usage consist of starting the systray applet and enabling the systemd timer.
+For desktop machines, the usage consist of starting the systray applet and enabling the automated updates checks.  
+For headless machines, Arch-Update includes an extensive CLI.
 
 ## The systray applet
 
-To start the systray applet, launch the *Arch-Update Systray Applet* application from your app menu.
-
-To start it automatically at boot, you can either:
+To start the systray applet and enable it automatically at boot, you can either:
 
 - Run the following command (preferred method for most Desktop Environments, uses XDG Autostart): 
 
@@ -113,15 +113,15 @@ The systray icon dynamically changes to indicate the current state of your syste
 
 *If clicking the systray applet does nothing*, please read the *"Run Arch-Update in a specific terminal emulator"* chapter in the *"TIPS AND TRICKS"* section below.
 
-## The systemd timer
+## Automated updates check
 
-To perform automatic and periodic checks for available updates, enable the associated systemd timer:
+To enable automated and periodic checks for available updates, run the following command:
 
 ```
-systemctl --user enable --now arch-update.timer
+arch-update --check --enable
 ```
 
-By default, a check is performed at *boot and then once every hour*. The check cycle can be customized, see the *"Modify the check cycle"* chapter in the *"TIPS AND TRICKS"* section below.
+By default, a check is performed *at boot and then once every 6 hours*. The check cycle can be customized, see the *"Modify the check cycle"* chapter in the *"TIPS AND TRICKS"* section below.
 
 # TIPS AND TRICKS 
 

--- a/res/desktop/arch-update-tray.desktop
+++ b/res/desktop/arch-update-tray.desktop
@@ -14,3 +14,4 @@ Icon=arch-update_updates-available-blue
 Type=Application
 Exec=arch-update --tray
 Categories=Utility
+NoDisplay=true

--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -4,6 +4,7 @@
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# shellcheck disable=SC2154
 if [ "${2}" == "--enable" ]; then
 	systemctl --user enable --now "${name}.timer"
 	info_msg "$(eval_gettext "The automated updates checks have been enabled")"

--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -4,6 +4,12 @@
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+if [ "${2}" == "--enable" ]; then
+	systemctl --user enable --now "${name}.timer"
+	info_msg "$(eval_gettext "The automated updates checks have been enabled")"
+	exit 0
+fi
+
 # shellcheck disable=SC2154
 touch "${statedir}"/last_updates_check_{packages,aur,flatpak}
 

--- a/src/lib/tray.sh
+++ b/src/lib/tray.sh
@@ -29,39 +29,39 @@ if [ "${2}" == "--enable" ]; then
 	else
 		mkdir -p "${XDG_CONFIG_HOME:-${HOME}/.config}/autostart/" || exit 10
 		cp "${tray_desktop_file}" "${tray_desktop_file_autostart}" || exit 10
-		info_msg "$(eval_gettext "The '\${tray_desktop_file_autostart}' file has been created, the \${_name} systray applet will be automatically started at your next log on\nTo start it right now, you can launch the \"\${_name} Systray Applet\" application from your app menu")"
+		info_msg "$(eval_gettext "The '\${tray_desktop_file_autostart}' file has been created, the \${_name} systray applet will be automatically started at boot")"
 	fi
-else
-	# shellcheck disable=SC2154
-	if [ -n "${ARCH_UPDATE_TRAY_BIN}" ]; then
-	        tray_bin="${ARCH_UPDATE_TRAY_BIN}"
-	elif [ -f "${HOME}/.local/lib/${name}/${name}-tray" ]; then
-	        tray_bin="${HOME}/.local/lib/${name}/${name}-tray"
-	elif [ -f "/usr/local/lib/${name}/${name}-tray" ]; then
-	        tray_bin="/usr/local/lib/${name}/${name}-tray"
-	elif [ -f "/usr/lib/${name}/${name}-tray" ]; then
-	        tray_bin="/usr/lib/${name}/${name}-tray"
-	else
-	        echo -e >&2 "ERROR: Systray applet binary not found"
-	        exit 3
-	fi
-
-	# shellcheck disable=SC2154
-	if [ ! -f "${statedir}/tray_icon" ]; then
-		icon_up-to-date
-	fi
-
-	# shellcheck disable=SC2154
-	touch "${statedir}"/last_updates_check{,_time,_packages,_aur,_flatpak}
-
-	# shellcheck disable=SC2154
-	exec {fd_tray}>"${tmpdir}/tray.lock"
-
-	if ! flock -n "${fd_tray}"; then
-		error_msg "$(eval_gettext "There's already a running instance of the \${_name} systray applet")"
-		exit 3
-	fi
-
-	# shellcheck disable=SC2154
-	"${tray_bin}" || exit 3
 fi
+
+# shellcheck disable=SC2154
+if [ -n "${ARCH_UPDATE_TRAY_BIN}" ]; then
+        tray_bin="${ARCH_UPDATE_TRAY_BIN}"
+elif [ -f "${HOME}/.local/lib/${name}/${name}-tray" ]; then
+        tray_bin="${HOME}/.local/lib/${name}/${name}-tray"
+elif [ -f "/usr/local/lib/${name}/${name}-tray" ]; then
+        tray_bin="/usr/local/lib/${name}/${name}-tray"
+elif [ -f "/usr/lib/${name}/${name}-tray" ]; then
+        tray_bin="/usr/lib/${name}/${name}-tray"
+else
+        echo -e >&2 "ERROR: Systray applet binary not found"
+        exit 3
+fi
+
+# shellcheck disable=SC2154
+if [ ! -f "${statedir}/tray_icon" ]; then
+	icon_up-to-date
+fi
+
+# shellcheck disable=SC2154
+touch "${statedir}"/last_updates_check{,_time,_packages,_aur,_flatpak}
+
+# shellcheck disable=SC2154
+exec {fd_tray}>"${tmpdir}/tray.lock"
+
+if ! flock -n "${fd_tray}"; then
+	error_msg "$(eval_gettext "There's already a running instance of the \${_name} systray applet")"
+	exit 3
+fi
+
+# shellcheck disable=SC2154
+setsid "${tray_bin}" &


### PR DESCRIPTION
### Description

Add the `--enable` arg to `--check` in order to enable the systemd timer for automated and periodic updates checks.

Start the systray applet when running `--tray --enable` (in addition of setting XDG autostart). Also start it in the background by default.

Finally, set `NoDisplay` to the systray applet desktop file.

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/642
