### PR TITLE
update zh_CN

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4,13 +4,14 @@
 #
 # Translators:
 # Aubrey Carlson <aubreycarlson24@outlook.com>, 2025
+# taotieren <admin@taotieren.com>, 2026
 msgid ""
 msgstr ""
 "Project-Id-Version: Arch-Update 4.1.5\n"
 "Report-Msgid-Bugs-To: https://github.com/Antiz96/arch-update/issues\n"
 "POT-Creation-Date: 2024-03-17 16:22+0100\n"
-"PO-Revision-Date: 2025-12-02 12:00+0800\n"
-"Last-Translator: Aubrey Carlson <aubreycarlson24@outlook.com>\n"
+"PO-Revision-Date: 2026-08-12 12:00+0800\n"
+"Last-Translator: taotieren <admin@taotieren.com>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,22 +20,22 @@ msgstr ""
 #: src/lib/alhp_check.sh:14
 #, sh-format
 msgid "Your primary ALHP mirror is out of date!\\n"
-msgstr ""
+msgstr "你的主 ALHP 镜像已过期！\\n"
 
 #: src/lib/alhp_check.sh:20
 #, sh-format
 msgid "The following packages still have pending ALHP builds:"
-msgstr ""
+msgstr "以下软件包仍有待构建的 ALHP 包："
 
 #: src/lib/alhp_check.sh:23
 #, sh-format
 msgid "Error during ALHP check:"
-msgstr ""
+msgstr "ALHP 检查出错："
 
 #: src/lib/check.sh:10
 #, sh-format
 msgid "Automated update checks have been enabled"
-msgstr ""
+msgstr "已启用自动更新检查"
 
 #: src/lib/common.sh:96
 #, sh-format
@@ -49,32 +50,32 @@ msgstr "错误"
 #: src/lib/common.sh:107
 #, sh-format
 msgid "Press \"enter\" to continue "
-msgstr "按下 \"enter\" 继续"
+msgstr "按 \"enter\" 继续 "
 
 #: src/lib/common.sh:113
 #, sh-format
 msgid "Press \"enter\" to quit "
-msgstr "按下 \"enter\" 退出"
+msgstr "按 \"enter\" 退出 "
 
 #: src/lib/common.sh:134
 #, sh-format
 msgid ""
 "The ${aur_helper} AUR helper set for AUR packages support in the "
 "${name}.conf configuration file is not found\\n"
-msgstr "配置在 ${name}.conf 文件中的 AUR 帮助程序 ${aur_helper} 未找到\\n"
+msgstr "在 ${name}.conf 配置文件中设置的 AUR 助手 ${aur_helper} 未找到\\n"
 
 #: src/lib/common.sh:175
 #, sh-format
 msgid ""
 "A privilege elevation command is required (sudo, sudo-rs, doas or run0)\\n"
-msgstr "需要特权提升命令程序（sudo、sudo-rs、doas 或 run0）\\n"
+msgstr "需要一个提权命令（sudo、sudo-rs、doas 或 run0）\\n"
 
 #: src/lib/common.sh:180
 #, sh-format
 msgid ""
 "The ${su_cmd} command set for privilege escalation in the ${name}.conf "
 "configuration file is not found\\n"
-msgstr "配置在 ${name}.conf 文件中的特权提升命令程序 ${su_cmd} 未找到\\n"
+msgstr "在 ${name}.conf 配置文件中设置的提权命令 ${su_cmd} 未找到\\n"
 
 #: src/lib/common.sh:192
 #, sh-format
@@ -82,7 +83,7 @@ msgid ""
 "The ${diff_prog} editor set for visualizing / editing differences of pacnew "
 "files in the ${name}.conf configuration file is not found\\n"
 msgstr ""
-"配置在 ${name}.conf 文件中的，用于可视化和编辑 pacnew 文件差异的程序 "
+"在 ${name}.conf 配置文件中设置的、用于查看 / 编辑 pacnew 文件差异的编辑器 "
 "${diff_prog} 未找到\\n"
 
 #: src/lib/edit-config.sh:9 src/lib/show-config.sh:9
@@ -98,23 +99,23 @@ msgid ""
 "Unable to determine the editor to use\\nThe \"EDITOR\" environment variable "
 "is not set and \"nano\" (fallback option) is not installed"
 msgstr ""
-"无法确定要使用的编辑器\\n\"EDITOR\" 环境变量未设置且 \"nano\" (备用选项) 未安"
-"装"
+"无法确定要使用的编辑器\\n\"EDITOR\" 环境变量未设置，且 \"nano\"（备用选项）未"
+"安装"
 
 #: src/lib/flatpak_unused_packages.sh:10
 #, sh-format
 msgid "Flatpak Unused Packages:"
