### PR TITLE
fix(check): Set the tray icon after the update stafile has been (re)written

### DIFF
--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -85,38 +85,34 @@ update_available=$(cat "${statedir}"/last_updates_check_{packages,aur,flatpak})
 # shellcheck disable=SC2154
 echo "${update_available}" > "${statedir}/current_updates_check"
 
-if [ -n "${update_available}" ]; then
-	if [ -n "${notification_support}" ]; then
-		if ! diff "${statedir}/current_updates_check" "${statedir}/last_updates_check" &> /dev/null; then
-			update_number=$(wc -l "${statedir}/current_updates_check" | awk '{print $1}')
+if [ -n "${update_available}" ] && [ -n "${notification_support}" ] && ! diff "${statedir}/current_updates_check" "${statedir}/last_updates_check" &> /dev/null; then
+	update_number=$(wc -l "${statedir}/current_updates_check" | awk '{print $1}')
 
-			# shellcheck disable=SC2154
-			last_notif_id=$(sed -n '1p' "${tmpdir}/notif_param" 2> /dev/null)
+	# shellcheck disable=SC2154
+	last_notif_id=$(sed -n '1p' "${tmpdir}/notif_param" 2> /dev/null)
 
-			systemd-run --user --unit="${name}"-notification-"$(date +%Y%m%d-%H%M%S)" --quiet \
-				--setenv=DISPLAY="${DISPLAY}" \
-				--setenv=DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}" \
-				--setenv=TEXTDOMAIN="${_name}" \
-				--setenv=TEXTDOMAINDIR="${TEXTDOMAINDIR}" \
-				--setenv=LANG="${LANG}" \
-				--setenv=LANGUAGE="${LANGUAGE}" \
-				--setenv=LC_ALL="${LC_ALL}" \
-				--setenv=LC_MESSAGES="${LC_MESSAGES}" \
-				--setenv=XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR}" \
-				--setenv=XDG_DATA_HOME="${XDG_DATA_HOME}" \
-				--setenv=XDG_DATA_DIRS="${XDG_DATA_DIRS}" \
-				--setenv=HOME="${HOME}" \
-				--setenv=update_number="${update_number}" \
-				--setenv=last_notif_id="${last_notif_id}" \
-				--setenv=_name="${_name}" \
-				--setenv=name="${name}" \
-				--setenv=tray_icon_style="${tray_icon_style}" \
-				--setenv=colorblind_mode="${colorblind_mode}" \
-				--setenv=tmpdir="${tmpdir}" \
-				--setenv=desktop_file="${desktop_file}" \
-			 "${libdir}/notification.sh"
-		fi
-	fi
+	systemd-run --user --unit="${name}"-notification-"$(date +%Y%m%d-%H%M%S)" --quiet \
+		--setenv=DISPLAY="${DISPLAY}" \
+		--setenv=DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS}" \
+		--setenv=TEXTDOMAIN="${_name}" \
+		--setenv=TEXTDOMAINDIR="${TEXTDOMAINDIR}" \
+		--setenv=LANG="${LANG}" \
+		--setenv=LANGUAGE="${LANGUAGE}" \
+		--setenv=LC_ALL="${LC_ALL}" \
+		--setenv=LC_MESSAGES="${LC_MESSAGES}" \
+		--setenv=XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR}" \
+		--setenv=XDG_DATA_HOME="${XDG_DATA_HOME}" \
+		--setenv=XDG_DATA_DIRS="${XDG_DATA_DIRS}" \
+		--setenv=HOME="${HOME}" \
+		--setenv=update_number="${update_number}" \
+		--setenv=last_notif_id="${last_notif_id}" \
+		--setenv=_name="${_name}" \
+		--setenv=name="${name}" \
+		--setenv=tray_icon_style="${tray_icon_style}" \
+		--setenv=colorblind_mode="${colorblind_mode}" \
+		--setenv=tmpdir="${tmpdir}" \
+		--setenv=desktop_file="${desktop_file}" \
+	"${libdir}/notification.sh"
 fi
 
 if [ -f "${statedir}/current_updates_check" ]; then

--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -86,8 +86,6 @@ update_available=$(cat "${statedir}"/last_updates_check_{packages,aur,flatpak})
 echo "${update_available}" > "${statedir}/current_updates_check"
 
 if [ -n "${update_available}" ]; then
-	icon_updates-available
-
 	if [ -n "${notification_support}" ]; then
 		if ! diff "${statedir}/current_updates_check" "${statedir}/last_updates_check" &> /dev/null; then
 			update_number=$(wc -l "${statedir}/current_updates_check" | awk '{print $1}')
@@ -119,12 +117,16 @@ if [ -n "${update_available}" ]; then
 			 "${libdir}/notification.sh"
 		fi
 	fi
-else
-	icon_up-to-date
 fi
 
 if [ -f "${statedir}/current_updates_check" ]; then
 	mv -f "${statedir}/current_updates_check" "${statedir}/last_updates_check"
+fi
+
+if [ -n "${update_available}" ]; then
+	icon_updates-available
+else
+	icon_up-to-date
 fi
 
 date "+%s%n%F %T" > "${statedir}/last_updates_check_time"


### PR DESCRIPTION
### Description

Set the tray icon **after** the update statefile has been (re)written (not before).

This is slightly more logic / robust and this also fix an ordering issue which leads to eventual stale state info in the systray tooltip.