### PR TITLE
chore(tray): Reuse id for title and tooltip title

### DIFF
--- a/src/tray/src/tray.rs
+++ b/src/tray/src/tray.rs
@@ -51,13 +51,13 @@ impl ksni::Tray for ArchUpdateTray {
 
     // Set title
     fn title(&self) -> String {
-        "Arch-Update".into()
+        self.id()
     }
 
     // Set tooltip
     fn tool_tip(&self) -> ksni::ToolTip {
         ksni::ToolTip {
-            title: self.title(),
+            title: self.id(),
             description: match tray_helpers::get_updates_count(&self.updates_statefile_type.all) {
                 0 => gettext("System is up to date"),
                 1 => gettext("1 update available"),


### PR DESCRIPTION
### Description

Small refactor / refinement to reuse the id value for the systay applet title and tooltip title (as those are the same).