-msgstr "Flatpak 中未使用的包："
+msgstr "Flatpak 未使用的包："
 
 #: src/lib/flatpak_unused_packages.sh:14
 #, sh-format
 msgid "Would you like to remove this Flatpak unused package now? [y/N]"
-msgstr "是否现在删除这个未使用的 Flatpak 包？[y/N]"
+msgstr "是否现在移除这个未使用的 Flatpak 包？[y/N]"
 
 #: src/lib/flatpak_unused_packages.sh:16
 #, sh-format
 msgid "Would you like to remove these Flatpak unused packages now? [y/N]"
-msgstr "是否现在删除这些未使用的 Flatpak 包？[y/N]"
+msgstr "是否现在移除这些未使用的 Flatpak 包？[y/N]"
 
 #: src/lib/flatpak_unused_packages.sh:21 src/lib/kernel_reboot.sh:15
 #: src/lib/list_packages.sh:166 src/lib/orphan_packages.sh:21
@@ -133,7 +134,7 @@ msgstr "y"
 #: src/lib/flatpak_unused_packages.sh:23
 #, sh-format
 msgid "Removing Flatpak Unused Packages..."
-msgstr "正在删除未使用的 Flatpak 包..."
+msgstr "正在移除未使用的 Flatpak 包..."
 
 #: src/lib/flatpak_unused_packages.sh:27 src/lib/orphan_packages.sh:28
 #: src/lib/packages_cache.sh:38 src/lib/packages_cache.sh:48
@@ -142,18 +143,18 @@ msgstr "正在删除未使用的 Flatpak 包..."
 msgid ""
 "An error has occurred during the removal process\\nThe removal has been "
 "aborted\\n"
-msgstr "在删除过程中发生错误，删除已中止"
+msgstr "移除过程中发生错误，已中止移除\\n"
 
 #: src/lib/flatpak_unused_packages.sh:30 src/lib/orphan_packages.sh:31
 #, sh-format
 msgid "The removal has been applied\\n"
-msgstr "已成功删除"
+msgstr "已应用移除\\n"
 
 #: src/lib/flatpak_unused_packages.sh:35 src/lib/orphan_packages.sh:37
 #: src/lib/packages_cache.sh:75
 #, sh-format
 msgid "The removal hasn't been applied\\n"
-msgstr "删除失败"
+msgstr "未应用移除\\n"
 
 #: src/lib/flatpak_unused_packages.sh:39
 #, sh-format
@@ -163,12 +164,12 @@ msgstr "未找到未使用的 Flatpak 包\\n"
 #: src/lib/full_upgrade.sh:13
 #, sh-format
 msgid "There's already a running instance of ${_name}\\n"
-msgstr "已经有一个 ${_name} 实例在运行了\\n"
+msgstr "已经有一个 ${_name} 实例正在运行\\n"
 
 #: src/lib/gen-config.sh:19
 #, sh-format
 msgid "Example configuration file not found"
-msgstr "示例配置文件未找到"
+msgstr "未找到示例配置文件"
 
 #: src/lib/gen-config.sh:25
 #, sh-format
@@ -176,40 +177,41 @@ msgid ""
 "The '${config_file}' configuration file already exists\\nPlease, remove it "
 "before generating a new one (or use --force to overwrite it)"
 msgstr ""
-"${config_file} 配置文件已经存在\\n请在生成新配置文件之前删除它（或使用 --"
-"force 选项覆盖它）"
+"'${config_file}' 配置文件已存在\\n请在生成新配置文件前先将其删除（或使用 --"
+"force 覆盖）"
 
 #: src/lib/gen-config.sh:30
 #, sh-format
 msgid "The '${config_file}' configuration file has been generated"
-msgstr "${config_file} 配置文件已生成"
+msgstr "'${config_file}' 配置文件已生成"
 
 #: src/lib/help.sh:8
-#, fuzzy, sh-format
+#, sh-format
 msgid ""
 "An interactive update notifier & applier for Arch Linux that assists you "
 "with important pre / post update tasks."
 msgstr ""
-"一个用于检查和应用 Arch Linux 更新的程序，它帮助你完成重要的更新前后的任务。"
+"一个用于 Arch Linux 的交互式更新通知 & 应用工具，可协助你完成重要的更新前 / "
+"后任务。"
 
 #: src/lib/help.sh:10
 #, sh-format
 msgid "Run ${name} to perform the main 'update' function:"
-msgstr "运行 ${name} 来执行主要的 'update' 功能："
+msgstr "运行 ${name} 执行主要的 'update' 功能："
 
 #: src/lib/help.sh:11
 #, sh-format
 msgid ""
 "Display the list of packages available for update, then ask for the user's "
 "confirmation to proceed with the installation."
