### PR TITLE
fix(i18n): Use Latin y/n for the Russian confirmation prompts

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -118,26 +118,26 @@ msgstr "Неиспользуемые пакеты Flatpak:"
 #: src/lib/flatpak_unused_packages.sh:14
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
-msgstr "Удалить этот неиспользуемый пакет Flatpak сейчас? [д/Н]"
+msgstr "Удалить этот неиспользуемый пакет Flatpak сейчас? [y/N]"
 
 #: src/lib/flatpak_unused_packages.sh:16
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
-msgstr "Удалить эти неиспользуемые пакеты Flatpak сейчас? [д/Н]"
+msgstr "Удалить эти неиспользуемые пакеты Flatpak сейчас? [y/N]"
 
 #: src/lib/flatpak_unused_packages.sh:21 src/lib/kernel_reboot.sh:15
 #: src/lib/list_packages.sh:166 src/lib/orphan_packages.sh:21
 #: src/lib/packages_cache.sh:30 src/lib/pacnew_files.sh:21
 #, sh-format
 msgid "Y"
-msgstr "Д"
+msgstr "Y"
 
 #: src/lib/flatpak_unused_packages.sh:21 src/lib/kernel_reboot.sh:15
 #: src/lib/list_packages.sh:166 src/lib/orphan_packages.sh:21
 #: src/lib/packages_cache.sh:30 src/lib/pacnew_files.sh:21
 #, sh-format
 msgid "y"
-msgstr "д"
+msgstr "y"
 
 #: src/lib/flatpak_unused_packages.sh:23
 #, sh-format
@@ -314,8 +314,8 @@ msgid ""
 "  --tray            Launch the ${_name} systray applet, you can optionally "
 "add the '--enable' argument to start it automatically at boot"
 msgstr ""
-"  --tray            Запустить апплет в системном трее. Добавьте --enable, "
-"чтобы автоматически запускать его при загрузке"
+"  --tray            Запустить апплет ${_name} в системном трее. Добавьте --"
+"enable, чтобы автоматически запускать его при загрузке"
 
 #: src/lib/help.sh:26
 #, sh-format
@@ -362,7 +362,7 @@ msgstr ""
 #: src/lib/kernel_reboot.sh:11
 #, sh-format
 msgid "Would you like to reboot now? [y/N]"
-msgstr "Перезагрузиться сейчас? [д/Н]"
+msgstr "Перезагрузиться сейчас? [y/N]"
 
 #: src/lib/kernel_reboot.sh:24
 #, sh-format
@@ -516,7 +516,7 @@ msgstr "Обновлений нет\\n"
 #: src/lib/list_packages.sh:162
 #, sh-format
 msgid "Proceed with update? [Y/n]"
-msgstr "Продолжить обновление? [Д/н]"
+msgstr "Продолжить обновление? [Y/n]"
 
 #: src/lib/list_packages.sh:172
 #, sh-format
@@ -562,7 +562,7 @@ msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
 msgstr ""
-"Удалить этот осиротевший пакет (и его возможные зависимости) сейчас? [д/Н]"
+"Удалить этот осиротевший пакет (и его возможные зависимости) сейчас? [y/N]"
 
 #: src/lib/orphan_packages.sh:16
 #, sh-format
@@ -570,7 +570,7 @@ msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
 msgstr ""
-"Удалить эти осиротевшие пакеты (и их возможные зависимости) сейчас? [д/Н]"
+"Удалить эти осиротевшие пакеты (и их возможные зависимости) сейчас? [y/N]"
 
 #: src/lib/orphan_packages.sh:23
 #, sh-format
@@ -591,7 +591,7 @@ msgstr ""
 #: src/lib/packages_cache.sh:22
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
-msgstr "Удалить его из кэша сейчас? [Д/н]"
+msgstr "Удалить его из кэша сейчас? [Y/n]"
 
 #: src/lib/packages_cache.sh:24
 #, sh-format
@@ -603,7 +603,7 @@ msgstr ""
 #: src/lib/packages_cache.sh:25
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
-msgstr "Удалить их из кэша сейчас? [Д/н]"
+msgstr "Удалить их из кэша сейчас? [Y/n]"
 
 #: src/lib/packages_cache.sh:33 src/lib/packages_cache.sh:54
 #, sh-format
@@ -628,12 +628,12 @@ msgstr "Файлы pacnew:"
 #: src/lib/pacnew_files.sh:14
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
-msgstr "Обработать этот файл сейчас? [Д/н]"
+msgstr "Обработать этот файл сейчас? [Y/n]"
 
 #: src/lib/pacnew_files.sh:16
 #, sh-format
 msgid "Would you like to process these files now? [Y/n]"
-msgstr "Обработать эти файлы сейчас? [Д/н]"
+msgstr "Обработать эти файлы сейчас? [Y/n]"
 
 #: src/lib/pacnew_files.sh:23
 #, sh-format


### PR DESCRIPTION
As discussed in #737, this switches the Russian confirmation prompts back to `[Y/n]` / `[y/N]` and restores `y`/`Y` as the accepted answers, so no keyboard layout switch is needed. This also matches the other Cyrillic-script locales (bg, be) as well as ka and ja, and pacman's own Russian prompts.

While editing the file I noticed one unrelated thing and fixed it in the same commit, since it is a one-line change to the same catalogue: the `--tray` help line had lost its `${_name}` placeholder, which makes `msgfmt --check` fail on `po/ru.po`. With it restored the catalogue checks out cleanly again. Happy to split that out if you would rather keep it separate.

The wording of the prompts themselves is untouched — only the letters inside the brackets.
