### PR TITLE
fix: Add input error handling for service restart selection

### DIFF
--- a/po/arch-update.pot
+++ b/po/arch-update.pot
@@ -389,12 +389,12 @@ msgid ""
 "\"enter\" to proceed with update:"
 msgstr ""
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -402,22 +402,22 @@ msgid ""
 "updating your system"
 msgstr ""
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr ""
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr ""
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr ""
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr ""
@@ -617,44 +617,44 @@ msgstr ""
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr ""
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
 "or press \"enter\" to continue without restarting the service(s):"
 msgstr ""
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr ""
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
 "above service(s) status\\n"
 msgstr ""
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr ""
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr ""
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
 "services that have been updated to fully apply the upgrade\\n"
 msgstr ""
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -446,12 +446,12 @@ msgstr ""
 "Выберыце навіны для чытання (напр. 1 3 5). Выберыце 0, каб прачытаць іх усе, "
 "або націсніце \"enter\", каб працягнуць абнаўленне:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -462,22 +462,22 @@ msgstr ""
 "чакання запыту)\\nКалі ласка, прачытайце выбраныя навіны Arch на ${news_url} "
 "перад абнаўленнем сістэмы"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Загаловак:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Аўтар:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Дата публікацыі:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -690,7 +690,7 @@ msgstr "Службы:\\nНаступная служба патрабуе пер�
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr "Службы:\\nНаступныя службы патрабуюць перазапуску пасля абнаўлення\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -699,12 +699,12 @@ msgstr ""
 "Выберыце службы для перазапуску (напр. 1 3 5). Увядзіце 0, каб перазапусціць "
 "усе, або націсніце \"enter\", каб працягнуць без перазапуску:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Службы паспяхова перазапушчаны\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -713,18 +713,18 @@ msgstr ""
 "Падчас перазапуску службаў узнікла памылка\\nКалі ласка, праверце іх "
 "статус\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "Служба ${service_selected} была паспяхова перазапушчана"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "Падчас перазапуску службы ${service_selected} узнікла памылка"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -733,7 +733,7 @@ msgstr ""
 "Перазапуск службаў не быў выкананы\\nКалі ласка, перазапусціце абноўленыя "
 "службы, каб поўнасцю прымяніць абнаўленні\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Службы, якія патрабуюць перазапуску пасля абнаўлення, не знойдзены\\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -447,12 +447,12 @@ msgstr ""
 "Изберете новини за прочитане (напр. 1 3 5), изберете 0 за всички или "
 "натиснете \"enter\" за да продължите с актуализацията:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -463,22 +463,22 @@ msgstr ""
 "или изтичане на заявката)\\nМоля, прочетете избраните новини на ${news_url} "
 "преди да актуализирате системата"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Заглавие:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Автор:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Дата на публикуване:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -690,7 +690,7 @@ msgstr "Услуги:\\nСледната услуга изисква реста�
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr "Услуги:\\nСледните услуги изискват рестартиране след обновяване\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -699,12 +699,12 @@ msgstr ""
 "Изберете услуга(и) за рестартиране (напр. 1 3 5), изберете 0 за всички или "
 "натиснете \"enter\" за да продължите без рестартиране:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Услугата(ите) са рестартирани успешно\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -713,18 +713,18 @@ msgstr ""
 "Възникна грешка при рестартирането на услугата(ите)\\nМоля, проверете "
 "състоянието на горепосочената(ите) услуга(и)\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "Услугата ${service_selected} е рестартирана успешно"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "Възникна грешка при рестартирането на услугата ${service_selected}"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -734,7 +734,7 @@ msgstr ""
 "рестартиране на услуги, които са актуализирани, за да се приложи напълно "
 "обновяването\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Няма намерени услуги, изискващи рестартиране след обновяване\\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -457,12 +457,12 @@ msgstr ""
 "Seleccioneu les notícies a llegir (p. ex. 1 3 5), seleccioneu 0 per a llegir-"
 "les totes o premeu «retorn» per a procedir amb l'actualització:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -473,22 +473,22 @@ msgstr ""
 "HTTP o temps d'espera esgotat)\\nSi us plau, llegiu les notícies d'Arch "
 "seleccionades a ${news_url} abans d'actualitzar el sistema"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Títol:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Autor:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Data de publicació:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -708,7 +708,7 @@ msgstr ""
 "Serveis:\\nEls serveis següents requereixen un reinici posterior a "
 "l'actualització\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -717,12 +717,12 @@ msgstr ""
 "Seleccioneu els serveis a reiniciar (p. ex. 1 3 5), seleccioneu 0 per a "
 "reiniciar-los tots o premeu «retorn» per a continuar sense reiniciar-los:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Els serveis s'han reiniciar correctament\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -731,18 +731,18 @@ msgstr ""
 "S'ha produït un error durant el reinici dels serveis\\nSi us plau, "
 "verifiqueu l'estat dels serveis esmentats dalt\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "El servei ${service_selected} s'ha reiniciat correctament"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "S'ha produït un error durant el reinici del servei ${service_selected}"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -751,7 +751,7 @@ msgstr ""
 "No s'ha realitzat el reinici dels serveis\\nSi us plau, considereu reiniciar "
 "els serveis que s'han actualitzat per a aplicar completament la millora\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -455,12 +455,12 @@ msgstr ""
 "Neuigkeiten zum Lesen auswählen (z. B. 1 3 5), 0 wählen, um alle zu lesen "
 "oder \"ENTER\" drücken, um mit der Aktualisierung fortzufahren:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