-msgstr "在执行更新之前，它会显示可用的包列表，并询问用户是否要继续安装。"
+msgstr "运行后会显示可更新的软件包列表，并请求用户确认后再进行安装。"
 
 #: src/lib/help.sh:12
 #, sh-format
 msgid ""
 "Before performing the update, it offers to display the latest Arch Linux "
 "news."
-msgstr "在执行更新之前，它会询问是否要显示最新的 Arch Linux 新闻。"
+msgstr "在执行更新之前，它会提示显示最新的 Arch Linux 新闻。"
 
 #: src/lib/help.sh:13
 #, sh-format
@@ -218,8 +220,8 @@ msgid ""
 "pacnew & pacsave files, pending kernel update as well as services requiring "
 "a post upgrade restart and, if there are, offers to process them."
 msgstr ""
-"更新完成后，它会检查是否有孤儿包、未使用的包、旧的缓存包、pacnew 和 pacsave "
-"文件、待更新内核以升级后及需要重启的服务，并根据情况提供处理这些选项的机会。"
+"更新完成后，它会检查孤立包 & 未使用的包、旧的缓存包、pacnew & pacsave 文件、"
+"待处理的内核更新，以及升级后需要重启的服务；若存在这些情况，会提供处理选项。"
 
 #: src/lib/help.sh:15
 #, sh-format
@@ -227,25 +229,26 @@ msgid "Options:"
 msgstr "选项："
 
 #: src/lib/help.sh:16
-#, fuzzy, sh-format
+#, sh-format
 msgid ""
 "  -c, --check       Check for available updates, change the systray icon and "
 "send a desktop notification containing the number of available updates (if "
 "there are new available updates compared to the last check). Optionally add "
 "the '--enable' argument to enable automated update checks."
 msgstr ""
-"  -c, --check       检查是否有可用更新，更改系统托盘图标并发送一个包含可用更"
-"新数量的桌面通知（如果与上次检查相比有新可用更新）"
+"  -c, --check       检查可用更新，更改系统托盘图标，并发送包含可用更新数量的"
+"桌面通知（相较于上次检查有新的可用更新时）。可附加 '--enable' 参数以启用自动"
+"更新检查。"
 
 #: src/lib/help.sh:17
 #, sh-format
 msgid "  -l, --list        Display the list of pending updates"
-msgstr "  -l, --list        显示待更新列表"
+msgstr "  -l, --list        显示待处理的更新列表"
 
 #: src/lib/help.sh:18
 #, sh-format
 msgid "  -d, --devel       Include AUR development packages updates"
-msgstr "  -d, --devel       包括 AUR 开发包更新"
+msgstr "  -d, --devel       包含 AUR 开发包的更新"
 
 #: src/lib/help.sh:19
 #, sh-format
@@ -253,18 +256,18 @@ msgid ""
 "  -n, --news [Num]  Display latest Arch news, you can optionally specify the "
 "number of Arch news to display with '--news [Num]' (e.g. '--news 10')"
 msgstr ""
-"  -n, --news [Num]  显示最新 Arch 新闻，你可以选择性地指定要显示的 Arch 新闻"
-"数量（例如：'--news 10'）"
+"  -n, --news [Num]  显示最新的 Arch 新闻，可通过 '--news [Num]' 选择性指定显"
+"示的新闻条数（例如 '--news 10'）"
 
 #: src/lib/help.sh:20
 #, sh-format
 msgid "  -s, --services    Check for services requiring a post upgrade restart"
-msgstr "  -s, --services    检查在升级后需要重启的服务"
+msgstr "  -s, --services    检查升级后需要重启的服务"
 
 #: src/lib/help.sh:21
 #, sh-format
 msgid "  -D, --debug       Display debug traces"
-msgstr "  -D, --debug       显示调试跟踪信息"
+msgstr "  -D, --debug       显示调试追踪信息"
 
 #: src/lib/help.sh:22
 #, sh-format
@@ -273,22 +276,22 @@ msgid ""
 "configuration file, you can optionally pass the '--force' argument to "
 "overwrite any existing '${name}.conf' configuration file"
 msgstr ""
-"  --gen-config      生成默认的 '${name}.conf' 配置文件，你可以选择性地传递 "
-"'--force' 参数来覆盖任何现有的 '${name}.conf' 配置文件"
+"  --gen-config      生成默认 / 示例 '${name}.conf' 配置文件，可选择性传入 '--"
+"force' 参数以覆盖任何已存在的 '${name}.conf' 配置文件"
 
 #: src/lib/help.sh:23
 #, sh-format
 msgid ""
 "  --show-config     Display the '${name}.conf' configuration file currently "
 "used (if it exists)"
-msgstr "  --show-config     显示当前使用的 '${name}.conf' 配置文件（如果存在）"
+msgstr "  --show-config     显示当前使用的 '${name}.conf' 配置文件（若存在）"
 
 #: src/lib/help.sh:24
 #, sh-format
 msgid ""
 "  --edit-config     Edit the '${name}.conf' configuration file currently "
 "used (if it exists)"
