### PR TITLE
chore(tray): Minor refactoring and error handling improvements

### DIFF
--- a/src/tray/src/desktop_file.rs
+++ b/src/tray/src/desktop_file.rs
@@ -14,13 +14,8 @@ pub fn get_desktop_file() -> io::Result<PathBuf> {
         // Purposely only searching the first XDG_DATA_DIRS entry for simplification
         // This can be updated if this ever becomes an issue
         env::var_os("XDG_DATA_DIRS").map(|path| {
-            PathBuf::from(
-                path.to_string_lossy()
-                    .split(':')
-                    .next()
-                    .expect("Unable to get the first XDG_DATA_DIRS entry"),
-            )
-            .join("applications/arch-update.desktop")
+            PathBuf::from(path.to_string_lossy().split(':').next().unwrap_or(""))
+                .join("applications/arch-update.desktop")
         }),
         Some(PathBuf::from(
             "/usr/local/share/applications/arch-update.desktop",

--- a/src/tray/src/i18n_dir.rs
+++ b/src/tray/src/i18n_dir.rs
@@ -5,20 +5,14 @@ use std::fs::File;
 use std::io::{self, Error};
 use std::path::PathBuf;
 
-pub fn get_i18n_dir() -> io::Result<PathBuf> {
+pub fn get_i18n_dir() -> io::Result<String> {
     let paths = [
         env::var_os("XDG_DATA_HOME").map(|path| PathBuf::from(path).join("locale")),
         env::var_os("HOME").map(|path| PathBuf::from(path).join(".local/share/locale")),
         // Purposely only searching the first XDG_DATA_DIRS entry for simplification
         // This can be updated if this ever becomes an issue
         env::var_os("XDG_DATA_DIRS").map(|path| {
-            PathBuf::from(
-                path.to_string_lossy()
-                    .split(':')
-                    .next()
-                    .expect("Unable to get the first XDG_DATA_DIRS entry"),
-            )
-            .join("locale")
+            PathBuf::from(path.to_string_lossy().split(':').next().unwrap_or("")).join("locale")
         }),
         Some(PathBuf::from("/usr/local/share/locale")),
         Some(PathBuf::from("/usr/share/locale")),
@@ -30,7 +24,9 @@ pub fn get_i18n_dir() -> io::Result<PathBuf> {
         .find_map(|path| {
             let translation_file = path.join("fr/LC_MESSAGES/Arch-Update.mo");
 
-            File::open(&translation_file).ok().map(|_| path)
+            File::open(&translation_file)
+                .ok()
+                .and_then(|_| path.to_str().map(str::to_owned))
         })
         .ok_or_else(|| Error::other("Unable to access the translation directory"))
 }

--- a/src/tray/src/tray.rs
+++ b/src/tray/src/tray.rs
@@ -258,7 +258,7 @@ pub async fn run(
     icon_statefile: PathBuf,
     updates_statefile_type: updates_statefiles::UpdatesStateFiles,
     desktop_file: PathBuf,
-    i18n_dir: PathBuf,
+    i18n_dir: String,
 ) {
     // Set gettext domain for translations
     if setlocale(LocaleCategory::LcMessages, "").is_none() {
@@ -269,12 +269,7 @@ pub async fn run(
         warn!("Unable to set gettext domain");
     }
 
-    if bindtextdomain(
-        "Arch-Update",
-        i18n_dir.to_str().expect("Unknown or invalid locale path"),
-    )
-    .is_err()
-    {
+    if bindtextdomain("Arch-Update", &i18n_dir).is_err() {
         warn!("Unable to bind gettext domain path");
     }
 
@@ -292,10 +287,10 @@ pub async fn run(
     };
 
     // Start the systray applet
-    let handle = tray
-        .spawn()
-        .await
-        .expect("Unable to start the systray applet");
+    let handle = tray.spawn().await.unwrap_or_else(|error| {
+        error!("Unable to start the systray applet: {error}");
+        process::exit(1);
+    });
 
     info!("Systray applet started");
 

--- a/src/tray/src/tray_helpers.rs
+++ b/src/tray/src/tray_helpers.rs
@@ -10,7 +10,7 @@ use std::env;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{self, Command};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
@@ -160,15 +160,29 @@ pub async fn icon_watcher(icon_statefile: PathBuf, handle: Handle<crate::tray::A
         },
         Config::default(),
     )
-    .expect("Unable to create icon statefile watcher");
+    .unwrap_or_else(|error| {
+        error!("Unable to create icon statefile watcher: {error}");
+        process::exit(1);
+    });
 
     watcher
         .watch(&icon_statefile, RecursiveMode::NonRecursive)
-        .expect("Unable to watch icon statefile");
+        .unwrap_or_else(|error| {
+            error!("Unable to watch icon statefile: {error}");
+            process::exit(1);
+        });
 
-    while let Some(Ok(event)) = rx.recv().await {
-        if matches!(event.kind, EventKind::Modify(_)) {
-            handle.update(|_| {}).await;
+    while let Some(result) = rx.recv().await {
+        match result {
+            Ok(event) => {
+                if matches!(event.kind, EventKind::Modify(_)) {
+                    handle.update(|_| {}).await;
+                }
+            }
+            Err(error) => {
+                error!("Icon statefile watcher error: {error}");
+                process::exit(1);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

- Use fallback value for `XDG_DATA_DIRS` parsing (avoids an unnecessary `expect()`)
- Make `i18n_dir` a String rather than a PathBuf (as this is the type that `bindtextdomain` expects, avoid an unnecessary conversion and associated `expect()`)
- Turn remaining `expect()` into `unwrap_or_else()` (doesn't change much technically but conceptually cleaner in these cases)
- Improve error handling for watcher (before, potential errors were not logged and the watcher would silently stop; now errors are logged and are considered fatal, so that the tray doesn't continue running with a knowingly broken watcher)