-msgstr "Ungültige Eingabe\\n"
+msgid "Invalid input"
+msgstr "Ungültige Eingabe"
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -471,22 +471,22 @@ msgstr ""
 "Fehlerantwort oder Zeitüberschreitung der Anfrage)\\nBitte die ausgewählten "
 "Arch-Neuigkeiten unter ${news_url} lesen, bevor das System aktualisiert wird"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Titel:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Autor:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Veröffentlichungsdatum:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -703,7 +703,7 @@ msgstr "Dienste:\\nDer folgende Dienst erfordert einen Neustart\\n"
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr "Dienste:\\nDie folgenden Dienste erfordern einen Neustart\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -712,12 +712,12 @@ msgstr ""
 "Dienst(e) zum Neustarten auswählen (z. B. 1 3 5), 0 wählen, um alle neu zu "
 "starten oder \"ENTER\" drücken, um ohne Neustart fortzufahren:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Dienst(e) erfolgreich neu gestartet\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -726,19 +726,19 @@ msgstr ""
 "Beim Neustart des/der Dienste(s) ist ein Fehler aufgetreten\\nBitte den "
 "Status des/der oben genannten Dienste(s) prüfen\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "Der ${service_selected} Dienst wurde erfolgreich neu gestartet"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr ""
 "Beim Neustart des ${service_selected} Dienstes ist ein Fehler aufgetreten"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -748,7 +748,7 @@ msgstr ""
 "aktualisierten Dienste neu starten, um die Aktualisierung vollständig "
 "durchzuführen\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Kein Dienst gefunden, der einen Neustart erfordert\\n"

--- a/po/es.po
+++ b/po/es.po
@@ -459,12 +459,12 @@ msgstr ""
 "Seleccione las noticias que desea leer (por ejemplo, 1, 3, 5), seleccione 0 "
 "para leerlas todas o pulse «Entrar» para continuar con la actualización:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -475,22 +475,22 @@ msgstr ""
 "error HTTP o tiempo de espera de la solicitud agotado)\\nPor favor, lea las "
 "noticias de Arch seleccionadas en ${news_url} antes de actualizar su sistema"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Título:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Autor:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Fecha de publicación:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -711,7 +711,7 @@ msgstr ""
 "Servicios:\\nLos siguientes servicios requieren un reinicio después de la "
 "actualización\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -721,12 +721,12 @@ msgstr ""
 "seleccione 0 para reiniciarlos todos o pulse «Entrar» para continuar sin "
 "reiniciar los servicios:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Servicio(s) reiniciado(s) correctamente\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -735,19 +735,19 @@ msgstr ""
 "Se ha producido un error durante el reinicio del servicio o servicios\\nPor "
 "favor, compruebe el estado de los servicios mencionados anteriormente\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "El servicio ${service_selected} se ha reiniciado correctamente"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr ""
 "Se ha producido un error durante el reinicio del servicio ${service_selected}"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -757,7 +757,7 @@ msgstr ""
 "reiniciar los servicios que se han actualizado para aplicar completamente la "
 "actualización\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -451,12 +451,12 @@ msgstr ""
 "Hautatu irakurri beharreko berriak (adib. 1 3 5), hautatu 0 guztiak "
 "irakurtzeko edo sakatu \"enter\" eguneraketarekin jarraitzeko:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