-msgstr "  --edit-config     编辑当前使用的 '${name}.conf' 配置文件（如果存在）"
+msgstr "  --edit-config     编辑当前使用的 '${name}.conf' 配置文件（若存在）"
 
 #: src/lib/help.sh:25
 #, sh-format
@@ -296,18 +299,18 @@ msgid ""
 "  --tray            Launch the ${_name} systray applet, you can optionally "
 "add the '--enable' argument to start it automatically at boot"
 msgstr ""
-"  --tray            启动 ${_name} 系统托盘应用程序，你可以选择性地添加 '--"
-"enable' 参数以在启动时自动启动"
+"  --tray            启动 ${_name} 系统托盘小程序，可选择性附加 '--enable' 参"
+"数以在开机时自动启动"
 
 #: src/lib/help.sh:26
 #, sh-format
 msgid "  -h, --help        Display this help message and exit"
-msgstr "  -h, --help        显示帮助信息"
+msgstr "  -h, --help        显示此帮助信息并退出"
 
 #: src/lib/help.sh:27
 #, sh-format
 msgid "  -V, --version     Display version information and exit"
-msgstr "  -V, --version     显示版本信息"
+msgstr "  -V, --version     显示版本信息并退出"
 
 #: src/lib/help.sh:29
 #, sh-format
@@ -320,7 +323,7 @@ msgid ""
 "Certain options can be enabled, disabled or modified via the ${name}.conf "
 "configuration file, see the ${name}.conf(5) man page."
 msgstr ""
-"某些选项可以通过 ${name}.conf 配置文件启用、禁用或修改，参阅 ${name}.conf(5) "
+"部分选项可通过 ${name}.conf 配置文件启用、禁用或修改，请参阅 ${name}.conf(5) "
 "手册页。"
 
 #: src/lib/invalid_option.sh:7
@@ -328,14 +331,15 @@ msgstr ""
 msgid ""
 "${name}: invalid option -- '${option}'\\nTry '${name} --help' for more "
 "information"
-msgstr "${name}: 无效选项 -- '${option}'\\n尝试 '${name} --help' 获取更多信息"
+msgstr ""
+"${name}：无效选项 -- '${option}'\\n请尝试 '${name} --help' 获取更多信息"
 
 #: src/lib/kernel_reboot.sh:10
 #, sh-format
 msgid ""
 "Reboot required:\\nThere's a pending kernel update on your system requiring "
 "a reboot to be applied\\n"
-msgstr "需要重启:\\n系统上有一个待更新的内核，需要重启才能应用\\n"
+msgstr "需要重启：\\n系统上有一个待处理的内核更新，需要重启才能应用\\n"
 
 #: src/lib/kernel_reboot.sh:11
 #, sh-format
@@ -345,21 +349,21 @@ msgstr "是否现在重启？[y/N]"
 #: src/lib/kernel_reboot.sh:24
 #, sh-format
 msgid "Rebooting in ${sec}...\\r"
-msgstr "在 ${sec} 秒后重启...\\r"
+msgstr "将在 ${sec} 秒后重启...\r"
 
 #: src/lib/kernel_reboot.sh:30
 #, sh-format
 msgid ""
 "An error has occurred during the reboot process\\nThe reboot has been "
 "aborted\\n"
-msgstr "在重启过程中发生错误\\n重启已被中止\\n"
+msgstr "重启过程中发生错误\\n已中止重启\\n"
 
 #: src/lib/kernel_reboot.sh:38
 #, sh-format
 msgid ""
 "The reboot hasn't been performed\\nPlease, consider rebooting to finalize "
 "the pending kernel update\\n"
-msgstr "重启未执行\\n请考虑手动重启以完成待处理的内核更新\\n"
+msgstr "未执行重启\\n请考虑重启以完成待处理的内核更新\\n"
 
 #: src/lib/kernel_reboot.sh:42
 #, sh-format
@@ -378,8 +382,8 @@ msgid ""
 "\\nPlease, look for any recent news at https://archlinux.org before updating "
 "your system"
 msgstr ""
-"无法检索最近的 Arch 新闻（HTTP 错误响应或请求超时）\\n请在更新系统之前查看 "
-"https://archlinux.org 上的任何最新新闻"
+"无法获取最近的 Arch 新闻（HTTP 错误响应或请求超时）\\n请在更新系统前前往 "
+"https://archlinux.org 查看最新新闻"
 
 #: src/lib/list_news.sh:23
 #, sh-format
@@ -389,7 +393,7 @@ msgstr "未找到最近的 Arch 新闻"
 #: src/lib/list_news.sh:37
 #, sh-format
 msgid "Arch News:"
