### PR TITLE
fix(tray): Set UTF-8 codeset for localization

### DIFF
--- a/src/tray/src/tray.rs
+++ b/src/tray/src/tray.rs
@@ -278,6 +278,10 @@ pub async fn run(
         warn!("Unable to bind gettext domain path");
     }
 
+    if bind_textdomain_codeset("Arch-Update", "UTF-8").is_err() {
+        warn!("Unable to set gettext domain codeset");
+    }
+
     // Clone icon statefile path variable (used by the watcher)
     let watcher_icon_statefile = icon_statefile.clone();
 


### PR DESCRIPTION
### Description

Add missing UTF-8 codeset definition for localization / translations to avoid encoding issues.

### Screenshots / Logs

<img width="299" height="173" alt="image" src="https://github.com/user-attachments/assets/2d5afac6-b55c-4e22-b68b-199b74db3623" />