-msgstr ""
+msgid "Invalid input"
+msgstr "Sarrera ez-baliozkoa"
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -467,22 +467,22 @@ msgstr ""
 "eskaeraren denbora-muga)\\nMesezez, irakurri hautatutako berriak ${news_url} "
 "helbidean zure sistema eguneratu aurretik"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Izenburua:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Egilea:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Argitalpen data:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -699,7 +699,7 @@ msgstr ""
 "Zerbitzuak:\\nHurrengo zerbitzuak berrabiarazi behar dira eguneratu "
 "ondoren\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -709,12 +709,12 @@ msgstr ""
 "berrabiarazteko edo sakatu \"enter\" zerbitzuak berrabiarazi gabe "
 "jarraitzeko:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Zerbitzua(k) ondo berrabiarazi d(ir)a\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -723,18 +723,18 @@ msgstr ""
 "Errore bat gertatu da zerbitzua(k) berrabiaraztean\\nMesezez, egiaztatu "
 "goiko zerbitzuen egoera\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "${service_selected} zerbitzua ondo berrabiarazi da"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "Errore bat gertatu da ${service_selected} zerbitzua berrabiaraztean"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -743,7 +743,7 @@ msgstr ""
 "Ez da zerbitzurik berrabiarazi\\nMesezez, berrabiarazi eguneratutako "
 "zerbitzuak eguneraketa guztiz aplikatzeko\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Ez da aurkitu eguneratu ondoren berrabiarazi behar den zerbitzurik\\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -458,12 +458,12 @@ msgstr ""
 "Sélectionnez les news à lire (par exemple: 1 3 5), sélectionnez 0 pour "
 "toutes les lire ou appuyez sur \"entrée\" pour procéder à la mise à jour :"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
-msgstr "Entrée invalide\\n"
+msgid "Invalid input"
+msgstr "Entrée invalide"
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -475,22 +475,22 @@ msgstr ""
 "sélectionnée à l'adresse suivante avant de mettre à jour votre système : "
 "${news_url}"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Titre :"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Auteur :"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Date de publication :"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL :"
@@ -711,7 +711,7 @@ msgstr ""
 "Services :\\nLes services suivants requièrent un redémarrage suite à leur "
 "mise à jour\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -721,12 +721,12 @@ msgstr ""
 "sélectionnez 0 pour tous les redémarrer ou appuyez sur \"entrée\" pour "
 "continuer sans redémarrer le(s) service(s) :"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Service(s) redémarré(s) avec succès\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -735,19 +735,19 @@ msgstr ""
 "Une erreur est survenue pendant le redémarrage du/des service(s)\\n Veuillez "
 "vérifier le statut des services ci-dessus\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "Le service ${service_selected} a été redémarré avec succès"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr ""
 "Une erreur est survenue pendant le redémarrage du service ${service_selected}"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -757,7 +757,7 @@ msgstr ""
 "redémarrer les services qui ont été mis à jour pour appliquer complètement "
 "la mise à niveau\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -457,12 +457,12 @@ msgstr ""
 "összes elolvasásához vagy nyomja meg az „enter” gombot a frissítés "
 "folytatásához:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -473,22 +473,22 @@ msgstr ""
 "kérés-időtúllépés)\\nA kiválasztott Arch híreket elolvashatja a rendszer "
 "frissítése előtt a következő webcímen: ${news_url}"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Cím:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Szerző:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Közzétéve:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "Webcím:"