-msgstr "Arch 新闻:"
+msgstr "Arch 新闻："
 
 #: src/lib/list_news.sh:42
 #, sh-format
@@ -401,8 +405,7 @@ msgstr "[NEW]"
 msgid ""
 "Select the news to read (e.g. 1 3 5), select 0 to read them all or press "
 "\"enter\" to quit:"
-msgstr ""
-"选择要阅读的新闻（例如 1 3 5），选择 0 读取所有新闻，或按 \"enter\" 退出:"
+msgstr "选择要阅读的新闻（例如 1 3 5），选择 0 阅读全部，或按 \"enter\" 退出："
 
 #: src/lib/list_news.sh:57
 #, sh-format
@@ -410,13 +413,12 @@ msgid ""
 "Select the news to read (e.g. 1 3 5), select 0 to read them all or press "
 "\"enter\" to proceed with update:"
 msgstr ""
-"选择要阅读的新闻（例如 1 3 5），选择 0 读取所有新闻，或按 \"enter\" 继续更新"
-"系统"
+"选择要阅读的新闻（例如 1 3 5），选择 0 阅读全部，或按 \"enter\" 继续更新："
 
 #: src/lib/list_news.sh:85 src/lib/restart_services.sh:39
 #, sh-format
 msgid "Invalid input"
-msgstr ""
+msgstr "输入无效"
 
 #: src/lib/list_news.sh:103
 #, sh-format
@@ -425,8 +427,8 @@ msgid ""
 "timeout)\\nPlease, read the selected Arch News at ${news_url} before "
 "updating your system"
 msgstr ""
-"无法检索所选的 Arch 新闻（HTTP 错误响应或请求超时）\\n请在更新系统之前阅读所"
-"选的 Arch 新闻：${news_url}"
+"无法获取所选的 Arch 新闻（HTTP 错误响应或请求超时）\\n请在更新系统前于 "
+"${news_url} 阅读所选的 Arch 新闻"
 
 #: src/lib/list_news.sh:108
 #, sh-format
@@ -451,32 +453,32 @@ msgstr "URL："
 #: src/lib/list_packages.sh:7
 #, sh-format
 msgid "Looking for updates...\\n"
-msgstr "正在查找更新..."
+msgstr "正在查找更新...\n"
 
 #: src/lib/list_packages.sh:16
 #, sh-format
 msgid "Unable to retrieve Packages updates (request timeout)\\n"
-msgstr ""
+msgstr "无法获取软件包更新（请求超时）\\n"
 
 #: src/lib/list_packages.sh:32
 #, sh-format
 msgid "Unable to retrieve AUR Packages updates (request timeout)\\n"
-msgstr ""
+msgstr "无法获取 AUR 软件包更新（请求超时）\\n"
 
 #: src/lib/list_packages.sh:45
 #, sh-format
 msgid "Unable to retrieve Flatpak packages updates (request timeout)\\n"
-msgstr ""
+msgstr "无法获取 Flatpak 包更新（请求超时）\\n"
 
 #: src/lib/list_packages.sh:115
 #, sh-format
 msgid "Packages:"
-msgstr "官方包："
+msgstr "软件包："
 
 #: src/lib/list_packages.sh:127
 #, sh-format
 msgid "AUR Packages:"
-msgstr "AUR 包："
+msgstr "AUR 软件包："
 
 #: src/lib/list_packages.sh:139
 #, sh-format
@@ -486,23 +488,23 @@ msgstr "Flatpak 包："
 #: src/lib/list_packages.sh:150
 #, sh-format
 msgid "No update available\\n"
-msgstr "没有可用更新\\n"
+msgstr "没有可用的更新\\n"
 
 #: src/lib/list_packages.sh:162
 #, sh-format
 msgid "Proceed with update? [Y/n]"
-msgstr "是否现在进行更新？[Y/n]"
+msgstr "是否继续更新？[Y/n]"
 
 #: src/lib/list_packages.sh:172
 #, sh-format
 msgid "The update has been aborted\\n"
-msgstr "更新已取消\\n"
+msgstr "更新已中止\\n"
 
 #: src/lib/notification.sh:16 src/lib/notification.sh:19
 #: src/tray/src/tray.rs:100
 #, sh-format
 msgid "1 update available"
-msgstr "1 更新可用"
+msgstr "1 个更新可用"
 
 #: src/lib/notification.sh:16 src/lib/notification.sh:19
 #: src/lib/notification.sh:23 src/lib/notification.sh:25
@@ -529,77 +531,77 @@ msgstr "${_name} 桌面文件未找到"
 #: src/lib/orphan_packages.sh:10
 #, sh-format
 msgid "Orphan Packages:"
