### PR TITLE
Add Russian translation to the .desktop files

### DIFF
--- a/res/desktop/arch-update-tray.desktop
+++ b/res/desktop/arch-update-tray.desktop
@@ -10,6 +10,7 @@ Comment[it]=Applet del vassoio di sistema per Arch-Update
 Comment[ja]=Arch-Update 用のシステムトレイアプレット
 Comment[ka]=Arch-Update-ის აპლეტი სისტემურ საათთან
 Comment[nb]=Miniprogam for å legge Arch-Update i systemkurven
+Comment[ru]=Апплет Arch-Update в системном трее
 Icon=arch-update_updates-available-blue
 Type=Application
 Exec=/bin/sh -c "sleep 3 && arch-update --tray"

--- a/res/desktop/arch-update.desktop
+++ b/res/desktop/arch-update.desktop
@@ -10,6 +10,7 @@ Comment[it]=Un sistema interattivo di notifica & applicazione degli aggiornament
 Comment[ja]=Arch Linux 用の対話式アップデート通知 & 適用システム
 Comment[ka]=ინტერაქტიური განახლებების შეტყობინება და გადატარება Arch Linux-ისთვის
 Comment[nb]=En interaktiv oppdateringsvarsler og -gjennomfører for Arch Linux
+Comment[ru]=Интерактивный помощник по обновлению Arch Linux: уведомляет об обновлениях и устанавливает их
 Icon=arch-update-blue
 Type=Application
 Terminal=true


### PR DESCRIPTION
### Description

Adds Russian comments to the two `.desktop` files, as invited in #436 and following #534 as an example.

I kept the wording close to the existing `po/ru.po` translation, so the launcher entry and the `--help` output read the same way rather than describing the tool in two different voices. Checked it live on KDE Plasma 6 under a `ru_RU.UTF-8` locale, where the new comments do show up in the launcher, and both files still pass `desktop-file-validate`.

I noticed the Cachy-Update fork needs the same lines with its own product name. Happy to send those over as well if it saves you a minute, though I gather you usually handle that difference yourself.