@@ -702,7 +702,7 @@ msgstr ""
 "Szolgáltatások:\\nA következő szolgáltatások frissítés utáni újraindítást "
 "igényelnek\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -712,12 +712,12 @@ msgstr ""
 "0 értéket az összes újraindításához, vagy nyomja meg az „enter” gombot a "
 "szolgáltatás(ok) újraindítása nélküli folytatáshoz.:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "A szolgáltatás(ok) sikeresen újraindultak\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -726,18 +726,18 @@ msgstr ""
 "Hiba történt a szolgáltatás(ok) újraindításakor\\nEllenőrizze a fenti "
 "szolgáltatás(ok) állapotát\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "A(z) ${service_selected}-szolgáltatás sikeresen újraindult"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "Hiba történt a ${service_selected}-szolgáltatás újraindításakor"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -747,7 +747,7 @@ msgstr ""
 "megváltozott szolgáltatások újraindítását a frissítés teljes körű "
 "alkalmazásához\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Nem található frissítés utáni újraindítást igénylő szolgáltatás\\n"

--- a/po/it.po
+++ b/po/it.po
@@ -458,12 +458,12 @@ msgstr ""
 "Seleziona le notizie da leggere (per es. 1 3 5), selezionare 0 per leggerle "
 "tutte o premere \"invio\" per procedere con l'aggiornamento:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -475,22 +475,22 @@ msgstr ""
 "selezionate su Arch Linux all'indirizzo ${news_url} prima di aggiornare il "
 "sistema"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Titolo:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Autore:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Data di pubblicazione:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "Indirizzo:"
@@ -708,7 +708,7 @@ msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr ""
 "Servizi:\\nI seguenti servizi richiedono un riavvio post aggiornamento\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -718,12 +718,12 @@ msgstr ""
 "riavviarli tutti o premere \"invio\" per continuare senza riavviare il/i "
 "servizio/i:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Servizio/i riavviato/i con successo\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -732,19 +732,19 @@ msgstr ""
 "Si è verificato un errore durante il riavvio di uno o più servizi\\nSi prega "
 "di verificare lo stato del/dei servizio/i di cui sopra\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "Il servizio ${service_selected} è stato riavviato con successo"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr ""
 "Si è verificato un errore durante il riavvio del servizio ${service_selected}"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -753,7 +753,7 @@ msgstr ""
 "Il riavvio del/dei servizo/i non è stato effettuato\\nSi prega di riavviare "
 "i servizi che sono stati aggiornati per applicare a pieno l'aggiornamento\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -442,12 +442,12 @@ msgstr ""
 "表示するニュースを選択してください (例: 1 3 5)。0 ですべて表示、\"enter\" で"
 "アップデートへ進む:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -457,22 +457,22 @@ msgstr ""
 "選択した Arch ニュースを取得できませんでした (HTTP エラーまたはタイムアウト)"
 "\\nシステムをアップデートする前に ${news_url} でニュースを確認してください"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "タイトル:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "著者:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "公開日:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -688,7 +688,7 @@ msgstr "サービス:\\n次のサービスはアップグレード後に再起�
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr "サービス:\\n次のサービスはアップグレード後に再起動が必要です\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -697,12 +697,12 @@ msgstr ""
 "再起動するサービスを選択してください (例: 1 3 5)。0 ですべて再起動、"
 "\"enter\" でサービスを再起動せず続行:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "サービスを正常に再起動しました\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -711,18 +711,18 @@ msgstr ""
 "サービスの再起動中にエラーが発生しました\\n上記のサービスの状態を確認してくだ"
 "さい\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "${service_selected} サービスを正常に再起動しました"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "${service_selected} サービスの再起動中にエラーが発生しました"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -731,7 +731,7 @@ msgstr ""
 "サービスの再起動は実行されませんでした\\nアップグレードを完全に適用するため"
 "に、アップデートされたサービスの再起動をおすすめします\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "アップグレード後に再起動が必要なサービスはありません\\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -447,12 +447,12 @@ msgstr ""
 "აირჩიეთ სიახლეები წასაკითხად (მაგ: 1 3 5). აირჩიეთ 0 ყველას წასაკითხად, ან "
 "დააჭირეთ ღილაკს 'Enter' განახლების დასაწყებად:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -463,22 +463,22 @@ msgstr ""
 "მოლოდინის ვადა ამოიწურა\\nწაიკთხეთ Arch-ის სიახლე ბმულზე ${news_url} "
 "სისტემის განახლებამდე"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "სათაური:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "ავტორი:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "გამოქვეყნების თარიღი:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -683,7 +683,7 @@ msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr ""
 "სერვისები:\\nშემდეგი სერვისები ითხოვენ გადატვირთვას განახლების შემდეგ\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -693,12 +693,12 @@ msgstr ""
 "გადაიტვირთოს, ან დააჭირეთ ღილაკს 'Enter' სერვისების გადატვირთვის გარეშე "
 "გასაგრძელებლად:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "სერვის(ებ)-ი წარმატებით გადაიტვირთა\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -707,18 +707,18 @@ msgstr ""
 "სერვის(ებ)-ის გადატვირთვისას აღმოჩენილია შეცდომა\\nშეამოწმეთ შემდეგი "
 "სერვის(ებ)-ის სტატუსი\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "სერვისი ${service_selected} წარმატებით გადაიტვირთა"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "სერვისის ${service_selected} გადატვირთვისას აღმოჩენილია შეცდომა"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -727,7 +727,7 @@ msgstr ""
 "სერვის(ებ)-ის გადატვირთვა არ შესრულებულა\\nგანახლების სრულად გადასატარებლად "
 "საჭიროა, გადატვირთოთ სერვისები\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -449,12 +449,12 @@ msgstr ""
 "Velg hvilke nyheter du vil lese (f.eks.  1 3 5), velg 0 for å lese alle "
 "eller trykk «enter» for å fortsette med oppdateringen:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -465,22 +465,22 @@ msgstr ""
 "forespørselen gikk ut på tid)\\nSe etter nyheter på ${news_url} før du "
 "oppdaterer systemet ditt"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Tittel:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Forfatter:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Publiseringsdato:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "Nettadresse:"