-msgstr "孤儿包："
+msgstr "孤立包："
 
 #: src/lib/orphan_packages.sh:14
 #, sh-format
 msgid ""
 "Would you like to remove this orphan package (and its potential "
 "dependencies) now? [y/N]"
-msgstr "是否现在删除这个孤儿包（及其潜在依赖项）？[y/N]"
+msgstr "是否现在移除这个孤立包（及其可能的依赖）？[y/N]"
 
 #: src/lib/orphan_packages.sh:16
 #, sh-format
 msgid ""
 "Would you like to remove these orphan packages (and their potential "
 "dependencies) now? [y/N]"
-msgstr "是否现在删除这些孤儿包（及其潜在依赖项）？[y/N]"
+msgstr "是否现在移除这些孤立包（及其可能的依赖）？[y/N]"
 
 #: src/lib/orphan_packages.sh:23
 #, sh-format
 msgid "Removing Orphan Packages...\\n"
-msgstr "正在删除孤儿包...\\n"
+msgstr "正在移除孤立包...\n"
 
 #: src/lib/orphan_packages.sh:41
 #, sh-format
 msgid "No orphan package found\\n"
-msgstr "未找到孤儿包"
+msgstr "未找到孤立包\n"
 
 #: src/lib/packages_cache.sh:21
 #, sh-format
 msgid "Cached Packages:\\nThere's an old or uninstalled cached package\\n"
-msgstr "缓存的包:\\n有一个旧或未安装的缓存包\\n"
+msgstr "缓存的包：\\n存在旧的或未安装的缓存包\\n"
 
 #: src/lib/packages_cache.sh:22
 #, sh-format
 msgid "Would you like to remove it from the cache now? [Y/n]"
-msgstr "是否现在删除它？[Y/n]"
+msgstr "是否现在从缓存中移除它？[Y/n]"
 
 #: src/lib/packages_cache.sh:24
 #, sh-format
 msgid ""
 "Cached Packages:\\nThere are old and / or uninstalled cached packages\\n"
-msgstr "缓存的包:\\n有一些旧或未安装的缓存包\\n"
+msgstr "缓存的包：\\n存在旧的及 / 或卸载的缓存包\\n"
 
 #: src/lib/packages_cache.sh:25
 #, sh-format
 msgid "Would you like to remove them from the cache now? [Y/n]"
-msgstr "是否现在删除它们？[Y/n]"
+msgstr "是否现在从缓存中移除它们？[Y/n]"
 
 #: src/lib/packages_cache.sh:33 src/lib/packages_cache.sh:54
 #, sh-format
 msgid "Removing old cached packages..."
-msgstr "正在删除旧的缓存包...\\n"
+msgstr "正在移除旧的缓存包..."
 
 #: src/lib/packages_cache.sh:44 src/lib/packages_cache.sh:63
 #, sh-format
 msgid "Removing uninstalled cached packages..."
-msgstr "正在删除未安装的缓存包...\\n"
+msgstr "正在移除未安装的缓存包..."
 
 #: src/lib/packages_cache.sh:79
 #, sh-format
 msgid "No old or uninstalled cached package found\\n"
-msgstr "没有找到旧或未安装的缓存包\\n"
+msgstr "未找到旧的或未安装的缓存包\\n"
 
 #: src/lib/pacnew_files.sh:10
 #, sh-format
 msgid "Pacnew Files:"
-msgstr "pacnew 文件:"
+msgstr "Pacnew 文件："
 
 #: src/lib/pacnew_files.sh:14
 #, sh-format
 msgid "Would you like to process this file now? [Y/n]"
-msgstr "是否现在处理这个文件？[Y/n]"
+msgstr "是否现在处理此文件？[Y/n]"
 
 #: src/lib/pacnew_files.sh:16
 #, sh-format
@@ -609,39 +611,39 @@ msgstr "是否现在处理这些文件？[Y/n]"
 #: src/lib/pacnew_files.sh:23
 #, sh-format
 msgid "Processing Pacnew Files...\\n"
-msgstr "正在处理 pacnew 文件...\\n"
+msgstr "正在处理 Pacnew 文件...\n"
 
 #: src/lib/pacnew_files.sh:28
 #, sh-format
 msgid "The pacnew file(s) processing has been applied\\n"
-msgstr "一个或多个 pacnew 文件已经应用\\n"
+msgstr "已应用 Pacnew 文件处理\\n"
 
 #: src/lib/pacnew_files.sh:31
 #, sh-format
 msgid "An error occurred during the pacnew file(s) processing\\n"
-msgstr "一个或多个 pacnew 文件处理过程中发生错误\\n"
+msgstr "处理 Pacnew 文件时发生错误\\n"
 
 #: src/lib/pacnew_files.sh:37
 #, sh-format
 msgid ""
 "The pacnew file(s) processing hasn't been applied\\nPlease, consider "
 "processing them promptly\\n"
