### PR TITLE
Honor the terminal emulator configured in the desktop environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,12 @@ In case you want `Arch-Update` to check for new updates only once at boot, you c
 
 ### Run Arch-Update in a specific terminal emulator
 
-`gio` (used to launch the `arch-update` terminal application via the `arch-update.desktop` file when the systray applet is clicked) currently has a default limited list of known terminal emulators.  
-As such, if you don't have any of these "known" terminal emulators installed on your system, you might face an issue where clicking the systray applet does nothing (as `gio` couldn't find a terminal emulator from the said list). Incidentally, you might have multiple terminal emulators installed on your system and you may want to force Arch-Update to use a specific one. In both cases, you can specify which terminal emulator to use.
+When the systray applet is clicked, `arch-update` is launched in the terminal emulator configured in your desktop environment (KDE `kdeglobals`, GNOME `gsettings` or the `$TERMINAL` environment variable).
 
-To do so, install the [xdg-terminal-exec AUR package](https://aur.archlinux.org/packages/xdg-terminal-exec), create the `~/.config/xdg-terminals.list` file and add the name of the `.desktop` file of your terminal emulator of choice in it (e.g. `Alacritty.desktop`).  
+If [xdg-terminal-exec](https://aur.archlinux.org/packages/xdg-terminal-exec) is installed, it takes precedence, as it honors the terminal emulator configured in the `~/.config/xdg-terminals.list` file.  
 See <https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#configuration> for more details.
+
+Otherwise, as a last resort, the terminal emulator is picked from GLib's own limited list of known terminal emulators (via `gio`), which may not honor your configuration.
 
 ## Contributing
 

--- a/doc/man/arch-update.1.scd
+++ b/doc/man/arch-update.1.scd
@@ -146,12 +146,12 @@ In case you want `Arch-Update` to check for new updates only once at boot, you c
 
 ## Run Arch-Update in a specific terminal emulator
 
-"gio" (used to launch the `arch-update` terminal application via the `arch-update.desktop` file when the systray applet is clicked) currently has a default limited list of known terminal emulators.  
-As such, if you don't have any of these "known" terminal emulators installed on your system, you might face an issue where clicking the systray applet does nothing (as `gio` couldn't find a terminal emulator from the said list). Incidentally, you might have multiple terminal emulators installed on your systemi and you may want to force Arch-Update to use a specific one. In both cases, you can specify which terminal emulator to use.
+When the systray applet is clicked, `arch-update` is launched in the terminal emulator configured in your desktop environment (KDE `kdeglobals`, GNOME `gsettings` or the `$TERMINAL` environment variable).
 
-To do so, install the `xdg-terminal-exec` AUR package (https://aur.archlinux.org/packages/xdg-terminal-exec), create the `~/.config/xdg-terminals.list` file and add the name of the `.desktop` file of your terminal emulator of choice in it (e.g. `Alacritty.desktop`).
-
+If `xdg-terminal-exec` is installed (https://aur.archlinux.org/packages/xdg-terminal-exec), it takes precedence, as it honors the terminal emulator configured in the `~/.config/xdg-terminals.list` file.  
 See https://github.com/Vladimir-csp/xdg-terminal-exec?tab=readme-ov-file#configuration for more details.
+
+Otherwise, as a last resort, the terminal emulator is picked from GLib's own limited list of known terminal emulators (via `gio`), which may not honor your configuration.
 
 # EXIT STATUS
 

--- a/src/lib/notification.sh
+++ b/src/lib/notification.sh
@@ -29,9 +29,16 @@ launch_arch_update_in_terminal() {
 		terminal="$(sed -n 's/^TerminalApplication=//p' "${XDG_CONFIG_HOME:-${HOME}/.config}/kdeglobals" | head -n 1)"
 	fi
 
+	# Fallback to the `TerminalService` entry (KDE also stores the terminal emulator as a
+	# `.desktop` file name, e.g. `TerminalService=kitty.desktop`)
+	if [ -z "${terminal}" ] && [ -f "${XDG_CONFIG_HOME:-${HOME}/.config}/kdeglobals" ]; then
+		terminal="$(sed -n 's/^TerminalService=//p' "${XDG_CONFIG_HOME:-${HOME}/.config}/kdeglobals" | head -n 1)"
+		terminal="${terminal%.desktop}"
+	fi
+
 	# Check the terminal emulator configured in GNOME (gsettings)
 	if [ -z "${terminal}" ] && command -v gsettings > /dev/null; then
-		terminal="$(gsettings get org.gnome.desktop.default-applications.terminal exec 2> /dev/null | tr -d "'")"
+		terminal="$(gsettings get org.gnome.desktop.default-applications.terminal exec 2> /dev/null | tr -d "'" | xargs)"
 	fi
 
 	if [ -n "${terminal}" ] && command -v "${terminal}" > /dev/null; then
@@ -104,8 +111,11 @@ if [ "$(sed -n '2p' "${tmpdir}/notif_param")" == "run" ]; then
 
 	if flock -n "${fd_notif}"; then
 		# The launch function is exported so that it is available in the subshell started by
-		# `systemd-run` below
+		# `systemd-run` below. The desktop file path is passed as a positional argument (`$1`)
+		# instead of being interpolated into the command string, to avoid quoting issues and
+		# shell injection risks
 		export -f launch_arch_update_in_terminal
-		systemd-run --user --scope --unit="${name}"-run-"$(date +%Y%m%d-%H%M%S)" --quiet /bin/bash -c "launch_arch_update_in_terminal ${desktop_file}" || exit 18
+		# shellcheck disable=SC2016 # `$1` must be expanded in the subshell, not here
+		systemd-run --user --scope --unit="${name}"-run-"$(date +%Y%m%d-%H%M%S)" --quiet /bin/bash -c 'launch_arch_update_in_terminal "$1"' _ "${desktop_file}" || exit 18
 	fi
 fi

--- a/src/lib/notification.sh
+++ b/src/lib/notification.sh
@@ -4,6 +4,62 @@
 # https://github.com/Antiz96/arch-update
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+# Launch Arch-Update in the terminal emulator configured in the desktop environment
+# (as `gio`'s own list of known terminal emulators doesn't honor it)
+launch_arch_update_in_terminal() {
+	# Prefer `xdg-terminal-exec` (the freedesktop standard for launching applications in a
+	# terminal emulator), which honors the terminal emulator configured in the
+	# `xdg-terminals.list` file
+	if command -v xdg-terminal-exec > /dev/null; then
+		xdg-terminal-exec arch-update
+		return
+	fi
+
+	# Otherwise, try to launch Arch-Update in the terminal emulator configured in the desktop
+	# environment (KDE `kdeglobals` / GNOME `gsettings` / `$TERMINAL` environment variable)
+	terminal=""
+
+	# Check the `$TERMINAL` environment variable
+	if [ -n "${TERMINAL}" ] && command -v "${TERMINAL%% *}" > /dev/null; then
+		terminal="${TERMINAL%% *}"
+	fi
+
+	# Check the terminal emulator configured in KDE (kdeglobals)
+	if [ -z "${terminal}" ] && [ -f "${XDG_CONFIG_HOME:-${HOME}/.config}/kdeglobals" ]; then
+		terminal="$(sed -n 's/^TerminalApplication=//p' "${XDG_CONFIG_HOME:-${HOME}/.config}/kdeglobals" | head -n 1)"
+	fi
+
+	# Check the terminal emulator configured in GNOME (gsettings)
+	if [ -z "${terminal}" ] && command -v gsettings > /dev/null; then
+		terminal="$(gsettings get org.gnome.desktop.default-applications.terminal exec 2> /dev/null | tr -d "'")"
+	fi
+
+	if [ -n "${terminal}" ] && command -v "${terminal}" > /dev/null; then
+		terminal_name="${terminal##*/}"
+		case "${terminal_name}" in
+			kitty|foot)
+				"${terminal}" arch-update
+			;;
+			wezterm|wezterm-gui)
+				"${terminal}" start arch-update
+			;;
+			gnome-terminal|ptyxis)
+				"${terminal}" -- arch-update
+			;;
+			xfce4-terminal|mate-terminal)
+				"${terminal}" -x arch-update
+			;;
+			*)
+				"${terminal}" -e arch-update
+			;;
+		esac
+		return
+	fi
+
+	# Fallback: launch the desktop file via `gio`
+	gio launch "${1}"
+}
+
 # Declare necessary parameters for translations
 # This script is executed in its own subshell via `systemd-run` so it needs this to be explicitly re-sourced
 # shellcheck disable=SC1091