@@ -696,7 +696,7 @@ msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr ""
 "Tjenester:\\nFølgende tjenester trenger å startes om etter oppgradering\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -705,12 +705,12 @@ msgstr ""
 "Velg tjeneste(r) som skal startes om (f.eks. 1 3 5), skriv 0 for å start "
 "alle om eller trykk «enter» for å fortsette uten å starte om tjenesten(e):"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Tjenesten(e) ble startet om\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -719,18 +719,18 @@ msgstr ""
 "En feil skjedde mens tjenesten(e) skulle startes om\\nKontroller status på "
 "de(n) tjenesten(e) over\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "Omstarten av tjenesten ${service_selected} gikk bra"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "Det skjedde en feil mens tjenesten ${service_selected} startet på ny"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -739,7 +739,7 @@ msgstr ""
 "Tjenesten(e) har ikke blitt startet om\\nDet anbefales å starte tjenester "
 "som er blitt oppdatert på ny for å fullføre oppdateringen\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Ingen tjenester som krever omstart ble funnet\\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -451,12 +451,12 @@ msgstr ""
 "Geef aan welk nieuws je wilt lezen (bijv. 1 3 5) of dat je alles wilt lezen "
 "(0). Druk op enter om verder te gaan:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
-msgstr "De invoer is ongeldig\\n"
+msgid "Invalid input"
+msgstr "De invoer is ongeldig"
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -467,22 +467,22 @@ msgstr ""
 "verlopen verzoek)\\nLees het nieuws op ${news_url} alvorens het systeem bij "
 "te werken"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Titel:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Auteur:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Publicatiedatum:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "Url:"