-msgstr "一个或多个 pacnew 文件处理过程中发生错误\\n请尽快处理这些文件\\n"
+msgstr "未应用 Pacnew 文件处理\\n请尽快处理这些文件\\n"
 
 #: src/lib/pacnew_files.sh:41
 #, sh-format
 msgid "No pacnew file found\\n"
-msgstr "没有找到 pacnew 文件\\n"
+msgstr "未找到 Pacnew 文件\\n"
 
 #: src/lib/restart_services.sh:13
 #, sh-format
 msgid "Services:\\nThe following service requires a post upgrade restart\\n"
-msgstr "服务：\\n这个服务升级后需要重启\\n"
+msgstr "服务：\\n以下服务需要升级后重启\\n"
 
 #: src/lib/restart_services.sh:15
 #, sh-format
 msgid "Services:\\nThe following services require a post upgrade restart\\n"
-msgstr "服务：\\n这些服务升级后需要重启\\n"
+msgstr "服务：\\n以下服务需要升级后重启\\n"
 
 #: src/lib/restart_services.sh:26
 #, sh-format
@@ -649,25 +651,25 @@ msgid ""
 "Select the service(s) to restart (e.g. 1 3 5), select 0 to restart them all "
 "or press \"enter\" to continue without restarting the service(s):"
 msgstr ""
-"选择要重启的服务（例如 1 3 5），选择 0 重启所有服务，或者按 \"enter\" 继续而"
-"不重启服务："
+"选择要重启的服务（例如 1 3 5），选择 0 重启全部，或按 \"enter\" 继续而不重启"
+"任何服务："
 
 #: src/lib/restart_services.sh:48 src/lib/restart_services.sh:75
 #, sh-format
 msgid "Service(s) restarted successfully\\n"
-msgstr "一个或多个服务重启成功\\n"
+msgstr "服务重启成功\\n"
 
 #: src/lib/restart_services.sh:51 src/lib/restart_services.sh:78
 #, sh-format
 msgid ""
 "An error has occurred during the service(s) restart\\nPlease, verify the "
 "above service(s) status\\n"
-msgstr "一个或多个服务重启失败，请检查上述服务状态\\n"
+msgstr "重启服务时发生错误\\n请检查上述服务状态\\n"
 
 #: src/lib/restart_services.sh:64
 #, sh-format
 msgid "The ${service_selected} service has been successfully restarted"
-msgstr "${service_selected} 服务重启成功"
+msgstr "${service_selected} 服务已成功重启"
 
 #: src/lib/restart_services.sh:66
 #, sh-format
@@ -680,22 +682,22 @@ msgstr "${service_selected} 服务重启失败"
 msgid ""
 "The service(s) restart hasn't been performed\\nPlease, consider restarting "
 "services that have been updated to fully apply the upgrade\\n"
-msgstr "一个或多个服务重启失败，请考虑重启已更新的服务以完全应用升级\\n"
+msgstr "未执行服务重启\\n请考虑重启已更新的服务以完全应用升级\\n"
 
 #: src/lib/restart_services.sh:86
 #, sh-format
 msgid "No service requiring a post upgrade restart found\\n"
-msgstr "没有需要在升级后重启的服务\\n"
+msgstr "未找到需要升级后重启的服务\\n"
 
 #: src/lib/tray.sh:20
 #, sh-format
 msgid "${_name} tray desktop file not found"
-msgstr "${_name} tray 桌面文件未找到"
+msgstr "${_name} 托盘桌面文件未找到"
 
 #: src/lib/tray.sh:27
 #, sh-format
 msgid "The '${tray_desktop_file_autostart}' file already exists"
-msgstr "${tray_desktop_file_autostart} 文件已经存在"
+msgstr "'${tray_desktop_file_autostart}' 文件已存在"
 
 #: src/lib/tray.sh:32
 #, sh-format
@@ -703,71 +705,73 @@ msgid ""
 "The '${tray_desktop_file_autostart}' file has been created, the ${_name} "
 "systray applet will be automatically started at boot\\n"
 msgstr ""
+"'${tray_desktop_file_autostart}' 文件已创建，${_name} 系统托盘小程序将在开机"
+"时自动启动\\n"
 
 #: src/lib/tray.sh:62
 #, sh-format
 msgid "There's already a running instance of the ${_name} systray applet"
-msgstr "已经有 ${_name} 系统托盘应用程序的运行实例"
+msgstr "已经有一个 ${_name} 系统托盘小程序实例正在运行"
 
 #: src/lib/tray.sh:66
 #, sh-format
 msgid "Starting the ${_name} systray applet"
-msgstr ""
+msgstr "正在启动 ${_name} 系统托盘小程序"
 
 #: src/lib/update.sh:9
 #, sh-format
 msgid "Updating Packages...\\n"
