### PR TITLE
chore(tray): Switch wording and severity of some errors

### DIFF
--- a/src/tray/src/i18n.rs
+++ b/src/tray/src/i18n.rs
@@ -40,19 +40,19 @@ pub fn init_i18n(i18n_dir: &str) {
     // See https://github.com/gettext-rs/gettext-rs/blob/0.8.0/gettext-sys/lib.rs#L37-L49
     unsafe {
         if setlocale(LocaleCategory::LcMessages, "").is_none() {
-            warn!("Unable to load locale environment");
+            warn!("Failed to load locale environment");
         }
     }
 
     if textdomain("Arch-Update").is_err() {
-        warn!("Unable to set gettext domain");
+        warn!("Failed to set gettext domain");
     }
 
     if bindtextdomain("Arch-Update", i18n_dir).is_err() {
-        warn!("Unable to bind gettext domain path");
+        warn!("Failed to bind gettext domain path");
     }
 
     if bind_textdomain_codeset("Arch-Update", "UTF-8").is_err() {
-        warn!("Unable to set gettext domain codeset");
+        warn!("Failed to set gettext domain codeset");
     }
 }

--- a/src/tray/src/icon_statefile.rs
+++ b/src/tray/src/icon_statefile.rs
@@ -16,5 +16,5 @@ pub fn get_icon_statefile() -> anyhow::Result<PathBuf> {
         .into_iter()
         .flatten()
         .find_map(|path| File::open(&path).ok().map(|_| path))
-        .context("Unable to access the icon statefile")
+        .context("Failed to access the icon statefile")
 }

--- a/src/tray/src/tray.rs
+++ b/src/tray/src/tray.rs
@@ -38,7 +38,7 @@ impl ksni::Tray for ArchUpdateTray {
                 icon
             }
             Err(error) => {
-                error!("Unable to set the icon: {error}");
+                error!("Failed to set the icon: {error}");
                 process::exit(1);
             }
         }
@@ -196,7 +196,7 @@ impl ksni::Tray for ArchUpdateTray {
                 .into(),
             );
         } else {
-            warn!("Unable to determine the last Arch-Update check time");
+            warn!("Failed to determine the last Arch-Update check time");
         }
 
         // Add the "Next Check" menu entry (if the systemd timer is started / enabled)
@@ -213,7 +213,7 @@ impl ksni::Tray for ArchUpdateTray {
                 .into(),
             );
         } else {
-            warn!("Unable to determine next Arch-Update check time");
+            warn!("Failed to determine next Arch-Update check time");
         }
 
         // Add a menu group containing a separator and the "Run Arch-Update", "Check for updates" & "Exit" buttons
@@ -234,7 +234,7 @@ impl ksni::Tray for ArchUpdateTray {
                 activate: Box::new(
                     |_| match Command::new("arch-update").arg("--check").spawn() {
                         Ok(_) => info!("Arch-Update check executed"),
-                        Err(error) => error!("Unable to execute Arch-Update check: {error}"),
+                        Err(error) => error!("Failed to execute Arch-Update check: {error}"),
                     },
                 ),
                 ..Default::default()
@@ -273,7 +273,7 @@ pub async fn run(
     let handle = tray
         .spawn()
         .await
-        .context("Unable to start the systray applet")?;
+        .context("Failed to start the systray applet")?;
 
     info!("Systray applet started");
 

--- a/src/tray/src/tray_helpers.rs
+++ b/src/tray/src/tray_helpers.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, anyhow};
 use gettextrs::*;
 use ksni::Handle;
 use ksni::menu::*;
-use log::{error, info};
+use log::{error, info, warn};
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Deserialize;
 use std::env;
@@ -22,7 +22,7 @@ use crate::tray;
 pub fn launch_arch_update(desktop_file: &Path) {
     match Command::new("gio").arg("launch").arg(desktop_file).spawn() {
         Ok(_) => info!("Arch-Update launched"),
-        Err(error) => error!("Unable to launch Arch-Update: {error}"),
+        Err(error) => error!("Failed to launch Arch-Update: {error}"),
     }
 }
 
@@ -61,7 +61,7 @@ pub fn build_updates_submenu(
         }
 
         Err(error) => {
-            error!("Unable to read updates statefile: {error}");
+            error!("Failed to read updates statefile: {error}");
             Vec::new()
         }
     }
@@ -121,13 +121,13 @@ fn open_package_url(package: &str) {
     let pacman_output = match Command::new("pacman").arg("-Qi").arg(package).output() {
         Ok(pacman_output) => pacman_output,
         Err(error) => {
-            error!("Unable to query the {package} package information: {error}");
+            warn!("Failed to query the {package} package information: {error}");
             return;
         }
     };
 
     if !pacman_output.status.success() {
-        error!("Unable to get the {package} package information");
+        warn!("Failed to get the {package} package information");
         return;
     }
 
@@ -141,7 +141,7 @@ fn open_package_url(package: &str) {
             if url.starts_with("http://") || url.starts_with("https://") {
                 match Command::new("xdg-open").arg(url).spawn() {
                     Ok(_) => info!("Opened the {package} package URL: {url}"),
-                    Err(error) => error!("Unable to open the {package} package URL {url}: {error}"),
+                    Err(error) => warn!("Failed to open the {package} package URL {url}: {error}"),
                 }
             }
 
@@ -164,11 +164,11 @@ pub async fn icon_watcher(
         },
         Config::default(),
     )
-    .context("Unable to create icon statefile watcher")?;
+    .context("Failed to create icon statefile watcher")?;
 
     watcher
         .watch(&icon_statefile, RecursiveMode::NonRecursive)
-        .context("Unable to watch icon statefile")?;
+        .context("Failed to watch icon statefile")?;
 
     while let Some(result) = rx.recv().await {
         match result {

--- a/src/tray/src/updates_statefiles.rs
+++ b/src/tray/src/updates_statefiles.rs
@@ -38,5 +38,5 @@ pub fn get_updates_statefiles() -> anyhow::Result<UpdatesStateFiles> {
                 && File::open(&updates.flatpak).is_ok())
             .then_some(updates)
         })
-        .context("Unable to access updates statefiles")
+        .context("Failed to access updates statefiles")
 }


### PR DESCRIPTION
### Description

Switch some errors severity to 'warn' (as they are not bad enough to be considered errors) and replace the 'Unable' word to 'Failed' in error message (which is more accurate).