### PR TITLE
chore(i18n): Localize time units in systray applet

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -711,6 +711,26 @@ msgstr ""
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -791,6 +791,26 @@ msgstr "Абнаўленне было прыменена\\n"
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "Сістэма абноўлена"

--- a/po/bg.po
+++ b/po/bg.po
@@ -793,6 +793,26 @@ msgstr "Актуализацията е приложена\\n"
 msgid "Next page"
 msgstr "Следваща страница"
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "Системата е актуална"

--- a/po/ca.po
+++ b/po/ca.po
@@ -814,6 +814,26 @@ msgstr "S'ha aplicat l'actualització\\n"
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "El sistema està actualitzat"

--- a/po/de.po
+++ b/po/de.po
@@ -807,6 +807,26 @@ msgstr "Aktualisierung wurde durchgeführt\\n"
 msgid "Next page"
 msgstr "Nächste Seite"
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "System ist auf dem aktuellen Stand"

--- a/po/es.po
+++ b/po/es.po
@@ -823,6 +823,26 @@ msgstr "La actualización se ha aplicado\\n"
 msgid "Next page"
 msgstr "Página siguiente"
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "El sistema está actualizado"

--- a/po/eu.po
+++ b/po/eu.po
@@ -803,6 +803,26 @@ msgstr "Eguneraketa aplikatu da\\n"
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "Sistema eguneratuta dago"

--- a/po/fr.po
+++ b/po/fr.po
@@ -820,6 +820,26 @@ msgstr "La mise à jour a été appliquée\\n"
 msgid "Next page"
 msgstr "Page suivante"
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "Le système est à jour"

--- a/po/hu.po
+++ b/po/hu.po
@@ -804,6 +804,26 @@ msgstr "A frissítés alkalmazva lett\\n"
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "A rendszer naprakész"

--- a/po/it.po
+++ b/po/it.po
@@ -815,6 +815,26 @@ msgstr "L'aggiornamento è stato effettuato\\n"
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "Il sistema è aggiornato"

--- a/po/ja.po
+++ b/po/ja.po
@@ -782,6 +782,26 @@ msgstr "アップデートが完了しました\\n"
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "システムは最新の状態です"

--- a/po/ka.po
+++ b/po/ka.po
@@ -785,6 +785,26 @@ msgstr "განახლება გადატარებულია\\n"
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "სისტემა განახლებულია"

--- a/po/nb.po
+++ b/po/nb.po
@@ -798,6 +798,26 @@ msgstr "Oppdateringen er blitt installert\\n"
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "Systemet er oppdatert"

--- a/po/nl.po
+++ b/po/nl.po
@@ -800,6 +800,26 @@ msgstr "Alle pakketten zijn bijgewerkt\\n"
 msgid "Next page"
 msgstr "Volgende pagina"
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "Je beschikt over de nieuwste versies"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -809,6 +809,26 @@ msgstr "A atualização foi aplicada\\n"
 msgid "Next page"
 msgstr "Próxima página"
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "O sistema está atualizado"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -802,6 +802,26 @@ msgstr "A atualização foi aplicada\\n"
 msgid "Next page"
 msgstr "Página seguinte"
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "O sistema está atualizado"

--- a/po/ru.po
+++ b/po/ru.po
@@ -798,6 +798,26 @@ msgstr "Обновление было применено\\n"
 msgid "Next page"
 msgstr "Следующая страница"
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "Система обновлена"

--- a/po/sv.po
+++ b/po/sv.po
@@ -801,6 +801,26 @@ msgstr "Uppdateringen har applicerats\\n"
 msgid "Next page"
 msgstr "Nästa sida"
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "Systemet är uppdaterat"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -739,6 +739,26 @@ msgstr "更新已应用\\n"
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "系统已更新到最新版本"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -739,6 +739,26 @@ msgstr "更新已套用\\n"
 msgid "Next page"
 msgstr ""
 
+#: src/tray/src/tray_helpers.rs:229
+#, rust-format
+msgid "{days}d"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:232
+#, rust-format
+msgid "{hours}h"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:235
+#, rust-format
+msgid "{minutes}m"
+msgstr ""
+
+#: src/tray/src/tray_helpers.rs:238
+#, rust-format
+msgid "{seconds}s"
+msgstr ""
+
 #: src/tray/src/tray.rs:88
 msgid "System is up to date"
 msgstr "系統已是最新版本"

--- a/src/tray/src/tray_helpers.rs
+++ b/src/tray/src/tray_helpers.rs
@@ -226,16 +226,16 @@ fn format_time(time: Duration) -> Option<String> {
     let seconds = time.as_secs() % 60;
 
     if days > 0 {
-        parts.push(format!("{days}d"));
+        parts.push(gettext("{days}d").replace("{days}", &days.to_string()));
     }
     if hours > 0 {
-        parts.push(format!("{hours}h"));
+        parts.push(gettext("{hours}h").replace("{hours}", &hours.to_string()));
     }
     if minutes > 0 {
-        parts.push(format!("{minutes}m"));
+        parts.push(gettext("{minutes}m").replace("{minutes}", &minutes.to_string()));
     }
     if seconds > 0 {
-        parts.push(format!("{seconds}s"));
+        parts.push(gettext("{seconds}s").replace("{seconds}", &seconds.to_string()));
     }
 
     if parts.is_empty() {


### PR DESCRIPTION
### Description

Add time units for the last check / next check entries in the systray applet to translations ("d" for days, "h" for hours, "m" for minutes, "s" for seconds).

### Addressed feature request

Closes https://github.com/Antiz96/arch-update/issues/669