### PR TITLE
fix: force C locale when parsing AUR helper output

### DIFF
--- a/src/lib/check.sh
+++ b/src/lib/check.sh
@@ -29,10 +29,10 @@ fi
 if [ -n "${aur_helper}" ]; then
 	if [ -z "${no_version}" ]; then
 		# shellcheck disable=SC2154
-		"${aur_helper}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$" > "${statedir}/last_updates_check_aur"
+		LC_ALL=C "${aur_helper}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$" > "${statedir}/last_updates_check_aur"
 	else
 		# shellcheck disable=SC2154
-		"${aur_helper}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$" | awk '{print $1}' > "${statedir}/last_updates_check_aur"
+		LC_ALL=C "${aur_helper}" -Qua 2> /dev/null | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$" | awk '{print $1}' > "${statedir}/last_updates_check_aur"
 	fi
 fi
 

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -24,7 +24,7 @@ if [ -n "${aur_helper}" ]; then
 	# The former because it assumes an interactive TTY environment (causing `timeout` to behave unexpectedly) 
 	# The latter because it outputs some descriptive string in stderr when looking for updates with -Qua
 	# shellcheck disable=SC2154
-	unformatted_aur_packages=$(timeout "${update_check_timeout}" "${aur_helper}" --color never "${devel_flag[@]}" -Qua < /dev/null 2> /dev/null)
+	unformatted_aur_packages=$(timeout "${update_check_timeout}" env LC_ALL=C "${aur_helper}" --color never "${devel_flag[@]}" -Qua < /dev/null 2> /dev/null)
 	unformatted_aur_packages_exit_code=$?
 	aur_packages=$(echo "${unformatted_aur_packages}" | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$")
 

--- a/src/lib/list_packages.sh
+++ b/src/lib/list_packages.sh
@@ -24,7 +24,7 @@ if [ -n "${aur_helper}" ]; then
 	# The former because it assumes an interactive TTY environment (causing `timeout` to behave unexpectedly) 
 	# The latter because it outputs some descriptive string in stderr when looking for updates with -Qua
 	# shellcheck disable=SC2154
-	unformatted_aur_packages=$(timeout "${update_check_timeout}" env LC_ALL=C "${aur_helper}" --color never "${devel_flag[@]}" -Qua < /dev/null 2> /dev/null)
+	unformatted_aur_packages=$(timeout "${update_check_timeout}" LC_ALL=C "${aur_helper}" --color never "${devel_flag[@]}" -Qua < /dev/null 2> /dev/null)
 	unformatted_aur_packages_exit_code=$?
 	aur_packages=$(echo "${unformatted_aur_packages}" | sed 's/^ *//' | sed 's/ \+/ /g' | grep -vw "\[ignored\]$")
 


### PR DESCRIPTION
Fixes #780.

AUR helpers translate the `[ignored]` marker, so `grep -vw "\[ignored\]$"` never
matches on non-English locales and ignored AUR packages end up listed as pending
updates. Forcing the C locale keeps the marker untranslated so the existing filter
works as intended.

Three call sites changed:
- `src/lib/check.sh` (both branches)
- `src/lib/list_packages.sh` — `env` is needed here since the call goes through `timeout`

The helper call in `src/lib/update.sh` is deliberately left alone: that output is
meant to be read by the user, not parsed, and forcing the locale there would show
the update transaction in English for everyone.

Tested with paru on an `es_ES.UTF-8` system. shellcheck clean.