### PR TITLE
chore: Switch to anyhow for a streamlined error propagation management

### DIFF
--- a/src/tray/Cargo.lock
+++ b/src/tray/Cargo.lock
@@ -62,9 +62,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "arch-update-tray"
 version = "4.1.3"
 dependencies = [
+ "anyhow",
  "env_logger",
  "gettext-rs",
  "ksni",

--- a/src/tray/Cargo.toml
+++ b/src/tray/Cargo.toml
@@ -7,6 +7,7 @@ description = "A systray applet for Arch-Update"
 license = "GPL-3.0-or-later"
 
 [dependencies]
+anyhow = "1.0.104"
 env_logger = "0.11.11"
 gettext-rs = { version = "0.8.0", features = ["gettext-system"] }
 ksni = "0.3.6"

--- a/src/tray/src/desktop_file.rs
+++ b/src/tray/src/desktop_file.rs
@@ -1,11 +1,11 @@
 //! Find the desktop file needed to run Arch-Update from the terminal
 
+use anyhow::Context;
 use std::env;
 use std::fs::File;
-use std::io::{self, Error};
 use std::path::PathBuf;
 
-pub fn get_desktop_file() -> io::Result<PathBuf> {
+pub fn get_desktop_file() -> anyhow::Result<PathBuf> {
     let paths = [
         env::var_os("XDG_DATA_HOME")
             .map(|path| PathBuf::from(path).join("applications/arch-update.desktop")),
@@ -27,5 +27,5 @@ pub fn get_desktop_file() -> io::Result<PathBuf> {
         .into_iter()
         .flatten()
         .find_map(|path| File::open(&path).ok().map(|_| path))
-        .ok_or_else(|| Error::other("Unable to access the desktop file"))
+        .context("Failed to access the desktop file")
 }

--- a/src/tray/src/i18n.rs
+++ b/src/tray/src/i18n.rs
@@ -1,14 +1,14 @@
 //! Set and initialize localization
 
+use anyhow::Context;
 use gettextrs::*;
 use log::warn;
 use std::env;
 use std::fs::File;
-use std::io::{self, Error};
 use std::path::PathBuf;
 
 // Find the directory containing translation files
-pub fn get_i18n_dir() -> io::Result<String> {
+pub fn get_i18n_dir() -> anyhow::Result<String> {
     let paths = [
         env::var_os("XDG_DATA_HOME").map(|path| PathBuf::from(path).join("locale")),
         env::var_os("HOME").map(|path| PathBuf::from(path).join(".local/share/locale")),
@@ -31,13 +31,13 @@ pub fn get_i18n_dir() -> io::Result<String> {
                 .ok()
                 .and_then(|_| path.to_str().map(str::to_owned))
         })
-        .ok_or_else(|| Error::other("Unable to access the translation directory"))
+        .context("Failed to access the translation directory")
 }
 
 // Initialize localization
 pub fn init_i18n(i18n_dir: &str) {
     // Safety: setlocale() is safe to call here because no additional threads have been created
-    // at that point (the Tokio runtime is not created yet)
+    // at that point (the Tokio runtime is created at a later stage)
     // See https://github.com/gettext-rs/gettext-rs/blob/0.8.0/gettext-sys/lib.rs#L37-L49
     unsafe {
         if setlocale(LocaleCategory::LcMessages, "").is_none() {

--- a/src/tray/src/icon_statefile.rs
+++ b/src/tray/src/icon_statefile.rs
@@ -1,11 +1,11 @@
 //! Find the icon statefile containing the systray icon to set depending on the state
 
+use anyhow::Context;
 use std::env;
 use std::fs::File;
-use std::io::{self, Error};
 use std::path::PathBuf;
 
-pub fn get_icon_statefile() -> io::Result<PathBuf> {
+pub fn get_icon_statefile() -> anyhow::Result<PathBuf> {
     let paths = [
         env::var_os("XDG_STATE_HOME").map(|path| PathBuf::from(path).join("arch-update/tray_icon")),
         env::var_os("HOME")
@@ -16,5 +16,5 @@ pub fn get_icon_statefile() -> io::Result<PathBuf> {
         .into_iter()
         .flatten()
         .find_map(|path| File::open(&path).ok().map(|_| path))
-        .ok_or_else(|| Error::other("Unable to access the icon statefile"))
+        .context("Unable to access the icon statefile")
 }

--- a/src/tray/src/main.rs
+++ b/src/tray/src/main.rs
@@ -4,6 +4,7 @@
 
 use log::error;
 use std::process;
+use tokio::runtime;
 
 mod desktop_file;
 mod i18n;
@@ -18,33 +19,43 @@ fn main() {
 
     // Get the icon statefile
     let icon_statefile = icon_statefile::get_icon_statefile().unwrap_or_else(|error| {
-        error!("{error}");
+        error!("{error:?}");
         process::exit(1);
     });
 
     // Get the updates statefiles
     let updates_statefiles = updates_statefiles::get_updates_statefiles().unwrap_or_else(|error| {
-        error!("{error}");
+        error!("{error:?}");
         process::exit(1);
     });
 
     // Get the desktop file
     let desktop_file = desktop_file::get_desktop_file().unwrap_or_else(|error| {
-        error!("{error}");
+        error!("{error:?}");
         process::exit(1);
     });
 
     // Get the translation directory and initialize localization
     let i18n_dir = i18n::get_i18n_dir().unwrap_or_else(|error| {
-        error!("{error}");
+        error!("{error:?}");
         process::exit(1);
     });
     i18n::init_i18n(&i18n_dir);
 
     // Create single-threaded tokio runtime and start the systray applet
-    tokio::runtime::Builder::new_current_thread()
+    let tokio_runtime = runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .expect("Failed to create Tokio runtime")
-        .block_on(tray::run(icon_statefile, updates_statefiles, desktop_file));
+        .unwrap_or_else(|error| {
+            error!("Failed to create Tokio runtime: {error}");
+            process::exit(1);
+        });
+
+    // Start the systray applet
+    tokio_runtime
+        .block_on(tray::run(icon_statefile, updates_statefiles, desktop_file))
+        .unwrap_or_else(|error| {
+            error!("{error:?}");
+            process::exit(1);
+        });
 }

--- a/src/tray/src/tray.rs
+++ b/src/tray/src/tray.rs
@@ -3,6 +3,7 @@
 //! https://github.com/iovxw/ksni
 //! https://crates.io/crates/ksni
 
+use anyhow::Context;
 use gettextrs::*;
 use ksni::TrayMethods;
 use ksni::menu::*;
@@ -258,7 +259,7 @@ pub async fn run(
     icon_statefile: PathBuf,
     updates_statefile_type: updates_statefiles::UpdatesStateFiles,
     desktop_file: PathBuf,
-) {
+) -> anyhow::Result<()> {
     // Clone icon statefile path variable (used by the watcher)
     let watcher_icon_statefile = icon_statefile.clone();
 
@@ -269,10 +270,10 @@ pub async fn run(
     };
 
     // Start the systray applet
-    let handle = tray.spawn().await.unwrap_or_else(|error| {
-        error!("Unable to start the systray applet: {error}");
-        process::exit(1);
-    });
+    let handle = tray
+        .spawn()
+        .await
+        .context("Unable to start the systray applet")?;
 
     info!("Systray applet started");
 
@@ -283,5 +284,7 @@ pub async fn run(
     ));
 
     // Run forever
-    future::pending().await
+    future::pending::<()>().await;
+
+    Ok(())
 }

--- a/src/tray/src/tray_helpers.rs
+++ b/src/tray/src/tray_helpers.rs
@@ -1,5 +1,6 @@
 //! Collection of helpers / functions used by the systray applet for various needs and features
 
+use anyhow::{Context, anyhow};
 use gettextrs::*;
 use ksni::Handle;
 use ksni::menu::*;
@@ -10,7 +11,7 @@ use std::env;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::{self, Command};
+use std::process::Command;
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
@@ -151,7 +152,10 @@ fn open_package_url(package: &str) {
 
 // Watcher for the icon statefile, allowing to trigger a dynamic rebuild of the systray applet on
 // icon change
-pub async fn icon_watcher(icon_statefile: PathBuf, handle: Handle<crate::tray::ArchUpdateTray>) {
+pub async fn icon_watcher(
+    icon_statefile: PathBuf,
+    handle: Handle<crate::tray::ArchUpdateTray>,
+) -> anyhow::Result<()> {
     let (tx, mut rx) = mpsc::unbounded_channel();
 
     let mut watcher = RecommendedWatcher::new(
@@ -160,17 +164,11 @@ pub async fn icon_watcher(icon_statefile: PathBuf, handle: Handle<crate::tray::A
         },
         Config::default(),
     )
-    .unwrap_or_else(|error| {
-        error!("Unable to create icon statefile watcher: {error}");
-        process::exit(1);
-    });
+    .context("Unable to create icon statefile watcher")?;
 
     watcher
         .watch(&icon_statefile, RecursiveMode::NonRecursive)
-        .unwrap_or_else(|error| {
-            error!("Unable to watch icon statefile: {error}");
-            process::exit(1);
-        });
+        .context("Unable to watch icon statefile")?;
 
     while let Some(result) = rx.recv().await {
         match result {
@@ -180,11 +178,12 @@ pub async fn icon_watcher(icon_statefile: PathBuf, handle: Handle<crate::tray::A
                 }
             }
             Err(error) => {
-                error!("Icon statefile watcher error: {error}");
-                process::exit(1);
+                return Err(anyhow!("Icon statefile watcher error: {error}"));
             }
         }
     }
+
+    Ok(())
 }
 
 // Helper to get the next check time from the systemd timer metadata

--- a/src/tray/src/updates_statefiles.rs
+++ b/src/tray/src/updates_statefiles.rs
@@ -1,8 +1,8 @@
 //! Find the updates statefile containing the list of pending updates for each package types
 
+use anyhow::Context;
 use std::env;
 use std::fs::File;
-use std::io::{self, Error};
 use std::path::PathBuf;
 
 pub struct UpdatesStateFiles {
@@ -13,7 +13,7 @@ pub struct UpdatesStateFiles {
     pub flatpak: PathBuf,
 }
 
-pub fn get_updates_statefiles() -> io::Result<UpdatesStateFiles> {
+pub fn get_updates_statefiles() -> anyhow::Result<UpdatesStateFiles> {
     let paths = [
         env::var_os("XDG_STATE_HOME").map(|path| PathBuf::from(path).join("arch-update")),
         env::var_os("HOME").map(|path| PathBuf::from(path).join(".local/state/arch-update")),
@@ -38,5 +38,5 @@ pub fn get_updates_statefiles() -> io::Result<UpdatesStateFiles> {
                 && File::open(&updates.flatpak).is_ok())
             .then_some(updates)
         })
-        .ok_or_else(|| Error::other("Unable to access updates statefiles"))
+        .context("Unable to access updates statefiles")
 }


### PR DESCRIPTION
### Description

Switch to anyhow for an easier / streamlined error propagation management, including strandardize formating.

Also made some tiny refinements here and there.