### PR TITLE
chore(tray): Refactor i18n initialization

### DIFF
--- a/src/tray/src/i18n.rs
+++ b/src/tray/src/i18n.rs
@@ -1,10 +1,13 @@
-//! Find the directory containing translation files
+//! Set and initialize locatlization
 
+use gettextrs::*;
+use log::warn;
 use std::env;
 use std::fs::File;
 use std::io::{self, Error};
 use std::path::PathBuf;
 
+// Find the directory containing translation files
 pub fn get_i18n_dir() -> io::Result<String> {
     let paths = [
         env::var_os("XDG_DATA_HOME").map(|path| PathBuf::from(path).join("locale")),
@@ -29,4 +32,28 @@ pub fn get_i18n_dir() -> io::Result<String> {
                 .and_then(|_| path.to_str().map(str::to_owned))
         })
         .ok_or_else(|| Error::other("Unable to access the translation directory"))
+}
+
+// Initialize localization
+pub fn init_i18n(i18n_dir: &str) {
+    // Safety: setlocale() is safe to call here because no additional threads have been created
+    // at that point (the Tokio runtime is not created yet)
+    // See https://github.com/gettext-rs/gettext-rs/blob/0.8.0/gettext-sys/lib.rs#L37-L49
+    unsafe {
+        if setlocale(LocaleCategory::LcMessages, "").is_none() {
+            warn!("Unable to load locale environment");
+        }
+    }
+
+    if textdomain("Arch-Update").is_err() {
+        warn!("Unable to set gettext domain");
+    }
+
+    if bindtextdomain("Arch-Update", i18n_dir).is_err() {
+        warn!("Unable to bind gettext domain path");
+    }
+
+    if bind_textdomain_codeset("Arch-Update", "UTF-8").is_err() {
+        warn!("Unable to set gettext domain codeset");
+    }
 }

--- a/src/tray/src/main.rs
+++ b/src/tray/src/main.rs
@@ -6,14 +6,13 @@ use log::error;
 use std::process;
 
 mod desktop_file;
-mod i18n_dir;
+mod i18n;
 mod icon_statefile;
 mod tray;
 mod tray_helpers;
 mod updates_statefiles;
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
+fn main() {
     // Initialize logger
     env_logger::init();
 
@@ -35,12 +34,17 @@ async fn main() {
         process::exit(1);
     });
 
-    // Get the translation directory
-    let i18n_dir = i18n_dir::get_i18n_dir().unwrap_or_else(|error| {
+    // Get the translation directory and initialize localization
+    let i18n_dir = i18n::get_i18n_dir().unwrap_or_else(|error| {
         error!("{error}");
         process::exit(1);
     });
+    i18n::init_i18n(&i18n_dir);
 
-    // Start systray applet
-    tray::run(icon_statefile, updates_statefiles, desktop_file, i18n_dir).await;
+    // Create single-threaded tokio runtime and start the systray applet
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(tray::run(icon_statefile, updates_statefiles, desktop_file));
 }

--- a/src/tray/src/tray.rs
+++ b/src/tray/src/tray.rs
@@ -258,25 +258,7 @@ pub async fn run(
     icon_statefile: PathBuf,
     updates_statefile_type: updates_statefiles::UpdatesStateFiles,
     desktop_file: PathBuf,
-    i18n_dir: String,
 ) {
-    // Set gettext domain for translations
-    if setlocale(LocaleCategory::LcMessages, "").is_none() {
-        warn!("Unable to load locale environment");
-    }
-
-    if textdomain("Arch-Update").is_err() {
-        warn!("Unable to set gettext domain");
-    }
-
-    if bindtextdomain("Arch-Update", &i18n_dir).is_err() {
-        warn!("Unable to bind gettext domain path");
-    }
-
-    if bind_textdomain_codeset("Arch-Update", "UTF-8").is_err() {
-        warn!("Unable to set gettext domain codeset");
-    }
-
     // Clone icon statefile path variable (used by the watcher)
     let watcher_icon_statefile = icon_statefile.clone();
 


### PR DESCRIPTION
### Description

Move i18n related tasks (get i18n dir and init) into a dedicated module. There's no need to decorrelate those two tasks nor to init i18n within the tray module. This results in a clearer structure.

Additionally, this allows to call `setlocale()` before starting a tokio thread / runtime, ensuring a safe call (see
https://github.com/gettext-rs/gettext-rs/pull/156 & https://github.com/gettext-rs/gettext-rs/blob/0.8.0/gettext-sys/lib.rs#L37-L49).