### PR TITLE
chore(tray): Add context if panicking when creating the tokio runtime

### DIFF
--- a/src/tray/src/i18n.rs
+++ b/src/tray/src/i18n.rs
@@ -1,4 +1,4 @@
-//! Set and initialize locatlization
+//! Set and initialize localization
 
 use gettextrs::*;
 use log::warn;

--- a/src/tray/src/main.rs
+++ b/src/tray/src/main.rs
@@ -45,6 +45,6 @@ fn main() {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .unwrap()
+        .expect("Failed to create Tokio runtime")
         .block_on(tray::run(icon_statefile, updates_statefiles, desktop_file));
 }


### PR DESCRIPTION
### Description

Replace unwrap() by expect() to provide some context in case of panic (should be safe though, but some context / relevant message doesn't hurt).

Also small typo fix.
