### PR TITLE
fix(tray): Don't panic for gettext errors

### DIFF
--- a/src/tray/src/tray.rs
+++ b/src/tray/src/tray.rs
@@ -261,15 +261,22 @@ pub async fn run(
     i18n_dir: PathBuf,
 ) {
     // Set gettext domain for translations
-    setlocale(LocaleCategory::LcAll, "").expect("Failed to load environment locale");
+    if setlocale(LocaleCategory::LcMessages, "").is_none() {
+        warn!("Unable to load locale environment");
+    }
 
-    textdomain("Arch-Update").expect("Failed to set gettext domain");
+    if textdomain("Arch-Update").is_err() {
+        warn!("Unable to set gettext domain");
+    }
 
-    bindtextdomain(
+    if bindtextdomain(
         "Arch-Update",
         i18n_dir.to_str().expect("Unknown or invalid locale path"),
     )
-    .expect("Failed to bind gettext domain path");
+    .is_err()
+    {
+        warn!("Unable to bind gettext domain path");
+    }
 
     // Clone icon statefile path variable (used by the watcher)
     let watcher_icon_statefile = icon_statefile.clone();


### PR DESCRIPTION
### Description

Don't panic / crash for gettext errors.

Turns out those errors can happen in edge cases. We don't need to panic as the consequences are minor / recoverable (namely translations not being loaded). We can safely treat those as warnings.

### Fixed bug

Fixes https://github.com/Antiz96/arch-update/issues/695