@@ -695,7 +695,7 @@ msgstr "Diensten:\\nDeze dienst moet worden herstart:\\n"
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr "Diensten:\\nDeze diensten moeten worden herstart:\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -704,12 +704,12 @@ msgstr ""
 "Kies de te herstarten diensten (bijv. 1 3 5), herstart alle diensten (0) of "
 "druk op enter om verder te gaan zonder ze te herstarten:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "De diensten zijn herstart\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -718,19 +718,19 @@ msgstr ""
 "Er is een fout opgetreden tijdens het herstarten van de dienst(en)\\nBekijk "
 "de dienststatus(sen)\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "‘${service_selected}’ is herstart"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr ""
 "Er is een fout opgetreden tijdens het herstarten van ‘${service_selected}’"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -739,7 +739,7 @@ msgstr ""
 "De diensten zijn niet herstart\\nOverweeg om ze te herstarten, zodat de "
 "updates kunnen worden toegepast\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Er is geen dienst die moet worden herstart\\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -455,12 +455,12 @@ msgstr ""
 "Selecione as notícias para ler (ex: 1 3 5), selecione 0 para ler todas ou "
 "pressione \"enter\" para prosseguir com a atualização:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -471,22 +471,22 @@ msgstr ""
 "limite de solicitação)\\nPor favor, leia a notícia do Arch selecionada em "
 "${news_url} antes de atualizar seu sistema"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Título:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Autor:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Data de publicação:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -700,7 +700,7 @@ msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr ""
 "Serviços:\\nOs seguintes serviços requerem reinicialização pós-atualização\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -710,12 +710,12 @@ msgstr ""
 "reiniciar todos ou pressione \"enter\" para continuar sem reiniciar o(s) "
 "serviço(s):"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Serviço(s) reiniciado(s) com sucesso\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -724,19 +724,19 @@ msgstr ""
 "Ocorreu um erro durante a reinicialização do(s) serviço(s)\\nPor favor, "
 "verifique o status do(s) serviço(s) acima\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "O serviço ${service_selected} foi reiniciado com sucesso"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr ""
 "Ocorreu um erro durante a reinicialização do serviço ${service_selected}"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -746,7 +746,7 @@ msgstr ""
 "reiniciar serviços que foram atualizados para aplicar completamente a "
 "atualização\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr ""

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -456,12 +456,12 @@ msgstr ""
 "Selecione as notícias para ler (ex: 1 3 5), selecione 0 para ler todas ou "
 "prima \"enter\" para prosseguir com a atualização:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
-msgstr "Entrada inválida\\n"
+msgid "Invalid input"
+msgstr "Entrada inválida"
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -471,22 +471,22 @@ msgstr ""
 "Não foi possível obter as notícias selecionadas (erro HTTP ou tempo esgotado)"
 "\\nPor favor, leia as notícias em ${news_url} antes de atualizar o sistema"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Título:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Autor:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Data de publicação:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -700,7 +700,7 @@ msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr ""
 "Serviços:\\nOs seguintes serviços requerem um reinício pós-atualização\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -709,12 +709,12 @@ msgstr ""
 "Selecione o(s) serviço(s) para reiniciar (ex: 1 3 5), selecione 0 para todos "
 "ou prima \"enter\" para continuar sem reiniciar:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Serviço(s) reiniciado(s) com sucesso\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -723,18 +723,18 @@ msgstr ""
 "Ocorreu um erro durante o reinício do(s) serviço(s)\\nPor favor, verifique o "
 "estado do(s) mesmo(s)\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "O serviço ${service_selected} foi reiniciado com sucesso"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "Ocorreu um erro durante o reinício do serviço ${service_selected}"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -743,7 +743,7 @@ msgstr ""
 "O reinício do(s) serviço(s) não foi realizado\\nPor favor, considere "
 "reiniciar os serviços atualizados para aplicar totalmente a atualização\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Nenhum serviço que requeira reinício pós-atualização encontrado\\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -438,12 +438,12 @@ msgstr ""
 "Выберите новости для чтения (например, 1 3 5), 0 — все, или нажмите Enter, "
 "чтобы продолжить обновление:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
-msgstr "Неверный ввод\\n"
+msgid "Invalid input"
+msgstr "Неверный ввод"
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -453,22 +453,22 @@ msgstr ""
 "Не удалось получить выбранные новости (ошибка HTTP или тайм-аут)"
 "\\nПрочитайте их перед обновлением по адресу ${news_url}"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Заголовок:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Автор:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Дата публикации:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL:"