-msgstr "正在更新软件包...\\n"
+msgstr "正在更新软件包...\n"
 
 #: src/lib/update.sh:14 src/lib/update.sh:34 src/lib/update.sh:50
 #, sh-format
 msgid ""
 "An error has occurred during the update process\\nThe update has been "
 "aborted\\n"
-msgstr "更新过程中发生错误\\n更新已被中止\\n"
+msgstr "更新过程中发生错误\\n更新已中止\\n"
 
 #: src/lib/update.sh:29
 #, sh-format
 msgid "Updating AUR Packages...\\n"
-msgstr "正在更新 AUR 包...\\n"
+msgstr "正在更新 AUR 软件包...\n"
 
 #: src/lib/update.sh:46
 #, sh-format
 msgid "Updating Flatpak Packages...\\n"
-msgstr "正在更新 Flatpak 包...\\n"
+msgstr "正在更新 Flatpak 包...\n"
 
 #: src/lib/update.sh:61
 #, sh-format
 msgid "The update has been applied\\n"
-msgstr "更新已应用\\n"
+msgstr "已应用更新\\n"
 
 #: src/tray/src/tray_helpers.rs:108
 msgid "Next page"
-msgstr ""
+msgstr "下一页"
 
 #: src/tray/src/tray_helpers.rs:253
 #, rust-format
 msgid "{days}d"
-msgstr ""
+msgstr "{days} 天"
 
 #: src/tray/src/tray_helpers.rs:256
 #, rust-format
 msgid "{hours}h"
-msgstr ""
+msgstr "{hours} 小时"
 
 #: src/tray/src/tray_helpers.rs:259
 #, rust-format
 msgid "{minutes}m"
-msgstr ""
+msgstr "{minutes} 分钟"
 
 #: src/tray/src/tray_helpers.rs:262
 #, rust-format
 msgid "{seconds}s"
-msgstr ""
+msgstr "{seconds} 秒"
 
 #: src/tray/src/tray.rs:89
 msgid "System is up to date"
-msgstr "系统已更新到最新版本"
+msgstr "系统已是最新"
 
 #: src/tray/src/tray.rs:102
 #, rust-format
@@ -782,7 +786,7 @@ msgstr "全部 ({count})"
 #: src/tray/src/tray.rs:139
 #, rust-format
 msgid "Packages ({count})"
-msgstr "官方包 ({count})"
+msgstr "软件包 ({count})"
 
 #: src/tray/src/tray.rs:155
 #, rust-format
@@ -797,12 +801,12 @@ msgstr "Flatpak ({count})"
 #: src/tray/src/tray.rs:191
 #, rust-format
 msgid "Last check {last_check} ago"
-msgstr ""
+msgstr "上次检查：{last_check} 前"
 
 #: src/tray/src/tray.rs:208
 #, rust-format
 msgid "Next check in {next_check}"
-msgstr "下一次检查时间：{next_check}"
+msgstr "下次检查：{next_check}"
 
 #: src/tray/src/tray.rs:225
 msgid "Run Arch-Update"

--- a/res/desktop/arch-update-tray.desktop
+++ b/res/desktop/arch-update-tray.desktop
@@ -13,6 +13,7 @@ Comment[ka]=Arch-Update-ის აპლეტი სისტემურ ს�
 Comment[nb]=Miniprogam for å legge Arch-Update i systemkurven
 Comment[ru]=Апплет Arch-Update в системном трее
 Comment[tr]=Arch-Update sistem tepsisi uygulaması
+Comment[zh_CN]=Arch-Update 的系统托盘小程序
 Icon=arch-update_updates-available-blue
 Type=Application
 Exec=/bin/sh -c "sleep 3 && arch-update --tray"

--- a/res/desktop/arch-update.desktop
+++ b/res/desktop/arch-update.desktop
@@ -13,6 +13,7 @@ Comment[ka]=ინტერაქტიური განახლებებ�
 Comment[nb]=En interaktiv oppdateringsvarsler og -gjennomfører for Arch Linux
 Comment[ru]=Интерактивный помощник по обновлению Arch Linux: уведомляет об обновлениях и устанавливает их
 Comment[tr]=Arch Linux için etkileşimli bir güncelleme bildiricisi ve uygulayıcısı
+Comment[zh_CN]=Arch Linux 的交互式更新通知 & 应用工具
 Icon=arch-update-blue
 Type=Application
 Terminal=true


### PR DESCRIPTION
### Description

chore(i18n): Update zh_CN translation and .desktop comment
Update the Simplified Chinese (zh_CN) translation in po/zh_CN.po by filling in the previously untranslated entries and unifying spacing and punctuation conventions.

Add zh_CN Comment to the arch-update and arch-update-tray .desktop files.