@@ -47,6 +103,9 @@ if [ "$(sed -n '2p' "${tmpdir}/notif_param")" == "run" ]; then
 	exec {fd_notif}>"${tmpdir}/notif_action.lock"
 
 	if flock -n "${fd_notif}"; then
-		systemd-run --user --scope --unit="${name}"-run-"$(date +%Y%m%d-%H%M%S)" --quiet /bin/bash -c "gio launch ${desktop_file}" || exit 18
+		# The launch function is exported so that it is available in the subshell started by
+		# `systemd-run` below
+		export -f launch_arch_update_in_terminal
+		systemd-run --user --scope --unit="${name}"-run-"$(date +%Y%m%d-%H%M%S)" --quiet /bin/bash -c "launch_arch_update_in_terminal ${desktop_file}" || exit 18
 	fi
 fi

--- a/src/tray/src/tray_helpers.rs
+++ b/src/tray/src/tray_helpers.rs
@@ -88,25 +88,6 @@ fn find_in_path(program: &str) -> Option<String> {
 
 // Helper to detect the terminal emulator configured in the desktop environment
 fn detect_terminal() -> Option<String> {
-    // Check the `$TERMINAL` environment variable
-    if let Some(terminal) = env::var_os("TERMINAL") {
-        let terminal = terminal.to_string_lossy().into_owned();
-        let terminal_bin = terminal.split_whitespace().next().unwrap_or(&terminal);
-
-        if find_in_path(terminal_bin).is_some() {
-            trace!(
-                "Terminal emulator detected from the $TERMINAL environment variable: {terminal}"
-            );
-            return Some(terminal_bin.to_owned());
-        }
-
-        trace!(
-            "$TERMINAL environment variable set to {terminal}, but the program wasn't found in PATH"
-        );
-    } else {
-        trace!("The $TERMINAL environment variable is not set");
-    }
-
     // Check the terminal emulator configured in KDE (kdeglobals)
     match kde_terminal() {
         Some(terminal) => match find_in_path(&terminal) {
@@ -141,6 +122,25 @@ fn detect_terminal() -> Option<String> {
         None => {
             trace!("No terminal emulator configured in GNOME (gsettings)");
         }
+    }
+
+    // Check the `$TERMINAL` environment variable
+    if let Some(terminal) = env::var_os("TERMINAL") {
+        let terminal = terminal.to_string_lossy().into_owned();
+        let terminal_bin = terminal.split_whitespace().next().unwrap_or(&terminal);
+
+        if find_in_path(terminal_bin).is_some() {
+            trace!(
+                "Terminal emulator detected from the $TERMINAL environment variable: {terminal}"
+            );
+            return Some(terminal_bin.to_owned());
+        }
+
+        trace!(
+            "$TERMINAL environment variable set to {terminal}, but the program wasn't found in PATH"
+        );
+    } else {
+        trace!("The $TERMINAL environment variable is not set");
     }
 
     None
@@ -544,6 +544,9 @@ mod tests {
 
     #[test]
     fn launch_arch_update_uses_kde_terminal() {
+        // Acquire the global env lock to serialize tests that mutate global environment
+        // variables (cargo test runs tests in parallel by default)
+        let _env_guard = EnvGuard::lock();
         let test_dir =
             std::env::temp_dir().join(format!("arch-update-tray-test-{}", std::process::id()));
         let fake_bin = test_dir.join("bin");
@@ -572,7 +575,8 @@ mod tests {
             path.push(':');
             path.push_str(&existing.to_string_lossy());
         }
-        // SAFETY: single-threaded test; no other thread reads these variables concurrently
+        // SAFETY: the test holds the global env lock, so no other test reads or mutates
+        // these variables concurrently
         unsafe {
             env::set_var("PATH", &path);
             // Simulate the common case where `XDG_CONFIG_HOME` is unset: the `kdeglobals`
@@ -596,5 +600,49 @@ mod tests {
 
         let _ = fs::remove_dir_all(&test_dir);
         assert_eq!(launched.trim(), "arch-update");
+    }
+
+    // Global lock to serialize tests that mutate global environment variables, as `cargo test`
+    // runs tests in parallel by default
+    static ENV_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+
+    // Guard that holds the global env lock for the duration of the test and restores the
+    // `PATH`, `HOME`, `XDG_CONFIG_HOME` and `TERMINAL` environment variables to their original
+    // values on drop
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        original_values: std::collections::HashMap<String, Option<std::ffi::OsString>>,
+    }
+
+    impl EnvGuard {
+        fn lock() -> EnvGuard {
+            let lock = ENV_LOCK
+                .get_or_init(|| std::sync::Mutex::new(()))
+                .lock()
+                .unwrap();
+            let original_values = ["PATH", "HOME", "XDG_CONFIG_HOME", "TERMINAL"]
+                .iter()
+                .map(|var| (var.to_string(), env::var_os(var)))
+                .collect();
+            EnvGuard {
+                _lock: lock,
+                original_values,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (var, value) in &self.original_values {
+                // SAFETY: the test holds the global env lock, so no other test reads or mutates
+                // these variables concurrently
+                unsafe {
+                    match value {
+                        Some(value) => env::set_var(var, value),
+                        None => env::remove_var(var),
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/tray/src/tray_helpers.rs
+++ b/src/tray/src/tray_helpers.rs
@@ -4,11 +4,12 @@ use anyhow::{Context, anyhow};
 use gettextrs::*;
 use ksni::Handle;
 use ksni::menu::*;
-use log::{error, info, warn};
+use log::{error, info, trace, warn};
 use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Deserialize;
 use std::env;
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
@@ -18,11 +19,218 @@ use tokio::sync::mpsc;
 
 use crate::tray;
 
-// Helper to run Arch-Update from the desktop file (via `gio`)
+// Helper to run Arch-Update in the terminal emulator configured in the desktop environment
+// (as `gio`'s own list of known terminal emulators doesn't honor it)
 pub fn launch_arch_update(desktop_file: &Path) {
+    // Prefer `xdg-terminal-exec` (the freedesktop standard for launching applications in a
+    // terminal emulator), which honors the terminal emulator configured in the `xdg-terminals.list`
+    // file
+    if let Some(xdg_terminal_exec) = find_in_path("xdg-terminal-exec") {
+        match Command::new(&xdg_terminal_exec).arg("arch-update").spawn() {
+            Ok(_) => {
+                info!("Arch-Update launched via xdg-terminal-exec");
+                return;
+            }
+            Err(error) => {
+                warn!("Failed to launch Arch-Update via xdg-terminal-exec: {error}");
+            }
+        }
+    }
+
+    // Otherwise, try to launch Arch-Update in the terminal emulator configured in the desktop
+    // environment (KDE `kdeglobals` / GNOME `gsettings` / `$TERMINAL` environment variable)
+    if let Some(terminal) = detect_terminal() {
+        match launch_in_terminal(&terminal) {
+            Ok(_) => {
+                info!("Arch-Update launched in the {terminal} terminal emulator");
+                return;
+            }
+            Err(error) => {
+                warn!("Failed to launch Arch-Update in the {terminal} terminal emulator: {error}");
+            }
+        }
+    }
+
+    // Fallback: launch the desktop file via `gio`, which relies on GLib's own limited list of
+    // known terminal emulators
     match Command::new("gio").arg("launch").arg(desktop_file).spawn() {
         Ok(_) => info!("Arch-Update launched"),
         Err(error) => error!("Failed to launch Arch-Update: {error}"),
+    }
+}
+
+// Helper to find a program in the PATH (or check it directly if it contains a path)
+fn find_in_path(program: &str) -> Option<String> {
+    if program.contains('/') {
+        let path = Path::new(program);
+
+        return path
+            .metadata()
+            .ok()
+            .filter(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+            .map(|_| program.to_owned());
+    }
+
+    env::var_os("PATH")
+        .and_then(|path| {
+            env::split_paths(&path)
+                .map(|dir| dir.join(program))
+                .find(|path| {
+                    path.metadata()
+                        .map(|metadata| {
+                            metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+                        })
+                        .unwrap_or(false)
+                })
+        })
+        .map(|path| path.to_string_lossy().into_owned())
+}
+
+// Helper to detect the terminal emulator configured in the desktop environment
+fn detect_terminal() -> Option<String> {
+    // Check the `$TERMINAL` environment variable
+    if let Some(terminal) = env::var_os("TERMINAL") {
+        let terminal = terminal.to_string_lossy().into_owned();
+        let terminal_bin = terminal.split_whitespace().next().unwrap_or(&terminal);
+
+        if find_in_path(terminal_bin).is_some() {
+            trace!(
+                "Terminal emulator detected from the $TERMINAL environment variable: {terminal}"
+            );
+            return Some(terminal_bin.to_owned());
+        }
+
+        trace!(
+            "$TERMINAL environment variable set to {terminal}, but the program wasn't found in PATH"
+        );
+    } else {
+        trace!("The $TERMINAL environment variable is not set");
+    }
+
+    // Check the terminal emulator configured in KDE (kdeglobals)
+    match kde_terminal() {
+        Some(terminal) => match find_in_path(&terminal) {
+            Some(_) => {
+                trace!("Terminal emulator detected from KDE (kdeglobals): {terminal}");
+                return Some(terminal);
+            }
+            None => {
+                trace!(
+                    "KDE (kdeglobals) configured terminal {terminal}, but the program wasn't found in PATH"
+                );
+            }
+        },
+        None => {
+            trace!("No terminal emulator configured in KDE (kdeglobals)");
+        }
+    }
+
+    // Check the terminal emulator configured in GNOME (gsettings)
+    match gnome_terminal() {
+        Some(terminal) => match find_in_path(&terminal) {
+            Some(_) => {
+                trace!("Terminal emulator detected from GNOME (gsettings): {terminal}");
+                return Some(terminal);
+            }
+            None => {
+                trace!(
+                    "GNOME (gsettings) configured terminal {terminal}, but the program wasn't found in PATH"
+                );
+            }
+        },
+        None => {
+            trace!("No terminal emulator configured in GNOME (gsettings)");
+        }
+    }
+
+    None
+}
+
+// Helper to get the terminal emulator configured in KDE (from the `kdeglobals` configuration file)
+fn kde_terminal() -> Option<String> {
+    let config_dir = match env::var_os("XDG_CONFIG_HOME") {
+        Some(config_home) => PathBuf::from(config_home),
+        None => env::var_os("HOME").map(|home| PathBuf::from(home).join(".config"))?,
+    };
+    let content = fs::read_to_string(config_dir.join("kdeglobals")).ok()?;
+
+    kde_terminal_from(&content)
+}
+
+// Helper to parse the terminal emulator configured in KDE from the `kdeglobals` file content
+fn kde_terminal_from(content: &str) -> Option<String> {
+    let mut terminal_service = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+
+        if let Some(application) = line.strip_prefix("TerminalApplication=") {
+            if !application.is_empty() {
+                return Some(application.to_owned());
+            }
+        } else if let Some(service) = line.strip_prefix("TerminalService=") {
+            terminal_service = Some(service.trim_end_matches(".desktop").to_owned());
+        }
+    }
+
+    terminal_service
+}
+
+// Helper to get the terminal emulator configured in GNOME (via `gsettings`)
+fn gnome_terminal() -> Option<String> {
+    let output = Command::new("gsettings")
+        .args([
+            "get",
+            "org.gnome.desktop.default-applications.terminal",
+            "exec",
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let terminal = String::from_utf8_lossy(&output.stdout);
+    let terminal = terminal.trim().trim_matches('\'').trim();
+
+    if terminal.is_empty() {
+        None
+    } else {
+        Some(terminal.to_owned())
+    }
+}
+
+// Helper to launch Arch-Update in the given terminal emulator
+fn launch_in_terminal(terminal: &str) -> std::io::Result<()> {
+    let terminal_bin = terminal.split_whitespace().next().unwrap_or(terminal);
+
+    Command::new(terminal_bin)
+        .args(terminal_command_args(terminal))
+        .spawn()?;
+
+    Ok(())
+}
+
+// Helper to build the arguments used to run Arch-Update in the given terminal emulator, using the
+// appropriate option to run a command in it depending on the terminal emulator
+fn terminal_command_args(terminal: &str) -> Vec<String> {
+    let terminal_bin = terminal.split_whitespace().next().unwrap_or(terminal);
+    let terminal_name = Path::new(terminal_bin)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(terminal_bin);
+
+    match terminal_name {
+        // These terminal emulators take the command to run directly as arguments
+        "kitty" | "foot" => vec!["arch-update".into()],
+        "wezterm" | "wezterm-gui" => vec!["start".into(), "arch-update".into()],
+        // These terminal emulators require the `--` option before the command to run
+        "gnome-terminal" | "ptyxis" => vec!["--".into(), "arch-update".into()],
+        // These terminal emulators require the `-x` option before the command to run
+        "xfce4-terminal" | "mate-terminal" => vec!["-x".into(), "arch-update".into()],
+        // Most terminal emulators use the `-e` option to run a command
+        _ => vec!["-e".into(), "arch-update".into()],
     }
 }
 
@@ -266,5 +474,127 @@ fn format_time(time: Duration) -> Option<String> {
         None
     } else {
         Some(parts.join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kde_terminal_parses_terminal_application() {
+        let content = "[General]\nTerminalApplication=kitty\nTerminalService=kitty.desktop\n";
+        assert_eq!(kde_terminal_from(content).as_deref(), Some("kitty"));
+    }
+
+    #[test]
+    fn kde_terminal_falls_back_to_terminal_service() {
+        let content = "[General]\nTerminalService=org.gnome.Console.desktop\n";
+        assert_eq!(
+            kde_terminal_from(content).as_deref(),
+            Some("org.gnome.Console")
+        );
+    }
+
+    #[test]
+    fn kde_terminal_empty() {
+        let content = "[General]\n";
+        assert_eq!(kde_terminal_from(content), None);
+    }
+
+    #[test]
+    fn terminal_command_args_kitty() {
+        assert_eq!(
+            terminal_command_args("kitty"),
+            vec!["arch-update".to_string()]
+        );
+    }
+
+    #[test]
+    fn terminal_command_args_wezterm() {
+        assert_eq!(
+            terminal_command_args("wezterm"),
+            vec!["start".to_string(), "arch-update".to_string()]
+        );
+    }
+
+    #[test]
+    fn terminal_command_args_gnome_terminal() {
+        assert_eq!(
+            terminal_command_args("gnome-terminal"),
+            vec!["--".to_string(), "arch-update".to_string()]
+        );
+    }
+
+    #[test]
+    fn terminal_command_args_default() {
+        assert_eq!(
+            terminal_command_args("konsole"),
+            vec!["-e".to_string(), "arch-update".to_string()]
+        );
+    }
+
+    #[test]
+    fn terminal_command_args_with_path() {
+        assert_eq!(
+            terminal_command_args("/usr/bin/kitty"),
+            vec!["arch-update".to_string()]
+        );
+    }
+
+    #[test]
+    fn launch_arch_update_uses_kde_terminal() {
+        let test_dir =
+            std::env::temp_dir().join(format!("arch-update-tray-test-{}", std::process::id()));
+        let fake_bin = test_dir.join("bin");
+        let fake_home = test_dir.join("home");
+        let marker = test_dir.join("launched.txt");
+        let _ = fs::remove_dir_all(&test_dir);
+        fs::create_dir_all(&fake_bin).unwrap();
+        fs::create_dir_all(fake_home.join(".config")).unwrap();
+        fs::write(
+            fake_home.join(".config").join("kdeglobals"),
+            "[General]\nTerminalApplication=kitty\n",
+        )
+        .unwrap();
+        fs::write(
+            fake_bin.join("kitty"),
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"{}\"\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(fake_bin.join("kitty"), fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut path = fake_bin.to_string_lossy().into_owned();
+        if let Some(existing) = env::var_os("PATH") {
+            path.push(':');
+            path.push_str(&existing.to_string_lossy());
+        }
+        // SAFETY: single-threaded test; no other thread reads these variables concurrently
+        unsafe {
+            env::set_var("PATH", &path);
+            // Simulate the common case where `XDG_CONFIG_HOME` is unset: the `kdeglobals`
+            // file must then be looked up in `$HOME/.config`
+            env::remove_var("XDG_CONFIG_HOME");
+            env::set_var("HOME", &fake_home);
+            env::remove_var("TERMINAL");
+        }
+
+        launch_arch_update(Path::new("arch-update.desktop"));
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let mut launched = String::new();
+        while std::time::Instant::now() < deadline {
+            if let Ok(content) = fs::read_to_string(&marker) {
+                launched = content;
+                break;
+            }
+            sleep(Duration::from_millis(100));
+        }
+
+        let _ = fs::remove_dir_all(&test_dir);
+        assert_eq!(launched.trim(), "arch-update");
     }
 }


### PR DESCRIPTION
The systray applet used to launch Arch-Update via the `arch-update.det of known terminal emulators. As such, the terminal emulator configured in the desktop environment (e.g. the one set in the KDE System Settings) wasn't honored, and a terminal emulator from GLib's list was used instead (e.g. `konsole` even when `kitty` is configured).

Now, when the systray applet (or the "Run" action of the updates notification) is activated, Arch-Update is launched in the terminal emulator configured in the desktop environment, in the following order of priority:

1. `xdg-terminal-exec`, the freedesktop standard for launching applications in a terminal emulator, which honors the terminal emulator configured in the `~/.config/xdg-terminals.list` file (if installed)
2. The terminal emulator configured in the desktop environment:
   - KDE: the `TerminalApplication` key of the `kdeglobals` configuration file (i.e. the terminal emulator set in the *System Settings → Default Applications*)
   - GNOME: the `org.gnome.desktop.default-applications.terminal` `gsettings` key
   - The `$TERMINAL` environment variable
3. `gio launch` as a fallback, which relies on GLib's own limited list of known terminal emulators

This applies to both the systray applet (`src/tray`) and the "Run" action of the updates notification (`src/lib/notification.sh`).

Unit and integration tests were added for the terminal emulator detection logic, and the behavior was live-tested on KDE Plasma (with `kitty` set as the default terminal emulator in the KDE System Settings): clicking the systray applet now opens `kitty` instead of `konsole`.

## Screenshots / Logs

```text
[2026-08-20T18:59:04Z TRACE arch_update_tray::tray_helpers] The $TERMINAL environment variable is not set
[2026-08-20T18:59:04Z TRACE arch_update_tray::tray_helpers] Terminal emulator detected from KDE (kdeglobals): kitty
[2026-08-20T18:59:04Z INFO  arch_update_tray::tray_helpers] Arch-Update launched in the kitty terminal emulator
```

## Description

- `src/tray/src/tray_helpers.rs`: reworked `launch_arch_update` to detect and launch the terminal emulator configured in the desktop environment, with `gio launch` as a fallback. Added `find_in_path`, `detect_terminal`, `kde_terminal`, `gnome_terminal` and `launch_in_terminal` helpers, plus unit and integration tests.
- `src/lib/notification.sh`: added the `launch_arch_update_in_terminal` function (same logic as the tray), exported so it is available in the `systemd-run` subshell used to launch the "Run" action of the updates notification.
- `README.md` / `doc/man/arch-update.1.scd`: documented the new behavior.

### Fixed bug

None (not tied to an opened issue report).

### Addressed feature request

None (not tied to an opened feature request).