@@ -674,7 +674,7 @@ msgstr "Службы:\\nСледующая служба требует пере�
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr "Службы:\\nСледующие службы требуют перезапуска после обновления\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -683,12 +683,12 @@ msgstr ""
 "Выберите службы для перезапуска (например, 1 3 5), 0 — все, или нажмите "
 "Enter, чтобы продолжить без перезапуска:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Служба(ы) успешно перезапущена\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -696,18 +696,18 @@ msgid ""
 msgstr ""
 "Произошла ошибка при перезапуске службы(служб)\\nПроверьте их статус\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "Служба ${service_selected} успешно перезапущена"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "Произошла ошибка при перезапуске службы ${service_selected}"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -716,7 +716,7 @@ msgstr ""
 "Перезапуск служб не выполнен\\nРекомендуется перезапустить обновлённые "
 "службы, чтобы изменения вступили в силу\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Служб, требующих перезапуска после обновления, не найдено\\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -453,12 +453,12 @@ msgstr ""
 "Välj nyheterna att läsa (t.ex. 1 3 5), välj 0 för att läsa dem alla eller "
 "tryck på \"enter\" för att fortsätta med uppdateringen:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
-msgstr "Ogiltig indata\\n"
+msgid "Invalid input"
+msgstr "Ogiltig indata"
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -469,22 +469,22 @@ msgstr ""
 "om timeout)\\nVänligen läs de valda Arch-nyheterna på ${news_url} innan du "
 "uppdaterar ditt system"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "Titel:"
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "Författare:"
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "Publiceringsdatum:"
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "Webbadress:"
@@ -696,7 +696,7 @@ msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr ""
 "Tjänster:\\nFöljande tjänster kräver en omstart efter uppgraderingen\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -706,12 +706,12 @@ msgstr ""
 "starta om alla eller tryck på \"enter\" för att fortsätta utan att starta om "
 "tjänsten/tjänsterna:"
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "Tjänsten/tjänsterna har startats om\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
@@ -720,18 +720,18 @@ msgstr ""
 "Ett fel har inträffat under omstarten av tjänsten/tjänsterna\\nKontrollera "
 "tjänsten/tjänsternas status ovan\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "Tjänsten ${service_selected} har startats om"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "Ett fel har inträffat under omstarten av ${service_selected}-tjänsten"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
@@ -741,7 +741,7 @@ msgstr ""
 "starta om tjänster som har uppdaterats för att tillämpa uppgraderingen "
 "helt\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "Ingen tjänst som kräver omstart efter uppgradering hittades\\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -413,12 +413,12 @@ msgstr ""
 "选择要阅读的新闻（例如 1 3 5），选择 0 读取所有新闻，或按 \"enter\" 继续更新"
 "系统"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -428,22 +428,22 @@ msgstr ""
 "无法检索所选的 Arch 新闻（HTTP 错误响应或请求超时）\\n请在更新系统之前阅读所"
 "选的 Arch 新闻：${news_url}"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "标题："
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "作者："
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "发布日期："
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "URL："
@@ -643,7 +643,7 @@ msgstr "服务：\\n这个服务升级后需要重启\\n"
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr "服务：\\n这些服务升级后需要重启\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -652,37 +652,37 @@ msgstr ""
 "选择要重启的服务（例如 1 3 5），选择 0 重启所有服务，或者按 \"enter\" 继续而"
 "不重启服务："
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "一个或多个服务重启成功\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
 "above service(s) status\\n"
 msgstr "一个或多个服务重启失败，请检查上述服务状态\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "${service_selected} 服务重启成功"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "${service_selected} 服务重启失败"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
 "services that have been updated to fully apply the upgrade\\n"
 msgstr "一个或多个服务重启失败，请考虑重启已更新的服务以完全应用升级\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "没有需要在升级后重启的服务\\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -413,12 +413,12 @@ msgid ""
 msgstr ""
 "請選擇要閱讀的新聞（例如：1 3 5），選 0 閱讀全部，或按下「Enter」繼續更新:"
 
-#: src/lib/list_news.sh:85
+#: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
-msgid "Invalid input\\n"
+msgid "Invalid input"
 msgstr ""
 
-#: src/lib/list_news.sh:102
+#: src/lib/list_news.sh:103
 #, sh-format
 msgid ""
 "Unable to retrieve the selected Arch News (HTTP error response or request "
@@ -428,22 +428,22 @@ msgstr ""
 "無法擷取所選的 Arch 新聞（HTTP 錯誤回應或要求逾時）\\n請在更新系統之前，前往 "
 "${news_url} 閱讀所選的 Arch 新聞"
 
