### PR TITLE
tray:  Show the current state summary in tooltip

### DIFF
--- a/src/tray/src/tray.rs
+++ b/src/tray/src/tray.rs
@@ -52,7 +52,14 @@ impl ksni::Tray for ArchUpdateTray {
     // Set tooltip
     fn tool_tip(&self) -> ksni::ToolTip {
         ksni::ToolTip {
-            title: "Arch-Update".into(),
+            title: self.title(),
+            description: match tray_helpers::get_updates_count(&self.updates_statefile_type.all) {
+                0 => gettext("System is up to date"),
+                1 => gettext("1 update available"),
+                count => {
+                    gettext("{count} updates available").replace("{count}", &count.to_string())
+                }
+            },
             ..Default::default()
         }
     }


### PR DESCRIPTION
### Description

I know, this has been added, and remove, and I agree that 
tooltip is not the right place for a giant string.

But most other tray icons, that can have dynamic states,
uses tooltip to show current state info, like...

 * NetworkManager Applet shows current network state (name, strength, profile)
 * Blueman Applet shows bluetooth state (connected?, device name)
 * Fcitx shows selected IM type ("Language (Layout)" or IM name) 
 * Quod Libet shows current song ("Album - Track")

### Screenshots / Logs

<img width="247" height="129" alt="image" src="https://github.com/user-attachments/assets/dc9f1554-5e01-4594-b6fc-8d27deaa1b51" />
