### PR TITLE
feat(tray): Add the `TrayUpdatesPerPage` option to configure pagination

### DIFF
--- a/doc/man/arch-update.conf.5.scd
+++ b/doc/man/arch-update.conf.5.scd
@@ -64,6 +64,9 @@ Options are case sensitive, so capital letters have to be respected.
 *DiffProg=[Editor]*
 	Editor to use to visualize / edit differences during the pacnew files processing. Defaults to the `$DIFFPROG` environment variable's value (or `vimdiff` if `$DIFFPROG` isn't set).
 
+*TrayUpdatesPerPage=[Num]*
+	Number of updates to show per page in the systray applet's updates lists submenues. Setting this option to "0" disables the pagination completely (entire updates list in a single page). Defaults to 0.
+
 *TrayIconStyle=[Style / Color]*
 	Style to be used for the systray applet icon. Valid values are the available style / color variants for the icon set, listed in https://github.com/Antiz96/arch-update/blob/main/res/icons/README.md. Defaults to "blue".
 

--- a/res/config/arch-update.conf.example
+++ b/res/config/arch-update.conf.example
@@ -16,5 +16,6 @@
 #KeepOldPackages=3
 #KeepUninstalledPackages=0
 #DiffProg=$DIFFPROG
+#TrayUpdatesPerPage=0
 #TrayIconStyle=blue
 #ColorblindMode

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -66,6 +66,10 @@ if [ -f "${config_file}" ]; then
 	# shellcheck disable=SC2034
 	diff_prog=$(grep -E '^[[:space:]]*DiffProg[[:space:]]*=[[:space:]]*[^[:space:]].*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
+	# Check the "TrayUpdatesPerPage" option in arch-update.conf
+	# shellcheck disable=SC2034
+	tray_updates_per_page=$(grep -E '^[[:space:]]*TrayUpdatesPerPage[[:space:]]*=[[:space:]]*[0-9][0-9]*[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
+
 	# Check the "TrayIconStyle" option in arch-update.conf
 	# shellcheck disable=SC2034
 	tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(blue|light|dark)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
@@ -81,4 +85,5 @@ fi
 [ -z "${update_check_timeout}" ] && update_check_timeout="30"
 [ -z "${old_packages_num}" ] && old_packages_num="3"
 [ -z "${uninstalled_packages_num}" ] && uninstalled_packages_num="0"
+[ -z "${tray_updates_per_page}" ] && tray_updates_per_page="0"
 [ -z "${tray_icon_style}" ] && tray_icon_style="blue"

--- a/src/lib/tray.sh
+++ b/src/lib/tray.sh
@@ -66,4 +66,4 @@ fi
 info_msg "$(eval_gettext "Starting the \${_name} systray applet")"
 
 # shellcheck disable=SC2154
-setsid "${tray_bin}" &
+ARCH_UPDATE_TRAY_UPDATES_PER_PAGE="${tray_updates_per_page}" setsid "${tray_bin}" &

--- a/src/tray/src/tray_helpers.rs
+++ b/src/tray/src/tray_helpers.rs
@@ -6,6 +6,7 @@ use ksni::menu::*;
 use log::{error, info};
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Deserialize;
+use std::env;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -38,8 +39,8 @@ pub fn count_update_types(updates_statefile: &Path) -> bool {
     get_updates_count(updates_statefile) > 0
 }
 
-// Helper to get the list of pending updates from the updates statefile and populate the submenus
-// accordingly
+// Helper to get the list of pending updates from the updates statefile as well as the number of
+// updates per pages for pagination
 pub fn build_updates_submenu(
     updates_statefile: &Path,
 ) -> Vec<ksni::MenuItem<tray::ArchUpdateTray>> {
@@ -50,7 +51,12 @@ pub fn build_updates_submenu(
                 .filter(|line| !line.trim().is_empty())
                 .collect();
 
-            build_updates_submenu_pagination(&updates, 0)
+            let updates_per_page = env::var("ARCH_UPDATE_TRAY_UPDATES_PER_PAGE")
+                .ok()
+                .and_then(|value| value.parse::<usize>().ok())
+                .unwrap_or(0);
+
+            build_updates_submenu_pagination(&updates, 0, updates_per_page)
         }
 
         Err(error) => {
@@ -60,15 +66,20 @@ pub fn build_updates_submenu(
     }
 }
 
-// Helper to handle pagination for updates submenus
-// Set a limit to 20 packages per page, split to another page otherwise
-const UPDATES_PER_PAGE: usize = 20;
+// Helper to populate submenus with the list of pending updates and
+// handle pagination if needed (0 = no pagination)
 fn build_updates_submenu_pagination(
     updates: &[&str],
     page: usize,
+    updates_per_page: usize,
 ) -> Vec<ksni::MenuItem<tray::ArchUpdateTray>> {
-    let start = page * UPDATES_PER_PAGE;
-    let end = (start + UPDATES_PER_PAGE).min(updates.len());
+    let (start, end) = if updates_per_page == 0 {
+        (0, updates.len())
+    } else {
+        let start = page * updates_per_page;
+        let end = (start + updates_per_page).min(updates.len());
+        (start, end)
+    };
 
     let mut menu = updates[start..end]
         .iter()
@@ -90,11 +101,11 @@ fn build_updates_submenu_pagination(
         })
         .collect::<Vec<_>>();
 
-    if end < updates.len() {
+    if updates_per_page > 0 && end < updates.len() {
         menu.push(
             SubMenu {
                 label: gettext("Next page"),
-                submenu: build_updates_submenu_pagination(updates, page + 1),
+                submenu: build_updates_submenu_pagination(updates, page + 1, updates_per_page),
                 ..Default::default()
             }
             .into(),


### PR DESCRIPTION
### Description

Add the new `TrayUpdatesPerPage` option in the `arch-update.conf` configuration file, allowing to configure the pagination of the update listing in submenus.

The value set for the option defines the number of updates to show per submenu pages.
If the option is unset or set to 0, the pagination is disabled.

The pagination option aims to workaround an issue for some Wayland compositors where the update list can sometimes exceed the screen height if it's too big (see https://github.com/Antiz96/arch-update/issues/622)

### Screenshots / Logs

- Pagination disabled (`TrayUpdatesPerPage` option unset or set to 0):

<img width="786" height="798" alt="image" src="https://github.com/user-attachments/assets/8ea21bd3-c171-4bbc-882a-21c2c874261d" />

- Pagination with 20 updates per page (`TrayUpdatesPerPage` option set to 20):

<img width="1285" height="797" alt="image" src="https://github.com/user-attachments/assets/2341e157-d9f6-4d07-b4bf-44a84487643f" />

### Fixed bug

Relates to https://github.com/Antiz96/arch-update/issues/622
Fixes https://github.com/Antiz96/arch-update/issues/715