-#: src/lib/list_news.sh:107
+#: src/lib/list_news.sh:108
 #, sh-format
 msgid "Title:"
 msgstr "標題："
 
-#: src/lib/list_news.sh:108
+#: src/lib/list_news.sh:109
 #, sh-format
 msgid "Author:"
 msgstr "作者："
 
-#: src/lib/list_news.sh:109
+#: src/lib/list_news.sh:110
 #, sh-format
 msgid "Publication date:"
 msgstr "發布日期："
 
-#: src/lib/list_news.sh:110
+#: src/lib/list_news.sh:111
 #, sh-format
 msgid "URL:"
 msgstr "網址："
@@ -643,7 +643,7 @@ msgstr "服務：\\n以下服務在升級後需要重新啟動\\n"
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
 msgstr "服務：\\n以下服務在升級後需要重新啟動\\n"
 
-#: src/lib/restart_services.sh:25
+#: src/lib/restart_services.sh:26
 #, sh-format
 msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
@@ -652,37 +652,37 @@ msgstr ""
 "請選擇要重新啟動的服務（例如：1 3 5），選 0 重新啟動所有服務，或按下「Enter」"
 "以繼續而不重新啟動服務："
 
-#: src/lib/restart_services.sh:31 src/lib/restart_services.sh:58
+#: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
 msgstr "服務已成功重新啟動\\n"
 
-#: src/lib/restart_services.sh:34 src/lib/restart_services.sh:61
+#: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
 "above service(s) status\\n"
 msgstr "在服務重新啟動期間發生錯誤\\n請驗證上述服務的狀態\\n"
 
-#: src/lib/restart_services.sh:47
+#: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
 msgstr "${service_selected} 服務已成功重新啟動"
 
-#: src/lib/restart_services.sh:49
+#: src/lib/restart_services.sh:66
 #, sh-format
 msgid ""
 "An error has occurred during the restart of the ${service_selected} service"
 msgstr "在 ${service_selected} 服務重新啟動期間發生錯誤"
 
-#: src/lib/restart_services.sh:65
+#: src/lib/restart_services.sh:82
 #, sh-format
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
 "services that have been updated to fully apply the upgrade\\n"
 msgstr "服務重新啟動未執行\\n請考慮重新啟動已更新的服務以完全套用升級\\n"
 
-#: src/lib/restart_services.sh:69
+#: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
 msgstr "找不到升級後需要重新啟動的服務\\n"

--- a/src/lib/list_news.sh
+++ b/src/lib/list_news.sh
@@ -82,7 +82,8 @@ else
 
 			if [ -n "${invalid_input}" ]; then
 				echo
-				warning_msg "$(eval_gettext "Invalid input\n")"
+				warning_msg "$(eval_gettext "Invalid input")"
+				echo
 			else
 				break
 			fi

--- a/src/lib/restart_services.sh
+++ b/src/lib/restart_services.sh
@@ -21,9 +21,26 @@ if [ -n "${services}" ]; then
 		((i=i+1))
 	done < <(printf '%s\n' "${services}")
 
-	echo
-	ask_msg_array "$(eval_gettext "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all or press \"enter\" to continue without restarting the service(s):")"
-	echo
+	while true; do
+		echo
+		ask_msg_array "$(eval_gettext "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all or press \"enter\" to continue without restarting the service(s):")"
+		echo
+
+		invalid_input=""
+
+		for num in "${answer_array[@]}"; do
+			if ! [[ "${num}" =~ ^[0-9]+$ ]] || [ "${num}" -gt "${services_num}" ] || [ "${num}" -lt 0 ]; then
+				invalid_input="true"
+				break
+			fi
+		done
+
+		if [ -n "${invalid_input}" ]; then
+			warning_msg "$(eval_gettext "Invalid input")"
+		else
+			break
+		fi
+	done
 
 	if [ "${answer_array[0]}" -eq 0 ] 2> /dev/null; then
 		# shellcheck disable=SC2086,SC2154


### PR DESCRIPTION
### Description

Add input error handling for service restart selection: if a user enters an invalid input (e.g. a non-numeric input or a number that is higher than the service selection range), print an "Invalid input" warning and ask again.

Same as https://github.com/Antiz96/arch-update/pull/700